### PR TITLE
fix #1016847 - opened file can be reopened in different tab

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -392,6 +392,17 @@ bool MainWindow::isNewEmptyTab(int index)
     }
 }
 
+bool MainWindow::fileAlreadyOpened(const QString & filepath)
+{
+    // visit all QScintilla instance to check if "filepath" is already opened
+    for ( int i = 0; i < tabWidget1->count(); ++i ) {
+        QsciScintillaqq* sci = getTextBoxFromIndex(i, tabWidget1);
+        if ( sci && sci->fileName() == filepath )
+            return true;
+    }
+    return false;
+}
+
 void MainWindow::openNewFile(QStringList fileNames)
 {
     if(!fileNames.isEmpty())
@@ -402,6 +413,9 @@ void MainWindow::openNewFile(QStringList fileNames)
 
             QFile file(fileNames[i]);
             QFileInfo fi(fileNames[i]);
+
+            if ( fileAlreadyOpened(fi.absoluteFilePath()) )
+                continue;
 
             int index = addEditorTab(true, fi.fileName(), tabWidget1);
             QsciScintillaqq* sci = this->getTextBoxFromIndex(index, tabWidget1);
@@ -757,6 +771,7 @@ void MainWindow::autoLexer(QString fullFileName, QsciScintillaqq* parent)
             // Let's try with mime-types!
 
             QString fileMime = generalFunctions::getFileMime(fullFileName);
+
             if(fileMime == "text/html" ||
                fileMime == "text/x-php")
             {
@@ -1535,7 +1550,7 @@ void MainWindow::on_actionCurrent_Directory_Path_to_Clipboard_triggered()
 }
 
 void MainWindow::on_actionIncrease_Line_Indent_triggered()
-{          
+{
     QsciScintillaqq *sci = getCurrentTextBox(tabWidget1);
     int lineFrom, indexFrom, lineTo, indexTo;
     sci->getSelection(&lineFrom, &indexFrom, &lineTo, &indexTo);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -71,6 +71,7 @@ public:
     void encodeIn(QString _enc, bool _bom, QsciScintillaqq * sci);
     void convertTo(QString _enc, bool _bom, QsciScintillaqq * sci);
     bool reloadFromDisk(QString filename, bool askConfirm, QsciScintillaqq * sci);
+    bool fileAlreadyOpened(const QString & filepath);
 
     /**
      * Describes the result of a save process. For example, if the user cancels the save dialog, \p saveFileResult_Canceled is returned.


### PR DESCRIPTION
This commit fixes this bug:
https://bugs.launchpad.net/notepadqq/+bug/1016847

before opening a file it check if it has already been opened in another tab.
