### PR TITLE
Word wrap and wide settings draft implementation

### DIFF
--- a/src/appwidesettings.cpp
+++ b/src/appwidesettings.cpp
@@ -1,0 +1,35 @@
+#include "appwidesettings.h"
+#include "mainwindow.h"
+#include <QSettings>
+
+namespace widesettings {
+
+    const char * SETTING_WRAP_MODE = "wrap_mode";
+
+    bool apply_wrap_mode(QsciScintilla::WrapMode m, QsciScintillaqq* w)
+    {
+        if ( !w )                 return false;
+        if ( m == w->wrapMode() ) return false;
+        w->setWrapMode(m);
+        MainWindow::instance()->getSettings()->setValue(SETTING_WRAP_MODE, m);
+        return true;
+    }
+
+    bool toggle_word_wrap(QsciScintillaqq* w)
+    {
+        if ( !w ) return false;
+        return apply_wrap_mode(
+                    (w->wrapMode() == QsciScintilla::WrapNone ?
+                     QsciScintilla::WrapWord : QsciScintilla::WrapNone), w );
+    }
+
+    void apply_settings(QsciScintillaqq * w )
+    {
+        if ( !w ) return;
+
+        // APPLY WORD WRAP
+        QsciScintilla::WrapMode m = static_cast<QsciScintilla::WrapMode>(
+                    MainWindow::instance()->getSettings()->value(SETTING_WRAP_MODE).toInt() );
+        apply_wrap_mode(m, w);
+    }
+}

--- a/src/appwidesettings.h
+++ b/src/appwidesettings.h
@@ -1,0 +1,17 @@
+#ifndef APPWIDESETTINGS_H
+#define APPWIDESETTINGS_H
+
+#include "qsciscintillaqq.h"
+class QSettings;
+
+namespace widesettings {
+
+    extern const char * SETTING_WRAP_MODE;
+
+    bool apply_wrap_mode (QsciScintilla::WrapMode m, QsciScintillaqq * w);
+    bool toggle_word_wrap(QsciScintillaqq * w);
+
+    void apply_settings(QsciScintillaqq * w);
+}
+
+#endif // APPWIDESETTINGS_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
     QApplication a(argc, argv);
     a.processEvents();
 
-#if SINGLEINSTANCE_EXPERIMENTAL
+#if defined(SINGLEINSTANCE_EXPERIMENTAL)
     /* Attach to an existing instance
      * only if there is at least
      * one file in the arguments.
@@ -74,6 +74,8 @@ int main(int argc, char *argv[])
     QCoreApplication::setAttribute(Qt::AA_DontUseNativeMenuBar, false);
 
     MainWindow* w = MainWindow::instance();
+    // 2-STEP initializer
+    w->init();
     w->showMaximized();
 
     //gdk_notify_startup_complete();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -46,6 +46,10 @@ class MainWindow : public QMainWindow
 public:
     explicit MainWindow(QWidget *parent = 0);
     ~MainWindow();
+
+    // 2-STEP initializer
+    void init();
+
     QTabWidgetsContainer *container;
 
     /**
@@ -119,6 +123,8 @@ private slots:
     void _on_newQsciScintillaqqChildCreated(QsciScintillaqq *sci);
     void _on_sci_copyAvailable(bool yes);
     void _on_sci_updateUI();
+    void _apply_wide_settings_to_tab(int tab);
+
     void on_action_New_triggered();
     void on_actionSave_as_triggered();
     void on_actionSave_triggered();
@@ -153,6 +159,7 @@ private slots:
     void on_actionFind_Next_triggered();
     void on_actionFind_Previous_triggered();
     void on_actionSave_a_Copy_As_triggered();
+    void on_actionWord_wrap_triggered();
 };
 
 #endif // MAINWINDOW_H;

--- a/src/notepadqq.pro
+++ b/src/notepadqq.pro
@@ -23,6 +23,10 @@ CONFIG(release, debug|release) {
     DESTDIR = ../build/release
 }
 
+win32 {
+    DEFINES += QSCINTILLA_DLL
+    LIBS += User32.lib
+}
 
 
 SOURCES += main.cpp\
@@ -35,7 +39,8 @@ SOURCES += main.cpp\
     qtabwidgetscontainer.cpp \
     frmsrchreplace.cpp \
     searchengine.cpp \
-    docengine.cpp
+    docengine.cpp \
+    appwidesettings.cpp
 
 HEADERS  += mainwindow.h \
     qsciscintillaqq.h \
@@ -46,9 +51,10 @@ HEADERS  += mainwindow.h \
     generalfunctions.h \
     qtabwidgetscontainer.h \
     frmsrchreplace.h \
-    ../searchengine.h \
     searchengine.h \
-    docengine.h
+    searchengine.h \
+    docengine.h \
+    appwidesettings.h
 
 FORMS    += mainwindow.ui \
     frmabout.ui \

--- a/src/qsciscintillaqq.cpp
+++ b/src/qsciscintillaqq.cpp
@@ -67,7 +67,7 @@
 #include <Qsci/qscilexeryaml.h>
 
 #include <Qsci/qscilexercustom.h>
-#include <userlexer.h>
+#include "userlexer.h"
 
 QsciScintillaqq::QsciScintillaqq(QWidget *parent) :
     QsciScintilla(parent)

--- a/src/qtabwidgetqq.cpp
+++ b/src/qtabwidgetqq.cpp
@@ -65,16 +65,11 @@ int QTabWidgetqq::addEditorTab(bool setFocus, QString title)
     // Let's add a new tab...
     QWidget *widget = new QWidget(this);
     widget->setObjectName("singleTabWidget");
-    int index = this->addTab(widget, title);
-    if(setFocus) {
-        this->setCurrentIndex(index);
-    }
-    this->setTabIcon(index, QIcon(":/icons/icons/saved.png"));
 
     QVBoxLayout *layout = new QVBoxLayout;
     layout->setContentsMargins(0, 0, 0, 0);
     // Create textbox
-    QsciScintillaqq* sci = new QsciScintillaqq(this->widget(index));
+    QsciScintillaqq* sci = new QsciScintillaqq(widget);
     sci->setObjectName("editorWidget");
 
     connect(sci, SIGNAL(modificationChanged(bool)), this, SLOT(on_modification_changed(bool)));
@@ -88,9 +83,9 @@ int QTabWidgetqq::addEditorTab(bool setFocus, QString title)
     */
 
     layout->addWidget(sci);
-    this->widget(index)->setLayout(layout);
+    widget->setLayout(layout);
     //this->setDocumentMode(true);
-    this->setTabToolTip(index, "");
+
 
     /* TODO
     bool _showallchars = ui->actionShow_All_Characters->isChecked();
@@ -100,6 +95,14 @@ int QTabWidgetqq::addEditorTab(bool setFocus, QString title)
         on_actionShow_All_Characters_triggered();
     }
     */
+
+    // Add the tab as last thing so we can use QSciScintillaqqAt method on currentTabChanged signal
+    int index = this->addTab(widget, title);
+    if(setFocus) {
+        this->setCurrentIndex(index);
+    }
+    this->setTabIcon(index, QIcon(":/icons/icons/saved.png"));
+
 
     this->getTabWidgetsContainer()->_on_newQsciScintillaqqWidget(sci);
 


### PR DESCRIPTION
This commit implements "Word wrap" toggle and a simple mechanism to reflect this settings to all the tabs.

The settings is persisted using QSettings; at startup the settings is loaded and applied to all the tabs opened.

Also when the current tab changes the settings are applied to that tab as well.

It is trivial to add support for other wide settings ( e.g. EOL, Text direction, etc.. )
