### PR TITLE
optionally deactivate Qt5 version check

### DIFF
--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -8,7 +8,9 @@
 #include <QElapsedTimer>
 
 bool shouldStartApp(int argc, char *argv[]);
+#ifdef CHECK_QT5_VERSION
 void checkQtVersion(MainWindow *w);
+#endif
 
 int main(int argc, char *argv[])
 {
@@ -44,11 +46,14 @@ int main(int argc, char *argv[])
     qDebug() << QString("Started in " + QString::number(__aet_elapsed / 1000 / 1000) + "msec").toStdString().c_str();
 #endif
 
+#ifdef CHECK_QT5_VERSION
     checkQtVersion(&w);
+#endif
 
     return a.exec();
 }
 
+#ifdef CHECK_QT5_VERSION
 void checkQtVersion(MainWindow *w)
 {
     QString runtimeVersion = qVersion();
@@ -76,6 +81,7 @@ void checkQtVersion(MainWindow *w)
         msgBox.exec();
     }
 }
+#endif
 
 void displayHelp()
 {

--- a/src/ui/notepadqq.pro
+++ b/src/ui/notepadqq.pro
@@ -21,6 +21,10 @@ equals(DEPLOY, true) {
     QMAKE_RPATH=
 }
 
+!equals(CHECK_QT5_VERSION, false) {
+    DEFINES += CHECK_QT5_VERSION
+}
+
 unix: CMD_FULLDELETE = rm -rf
 win32: CMD_FULLDELETE = del /F /S /Q
 


### PR DESCRIPTION
I found this warning at each startup a little annoying. Run `qmake CHECK_QT5_VERSION=false` to deactivate this function. Though I'd prefer an option in the settings.
