### PR TITLE
set_permissions: don't finish with exit code 1

### DIFF
--- a/src/ui/notepadqq.pro
+++ b/src/ui/notepadqq.pro
@@ -155,7 +155,8 @@ unix {
 
     # Dummy target used to fix permissions at the end of the install
     set_permissions.path = "$$INSTALL_ROOT$$PREFIX/bin/"  # A random path. Without one, qmake refuses to create the rule.
-    unix:set_permissions.extra = chmod 755 \"$$INSTALL_ROOT$$PREFIX/bin/notepadqq\"
+    unix:set_permissions.extra = (chmod 755 \"$$INSTALL_ROOT$$PREFIX/bin/notepadqq\" || \
+                                  echo \"couldn\'t set permissions of $$INSTALL_ROOT$$PREFIX/bin/notepadqq\")
 
     # MAKE INSTALL
     INSTALLS += target \


### PR DESCRIPTION
That line made my Launchpad builds break. Not sure why this doesn't happen if I build the package on my PC.

```
chmod: cannot access '/usr/bin/notepadqq': No such file or directory
Makefile:787: recipe for target 'install_set_permissions' failed
make[2]: *** [install_set_permissions] Error 1
```
