### PR TITLE
[Makefile] enable to comment out targets

### DIFF
--- a/src/editor/libs/codemirror/mode/makefile/makefile.js
+++ b/src/editor/libs/codemirror/mode/makefile/makefile.js
@@ -22,6 +22,15 @@ CodeMirror.defineMode('makefile', function() {
     var ch = stream.next();
     var cur = stream.current();
 
+  if (sol && ch === '#') {
+    if (stream.eat('!')) {
+        stream.skipToEnd();
+        return 'meta';
+      }
+      stream.skipToEnd();
+      return 'tag';
+    }
+
     // ifeq, ifneq
     if (ch === 'i' && (stream.match('feq ') || stream.match('fneq '))) {
       stream.skipToEnd();
@@ -52,10 +61,6 @@ CodeMirror.defineMode('makefile', function() {
     if (ch === '*') { return "quote"; }
     if (ch === '\\' && stream.eol()) { return "comment"; }
     if (ch === '#') {
-      if (sol && stream.eat('!')) {
-        stream.skipToEnd();
-        return 'meta'; // 'comment'?
-      }
       stream.skipToEnd();
       return 'tag';
     }


### PR DESCRIPTION
Still has some problems, see line 4-6.
![](http://s1.directupload.net/images/140916/wq2b3nzp.png)

However, you can now comment out targets, which is important.
This whole script is such a mess, someone whith enough knowledge should clean it up. ^^"
