### PR TITLE
add .la files (libtool library files) to "properties"

### DIFF
--- a/src/editor/classes/Languages.js
+++ b/src/editor/classes/Languages.js
@@ -422,7 +422,7 @@ var Languages = new function() {
             name: "Properties files",
             mode: "properties",
             mime: "text/x-properties",
-            fileExtensions: ["properties", "desktop", "theme", "ini"]
+            fileExtensions: ["properties", "desktop", "theme", "ini", "la"]
         },
 
         "python": {


### PR DESCRIPTION
Example code for an la file:

``` ini
# libGL.la - a libtool library file
# Generated by __GENERATED_BY__ (for use by libtool)
#
# Please DO NOT delete this file!
# It is necessary for linking the library.

# The name that we can dlopen(3).
dlname='libGL.so'

# Names of this library.
library_names='libGL.so.304.117 libGL.so.1 libGL.so'

# Libraries that this one depends upon.
dependency_libs=' -L/usr/X11R6/lib -lm -lXext -lX11 -ldl'

# Version information for libGL.
current=1
age=0
revision=304.117

# Is this an already installed library?
installed=yes

# Files to dlopen/dlpreopen
dlopen=''
dlpreopen=''

# Directory that this library needs to be installed in:
libdir='__LIBGL_PATH__'
```
