### PR TITLE
Added shortcut to duplicate and delete the current line

### DIFF
--- a/src/editor/app.js
+++ b/src/editor/app.js
@@ -377,6 +377,19 @@ UiDriver.registerEventHandler("C_FUN_GET_CURRENT_WORD", function(msg, data, prev
     return word;
 });
 
+UiDriver.registerEventHandler("C_CMD_DUPLICATE_LINE", function(msg, data, prevReturn) {
+    var cur = editor.getCursor();
+    var line = editor.getLine(cur.line)
+    var pos = {
+        line: cur.line,
+        ch: line.length
+    }
+    editor.replaceRange( '\n' + line, pos);
+});
+
+UiDriver.registerEventHandler("C_CMD_DELETE_LINE", function(msg, data, prevReturn) {
+    editor.execCommand("deleteLine");
+});
 
 $(document).ready(function () {
     editor = CodeMirror($(".editor")[0], {

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -154,6 +154,10 @@ private slots:
     void on_filesFindResultsModelRowsInserted(const QModelIndex &parent, int first, int last);
     void on_actionFind_in_Files_triggered();
 
+    void on_actionDelete_Line_triggered();
+
+    void on_actionDuplicate_Line_triggered();
+
 private:
     static QList<MainWindow*> m_instances;
     Ui::MainWindow*     ui;

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1813,3 +1813,13 @@ void MainWindow::on_actionFind_in_Files_triggered()
     m_frmSearchReplace->show(frmSearchReplace::TabSearchInFiles);
     m_frmSearchReplace->activateWindow();
 }
+
+void MainWindow::on_actionDelete_Line_triggered()
+{
+    currentEditor()->sendMessage("C_CMD_DELETE_LINE");
+}
+
+void MainWindow::on_actionDuplicate_Line_triggered()
+{
+    currentEditor()->sendMessage("C_CMD_DUPLICATE_LINE");
+}

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -110,6 +110,13 @@
      <addaction name="actionIndentation_Default_settings"/>
      <addaction name="actionIndentation_Custom"/>
     </widget>
+    <widget class="QMenu" name="menuLine_Operations">
+     <property name="title">
+      <string>Line Operations</string>
+     </property>
+     <addaction name="actionDuplicate_Line"/>
+     <addaction name="actionDelete_Line"/>
+    </widget>
     <addaction name="action_Undo"/>
     <addaction name="action_Redo"/>
     <addaction name="separator"/>
@@ -121,6 +128,7 @@
     <addaction name="separator"/>
     <addaction name="menuCopy_to_Clipboard"/>
     <addaction name="menuConvert_Case_to"/>
+    <addaction name="menuLine_Operations"/>
     <addaction name="menuEOL_Conversion"/>
     <addaction name="menuIndentation"/>
    </widget>
@@ -905,6 +913,28 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+F</string>
+   </property>
+  </action>
+  <action name="actionDelete_Line">
+   <property name="text">
+    <string>Delete Current Line</string>
+   </property>
+   <property name="toolTip">
+    <string>Delete the current line</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+L</string>
+   </property>
+  </action>
+  <action name="actionDuplicate_Line">
+   <property name="text">
+    <string>Duplicate Current Line</string>
+   </property>
+   <property name="toolTip">
+    <string>Duplicate the current line</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+D</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
I added a new menu voice "Line Operations" with the "Delete current line" and "Duplicate current line" voice with the right shortcut. There is a little bug (also in the production version): if you delete many lines and then you undo it by CTRL-Z, all the deletions are reverted. I think is a bug of CodeMirror, and i need to investigate it.