### PR TITLE
delete "out" directory with "make distclean"

### DIFF
--- a/notepadqq.pro
+++ b/notepadqq.pro
@@ -1,2 +1,3 @@
 TEMPLATE = subdirs
 SUBDIRS = src/ui
+QMAKE_DISTCLEAN += Makefile && rm -rf out


### PR DESCRIPTION
A kinda funny way to fool qmake. Normally `make distclean` doesn't remove directories that were added to `QMAKE_DISTCLEAN`.
```
djcj notepadqq $ make distclean 
cd src/ui/ && ( test -e Makefile || /usr/lib/x86_64-linux-gnu/qt5/bin/qmake /home/djcj/Downloads/notepadqq/src/ui/ui.pro PREFIX=/usr QMAKE_CXX=c++ QMAKE_CXXFLAGS=\  QMAKE_LFLAGS= -o Makefile ) && make -f Makefile distclean
make[1]: Entering directory `/home/djcj/Downloads/notepadqq/src/ui'
rm -f ../../out/build_data/qrc_resources.cpp
rm -f ../../out/build_data/moc_mainwindow.cpp ../../out/build_data/moc_topeditorcontainer.cpp ../../out/build_data/moc_editortabwidget.cpp ../../out/build_data/moc_docengine.cpp ../../out/build_data/moc_frmabout.cpp ../../out/build_data/moc_frmpreferences.cpp ../../out/build_data/moc_editor.cpp ../../out/build_data/moc_bannerfilechanged.cpp ../../out/build_data/moc_bannerbasicmessage.cpp ../../out/build_data/moc_bannerfileremoved.cpp ../../out/build_data/moc_customqwebview.cpp ../../out/build_data/moc_clickablelabel.cpp ../../out/build_data/moc_frmencodingchooser.cpp ../../out/build_data/moc_bannerindentationdetected.cpp ../../out/build_data/moc_frmindentationmode.cpp ../../out/build_data/moc_singleapplication.cpp ../../out/build_data/moc_filesearchresultswidget.cpp ../../out/build_data/moc_frmsearchreplace.cpp ../../out/build_data/moc_searchinfilesworker.cpp ../../out/build_data/moc_replaceinfilesworker.cpp ../../out/build_data/moc_dlgsearching.cpp
rm -f ../../out/build_data/ui_mainwindow.h ../../out/build_data/ui_frmabout.h ../../out/build_data/ui_frmpreferences.h ../../out/build_data/ui_frmencodingchooser.h ../../out/build_data/ui_frmindentationmode.h ../../out/build_data/ui_dlgsearching.h ../../out/build_data/ui_frmsearchreplace.h
rm -f ../../out/build_data/main.o ../../out/build_data/mainwindow.o ../../out/build_data/topeditorcontainer.o ../../out/build_data/editortabwidget.o ../../out/build_data/docengine.o ../../out/build_data/frmabout.o ../../out/build_data/notepadqq.o ../../out/build_data/frmpreferences.o ../../out/build_data/iconprovider.o ../../out/build_data/editor.o ../../out/build_data/bannerfilechanged.o ../../out/build_data/bannerbasicmessage.o ../../out/build_data/bannerfileremoved.o ../../out/build_data/customqwebview.o ../../out/build_data/clickablelabel.o ../../out/build_data/frmencodingchooser.o ../../out/build_data/bannerindentationdetected.o ../../out/build_data/frmindentationmode.o ../../out/build_data/singleapplication.o ../../out/build_data/localcommunication.o ../../out/build_data/filesearchresultswidget.o ../../out/build_data/frmsearchreplace.o ../../out/build_data/searchinfilesworker.o ../../out/build_data/replaceinfilesworker.o ../../out/build_data/dlgsearching.o ../../out/build_data/searchresultsitemdelegate.o ../../out/build_data/qrc_resources.o ../../out/build_data/moc_mainwindow.o ../../out/build_data/moc_topeditorcontainer.o ../../out/build_data/moc_editortabwidget.o ../../out/build_data/moc_docengine.o ../../out/build_data/moc_frmabout.o ../../out/build_data/moc_frmpreferences.o ../../out/build_data/moc_editor.o ../../out/build_data/moc_bannerfilechanged.o ../../out/build_data/moc_bannerbasicmessage.o ../../out/build_data/moc_bannerfileremoved.o ../../out/build_data/moc_customqwebview.o ../../out/build_data/moc_clickablelabel.o ../../out/build_data/moc_frmencodingchooser.o ../../out/build_data/moc_bannerindentationdetected.o ../../out/build_data/moc_frmindentationmode.o ../../out/build_data/moc_singleapplication.o ../../out/build_data/moc_filesearchresultswidget.o ../../out/build_data/moc_frmsearchreplace.o ../../out/build_data/moc_searchinfilesworker.o ../../out/build_data/moc_replaceinfilesworker.o ../../out/build_data/moc_dlgsearching.o
rm -f *~ core *.core
rm -f ../../out/release/lib/../../out/release/lib/notepadqq-bin 
rm -f Makefile
make[1]: Leaving directory `/home/djcj/Downloads/notepadqq/src/ui'
rm -f Makefile
rm -f Makefile && rm -rf out
```