### PR TITLE
add VapourSynth scripts to Python file extensions

### DIFF
--- a/src/editor/classes/Languages.js
+++ b/src/editor/classes/Languages.js
@@ -503,7 +503,7 @@ var Languages = new function() {
             name: "Python",
             mode: "python",
             mime: "text/x-python",
-            fileExtensions: ["py", "pyd", "pyw", "wsgi"],
+            fileExtensions: ["py", "pyd", "pyw", "vpy", "wsgi"],
             firstNonBlankLine: [/^#!.*\/python[\d\.]*($| )/, /^#!\/usr\/bin\/env python[\d\.]*($| )/]
         },
 


### PR DESCRIPTION
VapourSynth scripts are Python scripts, but the extension .vpy is used for them too:
http://www.vapoursynth.com/doc/gettingstarted.html#output-with-vspipe

Here's an example for a longer script: https://github.com/darealshinji/vapoursynth-plugins/blob/master/finesharp/finesharp.py