### PR TITLE
Missing modes: cmake, cython, troff

### DIFF
--- a/src/editor/classes/Languages.js
+++ b/src/editor/classes/Languages.js
@@ -81,6 +81,14 @@ var Languages = new function() {
             fileExtensions: ["clj", "cljs", "cljx"]
         },
 
+        "cmake": {
+            name: "CMake",
+            mode: "cmake",
+            mime: "text/x-cmake",
+            fileExtensions: ["cmake", "cmake.in"],
+            fileNames: ["CMakeLists.txt"]
+        },
+
         "coffeescript": {
             name: "CoffeeScript",
             mode: "coffeescript",
@@ -101,6 +109,13 @@ var Languages = new function() {
             mode: "cypher",
             mime: "application/x-cypher-query",
             fileExtensions: ["cyp", "cypher"]
+        },
+
+        "cython": {
+            name: "Cython",
+            mode: "python",
+            mime: "text/x-cython",
+            fileExtensions: ["pyx", "pxd", "pxi"]
         },
 
         "css": {
@@ -751,6 +766,13 @@ var Languages = new function() {
             mode: "tornado",
             mime: "text/x-tornado",
             fileExtensions: []
+        },
+
+        "troff": {
+            name: "troff",
+            mode: "troff",
+            mime: "troff",
+            fileExtensions: ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
         },
 
         "vb": {


### PR DESCRIPTION
They're in CodeMirror but they were missing in Languages.js.