### PR TITLE
Add support for Qt5.5

### DIFF
--- a/src/ui/singleapplication.cpp
+++ b/src/ui/singleapplication.cpp
@@ -2,6 +2,7 @@
 #include <QLocalSocket>
 #include <QDir>
 #include <QRegularExpression>
+#include <QtCore/QDataStream>
 #include "include/localcommunication.h"
 
 #if defined(Q_OS_WIN)

--- a/src/ui/singleapplication.cpp
+++ b/src/ui/singleapplication.cpp
@@ -2,7 +2,7 @@
 #include <QLocalSocket>
 #include <QDir>
 #include <QRegularExpression>
-#include <QtCore/QDataStream>
+#include <QDataStream>
 #include "include/localcommunication.h"
 
 #if defined(Q_OS_WIN)

--- a/support_files/launch/notepadqq
+++ b/support_files/launch/notepadqq
@@ -8,12 +8,14 @@ else
     GCC_DIR=gcc
 fi
 
+OPT_QT55=/opt/Qt/5.5/$GCC_DIR/lib
 OPT_QT54=/opt/Qt/5.4/$GCC_DIR/lib
 OPT_QT53=/opt/Qt/5.3/$GCC_DIR/lib
+PERSONAL_QT55=~/Qt/5.5/$GCC_DIR/lib
 PERSONAL_QT54=~/Qt/5.4/$GCC_DIR/lib
 PERSONAL_QT53=~/Qt/5.3/$GCC_DIR/lib
 
-export LD_LIBRARY_PATH="$OPT_QT54:$PERSONAL_QT54:$OPT_QT53:$PERSONAL_QT53:${LD_LIBRARY_PATH}"
+export LD_LIBRARY_PATH="$OPT_QT55:$PERSONAL_QT55:$OPT_QT54:$PERSONAL_QT54:$OPT_QT53:$PERSONAL_QT53:${LD_LIBRARY_PATH}"
 
 if [ -f "$SCRIPTPATH"/../lib/notepadqq/notepadqq-bin ]; then
     # Nqq is installed: this script is in bin/


### PR DESCRIPTION
Qt 5.5 has been released [a week](http://blog.qt.io/blog/2015/07/01/qt-5-5-released/) ago. Building under Qt5.5 failed with error `error: variable ‘QDataStream args’ has initializer but incomplete type`. The extra `#include` fixed it. Backward-compatible with Qt5.4 & 5.3 (tested).
Patch source: https://github.com/OtterBrowser/otter-browser/issues/706 https://github.com/OtterBrowser/otter-browser/commit/a2cd7465ce1cb29d69ee8ac97006f793e7d93121