### PR TITLE
always use tabSize from the preferences when converting tabs to spaces

### DIFF
--- a/src/editor/app.js
+++ b/src/editor/app.js
@@ -416,7 +416,16 @@ UiDriver.registerEventHandler("C_CMD_TRIM_LEADING_SPACE", function(msg, data, pr
 });
 
 UiDriver.registerEventHandler("C_CMD_TAB_TO_SPACE", function(msg, data, prevReturn) {
-    editLines(function (x) { return x.replace(/\t/g, (function(tabSize) {var result = ""; for (var i = 0; i< tabSize; i++) { result += " ";} return result;})(editor.getOption("tabSize"))); });
+    editLines(function (x) {
+        return x.replace(/\t/g, (function(tabSize) {
+            var result = "";
+            for (var i = 0; i< tabSize; i++) {
+                result += " ";}
+            return result;
+        })(
+            editor.getOption("tabSize")
+        ));
+    });
 });
 
 UiDriver.registerEventHandler("C_CMD_SPACE_TO_TAB_ALL", function(msg, data, prevReturn) {

--- a/src/editor/app.js
+++ b/src/editor/app.js
@@ -416,7 +416,7 @@ UiDriver.registerEventHandler("C_CMD_TRIM_LEADING_SPACE", function(msg, data, pr
 });
 
 UiDriver.registerEventHandler("C_CMD_TAB_TO_SPACE", function(msg, data, prevReturn) {
-    editLines(function (x) { return x.replace(/\t/g, " "); });
+    editLines(function (x) { return x.replace(/\t/g, (function(tabSize) {var result = ""; for (var i = 0; i< tabSize; i++) { result += " ";} return result;})(editor.getOption("tabSize"))); });
 });
 
 UiDriver.registerEventHandler("C_CMD_SPACE_TO_TAB_ALL", function(msg, data, prevReturn) {

--- a/src/editor/app.js
+++ b/src/editor/app.js
@@ -420,7 +420,8 @@ UiDriver.registerEventHandler("C_CMD_TAB_TO_SPACE", function(msg, data, prevRetu
         return x.replace(/\t/g, (function(tabSize) {
             var result = "";
             for (var i = 0; i< tabSize; i++) {
-                result += " ";}
+                result += " ";
+            }
             return result;
         })(
             editor.getOption("tabSize")


### PR DESCRIPTION
currently, converting tabs to spaces reduces each tab to one single space.
with this patch, each tab gets replaced by "tabSize" spaces.

this patch makes the command behave correctly for most but not all cases.
theoretically, the tab width should respect the context and only insert the number of spaces needed to jump to the next "tab mark"... but this cannot be done with the regexps currently in use.

i've been looking for a way to repeat a string and found a lodash module in the extensions, but it does not seem to get loaded.
if there a string.replace() function somewhere in the code base, it should be used instead of my quick and dirty lambda:
 
~~~.js
editLines(function (x) { return x.replace(/\t/g, _.repeat(' ', editor.getOption("tabSize"))); });
~~~