### PR TITLE
added Shift+Insert paste functionality

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -473,7 +473,11 @@ void MainWindow::on_editorUrlsDropped(QList<QUrl> urls)
 void MainWindow::keyPressEvent(QKeyEvent *ev)
 {
     if (ev->key() == Qt::Key_Insert) {
-        toggleOverwrite();
+        if (QApplication::keyboardModifiers().testFlag(Qt::ShiftModifier)) {
+	    on_action_Paste_triggered();
+        }else{
+            toggleOverwrite();
+	}
     } else {
         QMainWindow::keyPressEvent(ev);
     }


### PR DESCRIPTION
These changes let the user use Shift+Insert shortcut to paste.  I have been adding support every time I get a new version of notepadqq since this the shortcut I am in the habit of using.  I am not attached to my specific implementation since I am not a Qt developer and there is probably ample room for improvement.