### PR TITLE
Add Ctrl+Insert copy functionality

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -474,10 +474,12 @@ void MainWindow::keyPressEvent(QKeyEvent *ev)
 {
     if (ev->key() == Qt::Key_Insert) {
         if (QApplication::keyboardModifiers().testFlag(Qt::ShiftModifier)) {
-	    on_action_Paste_triggered();
-        }else{
+            on_action_Paste_triggered();
+        } else if (QApplication::keyboardModifiers().testFlag(Qt::ControlModifier)) {
+            on_action_Copy_triggered();
+        } else {
             toggleOverwrite();
-	}
+        }
     } else {
         QMainWindow::keyPressEvent(ev);
     }


### PR DESCRIPTION
Added the <kbd>Ctrl</kbd>+<kbd>Insert</kbd> copy functionality to pair with the <kbd>Shift</kbd>+<kbd>Insert</kbd> paste option implemented recently in #176. 