### PR TITLE
Add file extensions for newer Fortran standards

### DIFF
--- a/src/editor/classes/Languages.js
+++ b/src/editor/classes/Languages.js
@@ -228,7 +228,7 @@ var Languages = new function() {
             name: "Fortran",
             mode: "fortran",
             mime: "text/x-fortran",
-            fileExtensions: ["f", "f90", "for", "fpp", "ftn"]
+            fileExtensions: ["f", "f90", "for", "fpp", "ftn", "f95", "f03", "f08"]
         },
 
         "fsharp": {


### PR DESCRIPTION
I noticed a user asking for this feature on the [site](http://notepadqq.altervista.org/wp/download/#comment-27456) and hopefully there are other Fortran archaeologists out there benefiting from this.