### PR TITLE
Feature/keyboard tab switch

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -480,6 +480,9 @@ void MainWindow::keyPressEvent(QKeyEvent *ev)
         } else {
             toggleOverwrite();
         }
+    } else if (ev->key() >= Qt::Key_1 && ev->key() <= Qt::Key_9 &&
+               QApplication::keyboardModifiers().testFlag(Qt::AltModifier)) {
+        m_topEditorContainer->currentTabWidget()->setCurrentIndex(ev->key() - Qt::Key_1);
     } else {
         QMainWindow::keyPressEvent(ev);
     }

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -483,19 +483,19 @@ void MainWindow::keyPressEvent(QKeyEvent *ev)
     } else if (ev->key() >= Qt::Key_1 && ev->key() <= Qt::Key_9
                && QApplication::keyboardModifiers().testFlag(Qt::AltModifier)) {
         m_topEditorContainer->currentTabWidget()->setCurrentIndex(ev->key() - Qt::Key_1);
-    } else if (QApplication::keyboardModifiers().testFlag(Qt::ControlModifier)) {
-        if (ev->key() == Qt::Key_PageDown) {
-            // switch to the next tab to the right or wrap around if last
-            EditorTabWidget *curTabWidget = m_topEditorContainer->currentTabWidget();
-            int nextTabIndex = (curTabWidget->currentIndex() + 1) % curTabWidget->count();
-            curTabWidget->setCurrentIndex(nextTabIndex);
-        } else if (ev->key() == Qt::Key_PageUp) {
-            // switch to the previous tab or wrap around if first
-            EditorTabWidget *curTabWidget = m_topEditorContainer->currentTabWidget();
-            int prevTabIndex = (curTabWidget->currentIndex() + curTabWidget->count() - 1)
-                                    % curTabWidget->count();
-            curTabWidget->setCurrentIndex(prevTabIndex);
-        }
+    } else if (QApplication::keyboardModifiers().testFlag(Qt::ControlModifier)
+               && ev->key() == Qt::Key_PageDown) {
+        // switch to the next tab to the right or wrap around if last
+        EditorTabWidget *curTabWidget = m_topEditorContainer->currentTabWidget();
+        int nextTabIndex = (curTabWidget->currentIndex() + 1) % curTabWidget->count();
+        curTabWidget->setCurrentIndex(nextTabIndex);
+    } else if (QApplication::keyboardModifiers().testFlag(Qt::ControlModifier)
+               && ev->key() == Qt::Key_PageUp) {
+        // switch to the previous tab or wrap around if first
+        EditorTabWidget *curTabWidget = m_topEditorContainer->currentTabWidget();
+        int prevTabIndex = (curTabWidget->currentIndex() + curTabWidget->count() - 1)
+                            % curTabWidget->count();
+        curTabWidget->setCurrentIndex(prevTabIndex);
     } else {
         QMainWindow::keyPressEvent(ev);
     }

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -480,9 +480,22 @@ void MainWindow::keyPressEvent(QKeyEvent *ev)
         } else {
             toggleOverwrite();
         }
-    } else if (ev->key() >= Qt::Key_1 && ev->key() <= Qt::Key_9 &&
-               QApplication::keyboardModifiers().testFlag(Qt::AltModifier)) {
+    } else if (ev->key() >= Qt::Key_1 && ev->key() <= Qt::Key_9
+               && QApplication::keyboardModifiers().testFlag(Qt::AltModifier)) {
         m_topEditorContainer->currentTabWidget()->setCurrentIndex(ev->key() - Qt::Key_1);
+    } else if (QApplication::keyboardModifiers().testFlag(Qt::ControlModifier)) {
+        if (ev->key() == Qt::Key_PageDown) {
+            // switch to the next tab to the right or wrap around if last
+            EditorTabWidget *curTabWidget = m_topEditorContainer->currentTabWidget();
+            int nextTabIndex = (curTabWidget->currentIndex() + 1) % curTabWidget->count();
+            curTabWidget->setCurrentIndex(nextTabIndex);
+        } else if (ev->key() == Qt::Key_PageUp) {
+            // switch to the previous tab or wrap around if first
+            EditorTabWidget *curTabWidget = m_topEditorContainer->currentTabWidget();
+            int prevTabIndex = (curTabWidget->currentIndex() + curTabWidget->count() - 1)
+                                    % curTabWidget->count();
+            curTabWidget->setCurrentIndex(prevTabIndex);
+        }
     } else {
         QMainWindow::keyPressEvent(ev);
     }


### PR DESCRIPTION
Added shortcuts for:

1.   Navigating to a specific tab by pressing <kbd>Alt</kbd>+<kbd>1 .. 9 digit</kbd>. This way you can quickly jump to any of the nine left-most tabs in Notepadqq. For example, <kbd>Alt</kbd>+<kbd>3</kbd> will change focus to the third tab from the left or do nothing if you do not have three documents opened yet.
2.   Easily move to previous (left) tab or next (right) tab by using the <kbd>Ctrl</kbd>+<kbd>PageUp</kbd> or <kbd>Ctrl</kbd>+<kbd>PageDown</kbd> shortcuts. This will wrap around if you are on the first tab and try to move to the left, or if on last and moving to the right.

The choice of keys used for the combinations above matches other tab-based applications such as Chrome, Firefox, Pidgin, etc. These should help power users rely less on their mouse.