### PR TITLE
Make copyright year dynamic on About Notepadqq form

### DIFF
--- a/src/translations/notepadqq_de.ts
+++ b/src/translations/notepadqq_de.ts
@@ -1138,8 +1138,8 @@ Wollen Sie dennoch speichern?</translation>
     <name>QObject</name>
     <message>
         <location filename="../ui/notepadqq.cpp" line="17"/>
-        <source>Copyright © 2010-2015, Daniele Di Sarli</source>
-        <translation>Copyright © 2010-2015, Daniele Di Sarli</translation>
+        <source>Copyright © 2010-%1, Daniele Di Sarli</source>
+        <translation>Copyright © 2010-%1, Daniele Di Sarli</translation>
     </message>
     <message>
         <location filename="../ui/notepadqq.cpp" line="81"/>

--- a/src/translations/notepadqq_hu.ts
+++ b/src/translations/notepadqq_hu.ts
@@ -1147,8 +1147,8 @@ Biztosan menteni szeretné?</translation>
     <name>QObject</name>
     <message>
         <location filename="../ui/notepadqq.cpp" line="17"/>
-        <source>Copyright © 2010-2015, Daniele Di Sarli</source>
-        <translation>Szerzői jog © 2010-2015, Daniele Di Sarli</translation>
+        <source>Copyright © 2010-%1, Daniele Di Sarli</source>
+        <translation>Szerzői jog © 2010-%1, Daniele Di Sarli</translation>
     </message>
     <message>
         <location filename="../ui/notepadqq.cpp" line="81"/>

--- a/src/ui/include/notepadqq.h
+++ b/src/ui/include/notepadqq.h
@@ -35,6 +35,8 @@
 
 #define POINTVERSION "0.51.0" // major.minor.revision
 
+#define COPYRIGHT_YEAR "2016"
+
 #define MIB_UTF_8 106
 
 /**

--- a/src/ui/notepadqq.cpp
+++ b/src/ui/notepadqq.cpp
@@ -6,7 +6,6 @@
 #include <QDir>
 #include <QCheckBox>
 #include <QSettings>
-#include <QDate>
 
 const QString Notepadqq::version = POINTVERSION;
 const QString Notepadqq::contributorsUrl = "https://github.com/notepadqq/notepadqq/blob/master/CONTRIBUTORS.md";
@@ -15,7 +14,7 @@ bool Notepadqq::m_oldQt = false;
 
 QString Notepadqq::copyright()
 {
-    return QObject::trUtf8("Copyright © 2010-%1, Daniele Di Sarli").arg(QDate::currentDate().year());
+    return QObject::trUtf8("Copyright © 2010-%1, Daniele Di Sarli").arg(COPYRIGHT_YEAR);
 }
 
 QString Notepadqq::appDataPath(QString fileName)

--- a/src/ui/notepadqq.cpp
+++ b/src/ui/notepadqq.cpp
@@ -6,6 +6,7 @@
 #include <QDir>
 #include <QCheckBox>
 #include <QSettings>
+#include <QDate>
 
 const QString Notepadqq::version = POINTVERSION;
 const QString Notepadqq::contributorsUrl = "https://github.com/notepadqq/notepadqq/blob/master/CONTRIBUTORS.md";
@@ -14,7 +15,7 @@ bool Notepadqq::m_oldQt = false;
 
 QString Notepadqq::copyright()
 {
-    return QObject::trUtf8("Copyright © 2010-2015, Daniele Di Sarli");
+    return QObject::trUtf8("Copyright © 2010-%1, Daniele Di Sarli").arg(QDate::currentDate().year());
 }
 
 QString Notepadqq::appDataPath(QString fileName)


### PR DESCRIPTION
Hopefully this reduces the headache of keeping it up to date, especially as the number of translations increases.