### PR TITLE
Adding ability to Shift lines up/down ref issue #183

### DIFF
--- a/src/editor/app.js
+++ b/src/editor/app.js
@@ -398,6 +398,42 @@ UiDriver.registerEventHandler("C_CMD_DUPLICATE_LINE", function(msg, data, prevRe
     editor.replaceRange('\n' + line, pos);
 });
 
+UiDriver.registerEventHandler("C_CMD_MOVE_LINE_UP", function(msg, data, prevReturn) {
+    
+    var cur = editor.getCursor();
+    
+    //check previous line is not beginning of the document
+    if( (cur.line - 1) < 0) {
+        return;
+    }
+    
+    var line = editor.getLine(cur.line) + '\n' + editor.getLine(cur.line-1);
+    var from = { line: cur.line - 1, ch: 0           };
+    var to   = { line: cur.line,     ch: line.length };
+    
+    editor.replaceRange(line, from, to);
+    editor.setCursor(cur.line - 1, cur.ch );
+});
+
+UiDriver.registerEventHandler("C_CMD_MOVE_LINE_DOWN", function(msg, data, prevReturn) {
+    
+    var cur = editor.getCursor();
+    
+    // check that next line is not past end of document
+    if( (cur.line + 1) == editor.lineCount() )  {
+        return;
+    }
+    
+    var line = editor.getLine(cur.line + 1) + '\n' + editor.getLine(cur.line);
+    var from = { line: cur.line,     ch: 0           };
+    var to   = { line: cur.line + 1, ch: line.length };
+    
+    editor.replaceRange(line, from, to);
+    editor.setCursor(cur.line + 1, cur.ch );
+    
+});
+
+
 UiDriver.registerEventHandler("C_CMD_DELETE_LINE", function(msg, data, prevReturn) {
     editor.execCommand("deleteLine");
     editor.changeGeneration(true);

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -161,6 +161,8 @@ private slots:
     void on_actionFind_in_Files_triggered();
     void on_actionDelete_Line_triggered();
     void on_actionDuplicate_Line_triggered();
+    void on_actionMove_Line_Up_triggered();
+    void on_actionMove_Line_Down_triggered();
     void on_fileSearchResultFinished(FileSearchResult::SearchResult result);
     void on_resultMatchClicked(const FileSearchResult::FileResult &file, const FileSearchResult::Result &match);
     void on_actionTrim_Trailing_Space_triggered();

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1951,6 +1951,17 @@ void MainWindow::on_actionDuplicate_Line_triggered()
     currentEditor()->sendMessage("C_CMD_DUPLICATE_LINE");
 }
 
+void MainWindow::on_actionMove_Line_Up_triggered()
+{
+    currentEditor()->sendMessage("C_CMD_MOVE_LINE_UP");
+}
+
+void MainWindow::on_actionMove_Line_Down_triggered()
+{
+    //currentEditor()->sendMessage("C_CMD_MOVE_LINE_DOWN");
+    currentEditor()->sendMessage("C_CMD_MOVE_LINE_DOWN");
+}
+
 void MainWindow::on_resultMatchClicked(const FileSearchResult::FileResult &file, const FileSearchResult::Result &match)
 {
     QUrl url = stringToUrl(file.fileName);

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -116,6 +116,8 @@
      </property>
      <addaction name="actionDuplicate_Line"/>
      <addaction name="actionDelete_Line"/>
+     <addaction name="actionMove_Line_Up" />
+     <addaction name="actionMove_Line_Down"/>
     </widget>
     <widget class="QMenu" name="menuBlank_Operations">
      <property name="title">
@@ -962,6 +964,28 @@
     <string>Ctrl+D</string>
    </property>
   </action>
+  <action name="actionMove_Line_Up">
+   <property name="text">
+    <string>Move Line Up</string>
+   </property>
+   <property name="toolTip">
+    <string>Move the current line up</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+Up</string>
+   </property> 
+  </action>	 
+  <action name="actionMove_Line_Down">
+   <property name="text">
+    <string>Move Line Down</string>
+   </property>
+   <property name="toolTip">
+    <string>Move the current line down</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+Down</string>
+   </property> 
+  </action>	 
   <action name="actionTrim_Trailing_Space">
    <property name="text">
     <string>Trim Trailing Space</string>


### PR DESCRIPTION
Since I didn't see a way to this after reading issue #183, this pull request adds the ability to Move a Line Up (using Ctrl+Shift+Up) or Move a Line Down (using Ctrl+Shift+Down).  The way I have implemented it only works on single lines (similar to how delete line and duplicate line behave).  From what I recall this may be slightly different from notepad++ which I think allows the shifting of a selected region of text also.