### PR TITLE
Add localization switch functionality within Preferences

### DIFF
--- a/src/editor/app.js
+++ b/src/editor/app.js
@@ -398,6 +398,42 @@ UiDriver.registerEventHandler("C_CMD_DUPLICATE_LINE", function(msg, data, prevRe
     editor.replaceRange('\n' + line, pos);
 });
 
+UiDriver.registerEventHandler("C_CMD_MOVE_LINE_UP", function(msg, data, prevReturn) {
+    
+    var cur = editor.getCursor();
+    
+    //check previous line is not beginning of the document
+    if( (cur.line - 1) < 0) {
+        return;
+    }
+    
+    var line = editor.getLine(cur.line) + '\n' + editor.getLine(cur.line-1);
+    var from = { line: cur.line - 1, ch: 0           };
+    var to   = { line: cur.line,     ch: line.length };
+    
+    editor.replaceRange(line, from, to);
+    editor.setCursor(cur.line - 1, cur.ch );
+});
+
+UiDriver.registerEventHandler("C_CMD_MOVE_LINE_DOWN", function(msg, data, prevReturn) {
+    
+    var cur = editor.getCursor();
+    
+    // check that next line is not past end of document
+    if( (cur.line + 1) == editor.lineCount() )  {
+        return;
+    }
+    
+    var line = editor.getLine(cur.line + 1) + '\n' + editor.getLine(cur.line);
+    var from = { line: cur.line,     ch: 0           };
+    var to   = { line: cur.line + 1, ch: line.length };
+    
+    editor.replaceRange(line, from, to);
+    editor.setCursor(cur.line + 1, cur.ch );
+    
+});
+
+
 UiDriver.registerEventHandler("C_CMD_DELETE_LINE", function(msg, data, prevReturn) {
     editor.execCommand("deleteLine");
     editor.changeGeneration(true);

--- a/src/ui/frmpreferences.cpp
+++ b/src/ui/frmpreferences.cpp
@@ -4,6 +4,7 @@
 #include "include/EditorNS/editor.h"
 #include "include/mainwindow.h"
 #include "include/Extensions/extensionsloader.h"
+#include "include/notepadqq.h"
 #include <QFileDialog>
 
 frmPreferences::frmPreferences(TopEditorContainer *topEditorContainer, QWidget *parent) :
@@ -41,6 +42,7 @@ frmPreferences::frmPreferences(TopEditorContainer *topEditorContainer, QWidget *
 
     loadLanguages(&s);
     loadColorSchemes(&s);
+    loadTranslations(&s);
 
     ui->chkSearch_SearchAsIType->setChecked(s.value("Search/SearchAsIType", true).toBool());
 
@@ -72,6 +74,7 @@ void frmPreferences::on_buttonBox_accepted()
 
     saveLanguages(&s);
     saveColorScheme(&s);
+    saveTranslation(&s);
 
     s.setValue("Search/SearchAsIType", ui->chkSearch_SearchAsIType->isChecked());
 
@@ -173,6 +176,27 @@ void frmPreferences::loadColorSchemes(QSettings *s)
     m_previewEditor->forceRender(renderSize);
 }
 
+void frmPreferences::loadTranslations(QSettings *s)
+{
+    QList<QString> translations = Notepadqq::translations();
+
+    QString localizationSetting = s->value("General/Localization", "en").toString();
+
+    for (QString langCode : translations) {
+        QString langName = QLocale::languageToString(QLocale(langCode).language());
+
+        QMap<QString, QVariant> tmap;
+        tmap.insert("langName", langName);
+        tmap.insert("langCode", langCode);
+
+        ui->localizationComboBox->addItem(langName, tmap);
+
+        if (localizationSetting == langCode) {
+            ui->localizationComboBox->setCurrentIndex(ui->localizationComboBox->count() - 1);
+        }
+    }
+}
+
 void frmPreferences::saveLanguages(QSettings *s)
 {
     QString keyPrefix = "Languages/";
@@ -199,6 +223,12 @@ void frmPreferences::saveColorScheme(QSettings *s)
 {
     QMap<QString, QVariant> selected = ui->cmbColorScheme->currentData().toMap();
     s->setValue("Appearance/ColorScheme", selected.value("name").toString());
+}
+
+void frmPreferences::saveTranslation(QSettings *s)
+{
+    QMap<QString, QVariant> selected = ui->localizationComboBox->currentData().toMap();
+    s->setValue("General/Localization", selected.value("langCode").toString());
 }
 
 void frmPreferences::on_buttonBox_rejected()
@@ -276,6 +306,32 @@ void frmPreferences::on_cmbColorScheme_currentIndexChanged(int /*index*/)
     QMap<QString, QVariant> selected = ui->cmbColorScheme->currentData().toMap();
     QString name = selected.value("name").toString();
     m_previewEditor->setTheme(Editor::themeFromName(name));
+}
+
+void frmPreferences::on_localizationComboBox_activated(int /*index*/)
+{
+    QSettings settings;
+
+    if (settings.value("General/LocalizationShowPopup", true).toBool()) {
+
+        QMessageBox msgBox;
+        msgBox.setWindowTitle(QCoreApplication::applicationName());
+        msgBox.setIcon(QMessageBox::Information);
+        msgBox.setText("<h3>" + QObject::tr("Restart required") + "</h3>");
+        msgBox.setInformativeText("<html><body>"
+            "<p>" + QObject::tr("You need to restart Notepadqq for the localization changes to take effect.") + "</p>");
+
+        QCheckBox *chkDontShowAgain = new QCheckBox();
+        chkDontShowAgain->setText(QObject::tr("Don't show me this popup again"));
+
+        msgBox.setCheckBox(chkDontShowAgain);
+        msgBox.exec();
+
+        settings.setValue("General/LocalizationShowPopup",
+                          !chkDontShowAgain->isChecked());
+        chkDontShowAgain->deleteLater();
+
+    }
 }
 
 bool frmPreferences::extensionBrowseRuntime(QLineEdit *lineEdit)

--- a/src/ui/frmpreferences.cpp
+++ b/src/ui/frmpreferences.cpp
@@ -310,28 +310,12 @@ void frmPreferences::on_cmbColorScheme_currentIndexChanged(int /*index*/)
 
 void frmPreferences::on_localizationComboBox_activated(int /*index*/)
 {
-    QSettings settings;
-
-    if (settings.value("General/LocalizationShowPopup", true).toBool()) {
-
-        QMessageBox msgBox;
-        msgBox.setWindowTitle(QCoreApplication::applicationName());
-        msgBox.setIcon(QMessageBox::Information);
-        msgBox.setText("<h3>" + QObject::tr("Restart required") + "</h3>");
-        msgBox.setInformativeText("<html><body>"
-            "<p>" + QObject::tr("You need to restart Notepadqq for the localization changes to take effect.") + "</p>");
-
-        QCheckBox *chkDontShowAgain = new QCheckBox();
-        chkDontShowAgain->setText(QObject::tr("Don't show me this popup again"));
-
-        msgBox.setCheckBox(chkDontShowAgain);
-        msgBox.exec();
-
-        settings.setValue("General/LocalizationShowPopup",
-                          !chkDontShowAgain->isChecked());
-        chkDontShowAgain->deleteLater();
-
-    }
+    QMessageBox msgBox;
+    msgBox.setWindowTitle(QCoreApplication::applicationName());
+    msgBox.setIcon(QMessageBox::Information);
+    msgBox.setText("<h3>" + QObject::tr("Restart required") + "</h3>");
+    msgBox.setInformativeText(QObject::tr("You need to restart Notepadqq\nfor the localization changes to take effect."));
+    msgBox.exec();
 }
 
 bool frmPreferences::extensionBrowseRuntime(QLineEdit *lineEdit)

--- a/src/ui/frmpreferences.ui
+++ b/src/ui/frmpreferences.ui
@@ -109,6 +109,20 @@
           </widget>
          </item>
          <item>
+          <layout class="QFormLayout" name="formLayout">
+           <item row="0" column="0">
+            <widget class="QLabel" name="localizationLabel">
+             <property name="text">
+              <string>Localization:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QComboBox" name="localizationComboBox"/>
+           </item>
+          </layout>
+         </item>
+         <item>
           <spacer name="verticalSpacer_3">
            <property name="orientation">
             <enum>Qt::Vertical</enum>

--- a/src/ui/include/frmpreferences.h
+++ b/src/ui/include/frmpreferences.h
@@ -27,6 +27,7 @@ private slots:
     void on_txtLanguages_TabSize_valueChanged(int value);
     void on_chkLanguages_IndentWithSpaces_toggled(bool checked);
     void on_cmbColorScheme_currentIndexChanged(int index);
+    void on_localizationComboBox_activated(int index);
     void on_btnNodejsBrowse_clicked();
     void on_btnNpmBrowse_clicked();
     void on_txtNodejs_textChanged(const QString &);
@@ -47,6 +48,8 @@ private:
     void saveColorScheme(QSettings *s);
     bool extensionBrowseRuntime(QLineEdit *lineEdit);
     void checkExecutableExists(QLineEdit *path);
+    void loadTranslations(QSettings *s);
+    void saveTranslation(QSettings *s);
 };
 
 #endif // FRMPREFERENCES_H

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -161,6 +161,8 @@ private slots:
     void on_actionFind_in_Files_triggered();
     void on_actionDelete_Line_triggered();
     void on_actionDuplicate_Line_triggered();
+    void on_actionMove_Line_Up_triggered();
+    void on_actionMove_Line_Down_triggered();
     void on_fileSearchResultFinished(FileSearchResult::SearchResult result);
     void on_resultMatchClicked(const FileSearchResult::FileResult &file, const FileSearchResult::Result &match);
     void on_actionTrim_Trailing_Space_triggered();

--- a/src/ui/include/notepadqq.h
+++ b/src/ui/include/notepadqq.h
@@ -70,6 +70,8 @@ public:
 
     static QString extensionsPath();
 
+    static QList<QString> translations();
+
 signals:
     void newWindow(MainWindow *window);
 

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -39,13 +39,21 @@ int main(int argc, char *argv[])
     QCoreApplication::setApplicationName("Notepadqq");
     QCoreApplication::setApplicationVersion(Notepadqq::version);
 
-    if (translator.load(QLocale(),
+    QSettings::setDefaultFormat(QSettings::IniFormat);
+
+    forceDefaultSettings();
+
+    QSettings settings;
+
+    QString langCode = settings.value("General/Localization", "en").toString();
+
+    if (translator.load(QLocale(langCode),
                         QString("%1").arg(qApp->applicationName().toLower()),
                         QString("_"),
                         QString("%1/../appdata/translations")
                         .arg(qApp->applicationDirPath()))) {
         a.installTranslator(&translator);
-    } else if (translator.load(QLocale(),
+    } else if (translator.load(QLocale(langCode),
                                QString("%1").arg(qApp->applicationName().toLower()),
                                QString("_"),
                                QString("%1/../../share/%2/translations")
@@ -53,10 +61,6 @@ int main(int argc, char *argv[])
                                .arg(qApp->applicationName().toLower()))) {
         a.installTranslator(&translator);
     }
-
-    QSettings::setDefaultFormat(QSettings::IniFormat);
-
-    forceDefaultSettings();
 
     // Check for "run-and-exit" options like -h or -v
     Notepadqq::getCommandLineArgumentsParser(QApplication::arguments());
@@ -118,7 +122,6 @@ int main(int argc, char *argv[])
     qDebug() << QString("Started in " + QString::number(__aet_elapsed / 1000 / 1000) + "msec").toStdString().c_str();
 #endif
 
-    QSettings settings;
     if (Notepadqq::oldQt() && settings.value("checkQtVersionAtStartup", true).toBool()) {
         Notepadqq::showQtVersionWarning(true, w);
     }

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1967,6 +1967,17 @@ void MainWindow::on_actionDuplicate_Line_triggered()
     currentEditor()->sendMessage("C_CMD_DUPLICATE_LINE");
 }
 
+void MainWindow::on_actionMove_Line_Up_triggered()
+{
+    currentEditor()->sendMessage("C_CMD_MOVE_LINE_UP");
+}
+
+void MainWindow::on_actionMove_Line_Down_triggered()
+{
+    //currentEditor()->sendMessage("C_CMD_MOVE_LINE_DOWN");
+    currentEditor()->sendMessage("C_CMD_MOVE_LINE_DOWN");
+}
+
 void MainWindow::on_resultMatchClicked(const FileSearchResult::FileResult &file, const FileSearchResult::Result &match)
 {
     QUrl url = stringToUrl(file.fileName);

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -480,6 +480,22 @@ void MainWindow::keyPressEvent(QKeyEvent *ev)
         } else {
             toggleOverwrite();
         }
+    } else if (ev->key() >= Qt::Key_1 && ev->key() <= Qt::Key_9
+               && QApplication::keyboardModifiers().testFlag(Qt::AltModifier)) {
+        m_topEditorContainer->currentTabWidget()->setCurrentIndex(ev->key() - Qt::Key_1);
+    } else if (QApplication::keyboardModifiers().testFlag(Qt::ControlModifier)
+               && ev->key() == Qt::Key_PageDown) {
+        // switch to the next tab to the right or wrap around if last
+        EditorTabWidget *curTabWidget = m_topEditorContainer->currentTabWidget();
+        int nextTabIndex = (curTabWidget->currentIndex() + 1) % curTabWidget->count();
+        curTabWidget->setCurrentIndex(nextTabIndex);
+    } else if (QApplication::keyboardModifiers().testFlag(Qt::ControlModifier)
+               && ev->key() == Qt::Key_PageUp) {
+        // switch to the previous tab or wrap around if first
+        EditorTabWidget *curTabWidget = m_topEditorContainer->currentTabWidget();
+        int prevTabIndex = (curTabWidget->currentIndex() + curTabWidget->count() - 1)
+                            % curTabWidget->count();
+        curTabWidget->setCurrentIndex(prevTabIndex);
     } else {
         QMainWindow::keyPressEvent(ev);
     }

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -116,6 +116,8 @@
      </property>
      <addaction name="actionDuplicate_Line"/>
      <addaction name="actionDelete_Line"/>
+     <addaction name="actionMove_Line_Up" />
+     <addaction name="actionMove_Line_Down"/>
     </widget>
     <widget class="QMenu" name="menuBlank_Operations">
      <property name="title">
@@ -962,6 +964,28 @@
     <string>Ctrl+D</string>
    </property>
   </action>
+  <action name="actionMove_Line_Up">
+   <property name="text">
+    <string>Move Line Up</string>
+   </property>
+   <property name="toolTip">
+    <string>Move the current line up</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+Up</string>
+   </property> 
+  </action>	 
+  <action name="actionMove_Line_Down">
+   <property name="text">
+    <string>Move Line Down</string>
+   </property>
+   <property name="toolTip">
+    <string>Move the current line down</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+Down</string>
+   </property> 
+  </action>	 
   <action name="actionTrim_Trailing_Space">
    <property name="text">
     <string>Trim Trailing Space</string>

--- a/src/ui/notepadqq.cpp
+++ b/src/ui/notepadqq.cpp
@@ -146,3 +146,28 @@ QString Notepadqq::extensionsPath()
     QFileInfo f = QFileInfo(settings.fileName());
     return f.absoluteDir().absoluteFilePath("extensions");
 }
+
+QList<QString> Notepadqq::translations()
+{
+    QList<QString> out;
+
+    QString translationsPath = appDataPath();
+    translationsPath.append("/translations");
+    QDir dir(translationsPath);
+    QStringList fileNames = dir.entryList(QStringList("notepadqq_*.qm"));
+
+    // FIXME this can be removed if we create a .qm file for English too, which should exist for consistency purposes
+    out.append("en");
+
+    for (int i = 0; i < fileNames.size(); ++i) {
+        // get locale extracted by filename
+        QString langCode;
+        langCode = fileNames[i]; // "notepadqq_de.qm"
+        langCode.truncate(langCode.lastIndexOf('.')); // "notepadqq_de"
+        langCode.remove(0, langCode.indexOf('_') + 1); // "de"
+
+        out.append(langCode);
+    }
+
+    return out;
+}


### PR DESCRIPTION
Added a combo box inside the Preferences/General form in order to allow the user to switch the localization. This will translate the application the next time it runs to the language the user selected.

![notepadqq_localization_setting](https://cloud.githubusercontent.com/assets/3687404/13731282/63c60df8-e922-11e5-8d6b-0a32fec54d4a.jpg)

The choice gets saved in a QSettings property. Every time Notepadqq runs, it will perform the translation based on the language found in the property, or default to English if no property is found.

The list of translations in the combo box gets populated by reading the .qm files and extracting the language from them.

Upon the user making a language selection in the Localization combo box, a popup will notify the user of the requirement of a Notepadqq restart for the changes to take effect.

![notepadqq_localization_setting_popup](https://cloud.githubusercontent.com/assets/3687404/13731285/76165ce2-e922-11e5-8738-bf3486f4d637.jpg)

As soon as #155 is implemented, we could do a restart upon accepting the preferences or add a "Restart Now" button on the popup.
