### PR TITLE
Sort localization list by language name

### DIFF
--- a/src/ui/frmpreferences.cpp
+++ b/src/ui/frmpreferences.cpp
@@ -6,6 +6,7 @@
 #include "include/Extensions/extensionsloader.h"
 #include "include/notepadqq.h"
 #include <QFileDialog>
+#include <QSortFilterProxyModel>
 
 frmPreferences::frmPreferences(TopEditorContainer *topEditorContainer, QWidget *parent) :
     QDialog(parent),
@@ -190,11 +191,17 @@ void frmPreferences::loadTranslations(QSettings *s)
         tmap.insert("langCode", langCode);
 
         ui->localizationComboBox->addItem(langName, tmap);
-
-        if (localizationSetting == langCode) {
-            ui->localizationComboBox->setCurrentIndex(ui->localizationComboBox->count() - 1);
-        }
     }
+
+    QSortFilterProxyModel* proxy = new QSortFilterProxyModel(ui->localizationComboBox);
+    proxy->setSourceModel(ui->localizationComboBox->model());
+    ui->localizationComboBox->model()->setParent(proxy);
+    ui->localizationComboBox->setModel(proxy);
+    ui->localizationComboBox->model()->sort(0);
+
+    ui->localizationComboBox->setCurrentIndex(
+                ui->localizationComboBox->findData(
+                    QLocale::languageToString(QLocale(localizationSetting).language()), Qt::DisplayRole));
 }
 
 void frmPreferences::saveLanguages(QSettings *s)


### PR DESCRIPTION
As of right now, the Localization combo box from Preferences -> General gets its item order based on country codes (assuming all file names preserve current naming convention). And in the case of country codes such as "de", which maps to "German", we will end up with "German" appearing before "French" for example in the combo box.

The code changes from this pull request will now sort by the actual language name.