### PR TITLE
Add full path, dir path and filename to clipboard options in tab context menu

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -60,6 +60,8 @@ MainWindow::MainWindow(const QString &workingDirectory, const QStringList &argum
     m_tabContextMenu = new QMenu(this);
     QAction *separator = new QAction(this);
     separator->setSeparator(true);
+    QAction *separatorBottom = new QAction(this);
+    separatorBottom->setSeparator(true);
     m_tabContextMenuActions.append(ui->actionClose);
     m_tabContextMenuActions.append(ui->actionClose_All_BUT_Current_Document);
     m_tabContextMenuActions.append(ui->actionSave);
@@ -67,6 +69,10 @@ MainWindow::MainWindow(const QString &workingDirectory, const QStringList &argum
     m_tabContextMenuActions.append(ui->actionRename);
     m_tabContextMenuActions.append(ui->actionPrint);
     m_tabContextMenuActions.append(separator);
+    m_tabContextMenuActions.append(ui->actionCurrent_Full_File_path_to_Clipboard);
+    m_tabContextMenuActions.append(ui->actionCurrent_Filename_to_Clipboard);
+    m_tabContextMenuActions.append(ui->actionCurrent_Directory_Path_to_Clipboard);
+    m_tabContextMenuActions.append(separatorBottom);
     m_tabContextMenuActions.append(ui->actionMove_to_Other_View);
     m_tabContextMenuActions.append(ui->actionClone_to_Other_View);
     m_tabContextMenuActions.append(ui->actionMove_to_New_Window);

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -646,17 +646,17 @@
   </action>
   <action name="actionCurrent_Full_File_path_to_Clipboard">
    <property name="text">
-    <string>Current Full File Path to Clipboard</string>
+    <string>Copy Full Path to Clipboard</string>
    </property>
   </action>
   <action name="actionCurrent_Filename_to_Clipboard">
    <property name="text">
-    <string>Current Filename to Clipboard</string>
+    <string>Copy Filename to Clipboard</string>
    </property>
   </action>
   <action name="actionCurrent_Directory_Path_to_Clipboard">
    <property name="text">
-    <string>Current Directory Path to Clipboard</string>
+    <string>Copy Directory to Clipboard</string>
    </property>
   </action>
   <action name="actionZoom_In">
@@ -973,8 +973,8 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+Up</string>
-   </property> 
-  </action>	 
+   </property>
+  </action>
   <action name="actionMove_Line_Down">
    <property name="text">
     <string>Move Line Down</string>
@@ -984,8 +984,8 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+Down</string>
-   </property> 
-  </action>	 
+   </property>
+  </action>
   <action name="actionTrim_Trailing_Space">
    <property name="text">
     <string>Trim Trailing Space</string>


### PR DESCRIPTION
I have enabled the following existing functionality to the tab context menu:
- Current Full File Path to Clipboard
- Current Filename to Clipboard
- Current Directory Path to Clipboard

Having it available there matches other editors/IDEs such as Notepad++, IntelliJ IDEA, Visual Studio.

![notepadqq_tab_context_menu_paths](https://cloud.githubusercontent.com/assets/3687404/14343158/e3288e7e-fc53-11e5-8e34-f06edad420de.jpg)

Although the word "current" is kind of redundant in a tab context menu, to remove it would mean three new actions defined in the _mainwindow.ui_. Let me know if you would prefer that.

The three options are currently available under **Edit -> Copy to Clipboard**.