### PR TITLE
Added regex group reuse token functionality to Replace & Replace All

### DIFF
--- a/src/ui/Search/frmsearchreplace.cpp
+++ b/src/ui/Search/frmsearchreplace.cpp
@@ -187,6 +187,7 @@ void frmSearchReplace::replace(QString string, QString replacement, SearchHelper
         data.append(regexModifiersFromSearchOptions(searchOptions));
         data.append(forward);
         data.append(replacement);
+				data.append(QString::number(static_cast<int>(searchMode)));
         editor->sendMessage("C_FUN_REPLACE", QVariant::fromValue(data));
     }
 }
@@ -198,6 +199,7 @@ int frmSearchReplace::replaceAll(QString string, QString replacement, SearchHelp
     data.append(rawSearch);
     data.append(regexModifiersFromSearchOptions(searchOptions));
     data.append(replacement);
+		data.append(QString::number(static_cast<int>(searchMode)));
     QVariant count = currentEditor()->sendMessageWithResult("C_FUN_REPLACE_ALL", QVariant::fromValue(data));
     return count.toInt();
 }

--- a/src/ui/include/Search/searchhelpers.h
+++ b/src/ui/include/Search/searchhelpers.h
@@ -7,9 +7,9 @@ class SearchHelpers
 public:
 
     enum class SearchMode {
-        PlainText,
-        SpecialChars,
-        Regex
+        PlainText = 1,
+        SpecialChars = 2,
+        Regex = 3
     };
 
     struct SearchOptions {


### PR DESCRIPTION
Replace & Replace All now mimics Notepad++ replace functionality
for regular expressions with groups: \[1-9] get replaced by groups
with the corresponding group in the regular expression.

**Example**

Test file contents:
hello C++ goodbye
hello JavaScript goodbye
hello CodeMirror goodbye

Regular expression in "Find" input box of the Search dialog:
```(hell)o\s*([^ ]*)\s*goodbye```

In "Replace with":
\2 is \1

Output:
C++ is hell
JavaScript is hell
CodeMirror is hell

Implements #191