### PR TITLE
Show symbols

### DIFF
--- a/src/editor/app.js
+++ b/src/editor/app.js
@@ -71,6 +71,11 @@ UiDriver.registerEventHandler("C_CMD_SHOW_END_OF_LINE", function(msg, data, prev
     editor.refresh();
 });
 
+UiDriver.registerEventHandler("C_CMD_SHOW_WHITESPACE", function(msg, data, prevReturn) {
+    editor.setOption("showWhitespace",data == true);
+    editor.refresh();
+});
+
 UiDriver.registerEventHandler("C_FUN_GET_INDENTATION_MODE", function(msg, data, prevReturn) {
     return { useTabs: editor.options.indentWithTabs, size: editor.options.indentUnit };
 });

--- a/src/editor/app.js
+++ b/src/editor/app.js
@@ -66,6 +66,11 @@ UiDriver.registerEventHandler("C_CMD_SET_INDENTATION_MODE", function(msg, data, 
     editor.refresh();
 });
 
+UiDriver.registerEventHandler("C_CMD_SHOW_END_OF_LINE", function(msg, data, prevReturn) {
+    editor.setOption("showEOL",data == true);
+    editor.refresh();
+});
+
 UiDriver.registerEventHandler("C_FUN_GET_INDENTATION_MODE", function(msg, data, prevReturn) {
     return { useTabs: editor.options.indentWithTabs, size: editor.options.indentUnit };
 });

--- a/src/editor/app.js
+++ b/src/editor/app.js
@@ -267,8 +267,8 @@ UiDriver.registerEventHandler("C_FUN_SEARCH", function(msg, data, prevReturn) {
    (Helper function for search/replace & replace all.)
  */
 function HasGroupReuseTokens(replacement){
-	var groupReuseRegex = /\\([1-9])/g;
-	return (groupReuseRegex.exec(replacement) !== null);
+    var groupReuseRegex = /\\([1-9])/g;
+    return (groupReuseRegex.exec(replacement) !== null);
 }
 /*
    Substitute group reuse tokens (i.e. \1, \2, etc.) with 
@@ -279,28 +279,28 @@ function HasGroupReuseTokens(replacement){
    
 */
 function ApplyReusedGroups(replacement, groups){
-	//If we got match subgroups, see if we need to alter the replacement
-	for (var iReuseGroup = 1; iReuseGroup < groups.length; iReuseGroup ++){
-		//takes care of non-consecutive group reuse tokens,
-		//i.e. in "\1 \3" with no "\2", the "\3" is ignored 
-		groupToReuse = groups[iReuseGroup];
-		replacement = replacement.replace(new RegExp("\\\\"+iReuseGroup), groupToReuse);
-	}
-	var groupReuseRegex = /\\([1-9])/g;
-	//take care of all non-matched group reuse tokens (replace with empty string)
-	//this is the Notepad++ functionality
-	replacement = replacement.replace(groupReuseRegex,"");
-	return replacement;
+    //If we got match subgroups, see if we need to alter the replacement
+    for (var iReuseGroup = 1; iReuseGroup < groups.length; iReuseGroup ++){
+        //takes care of non-consecutive group reuse tokens,
+        //i.e. in "\1 \3" with no "\2", the "\3" is ignored 
+        groupToReuse = groups[iReuseGroup];
+        replacement = replacement.replace(new RegExp("\\\\"+iReuseGroup), groupToReuse);
+    }
+    var groupReuseRegex = /\\([1-9])/g;
+    //take care of all non-matched group reuse tokens (replace with empty string)
+    //this is the Notepad++ functionality
+    replacement = replacement.replace(groupReuseRegex,"");
+    return replacement;
 }
 
 /*
    Must match the definition of enum class SearchMode
-	 in src/ui/include/Search/searchhelpers.h
+     in src/ui/include/Search/searchhelpers.h
 */
 SearchMode = {
-	PlainText:1,
-	SpecialChars:2,
-	Regex:3
+    PlainText:1,
+    SpecialChars:2,
+    Regex:3
 }
 
 /* Replace the currently selected text, then search with a specified regex (calls C_FUN_SEARCH)
@@ -318,19 +318,19 @@ UiDriver.registerEventHandler("C_FUN_REPLACE", function(msg, data, prevReturn) {
     var regexStr = data[0];
     var regexModifiers = data[1];
     var forward = data[2];
-		var searchMode = Number(data[4]);
-	  if (editor.somethingSelected()) {
-    	var replacement = data[3];
-    	// Replace
-    	if(searchMode == SearchMode.Regex && HasGroupReuseTokens(replacement)){
-    		var searchRegex = new RegExp(regexStr, regexModifiers);
-    		groups = searchRegex.exec(editor.getSelection())
-    		if(groups !== null){//groups === null should never occur!
-    			editor.replaceSelection(ApplyReusedGroups(replacement,groups));
-    		}
-    	}else{
-    		editor.replaceSelection(replacement);
-    	}
+        var searchMode = Number(data[4]);
+      if (editor.somethingSelected()) {
+        var replacement = data[3];
+        // Replace
+        if(searchMode == SearchMode.Regex && HasGroupReuseTokens(replacement)){
+            var searchRegex = new RegExp(regexStr, regexModifiers);
+            groups = searchRegex.exec(editor.getSelection())
+            if(groups !== null){//groups === null should never occur!
+                editor.replaceSelection(ApplyReusedGroups(replacement,groups));
+            }
+        }else{
+            editor.replaceSelection(replacement);
+        }
     }
 
     // Find next/prev
@@ -341,7 +341,7 @@ UiDriver.registerEventHandler("C_FUN_REPLACE_ALL", function(msg, data, prevRetur
     var regexStr = data[0];
     var regexModifiers = data[1];
     var replacement = data[2];
-		var searchMode = Number(data[3]);
+        var searchMode = Number(data[3]);
     var searchCursor = editor.getSearchCursor(new RegExp(regexStr, regexModifiers), undefined, false);
 
     var count = 0;
@@ -353,7 +353,7 @@ UiDriver.registerEventHandler("C_FUN_REPLACE_ALL", function(msg, data, prevRetur
         count++;
         // Replace
         if(hasReuseTokens){
-        	searchCursor.replace(ApplyReusedGroups(replacement, groups), "*C_FUN_REPLACE_ALL" + id);
+            searchCursor.replace(ApplyReusedGroups(replacement, groups), "*C_FUN_REPLACE_ALL" + id);
         }else{
             searchCursor.replace(replacement, "*C_FUN_REPLACE_ALL" + id);
         }        
@@ -398,6 +398,7 @@ UiDriver.registerEventHandler("C_CMD_SET_THEME", function(msg, data, prevReturn)
     }
 
     editor.setOption("theme", data.name);
+    editor.execCommand('updateLineEndings');
 });
 
 UiDriver.registerEventHandler("C_CMD_SET_OVERWRITE", function(msg, data, prevReturn) {

--- a/src/editor/app.js
+++ b/src/editor/app.js
@@ -202,6 +202,7 @@ UiDriver.registerEventHandler("C_CMD_SET_TABS_VISIBLE", function(msg, data, prev
     } else {
         $(".editor").removeClass("show-tabs");
     }
+    editor.execCommand("updateLineEndings");
 });
 
 /* Search with a specified regex. Automatically select the text when found.

--- a/src/editor/index.html
+++ b/src/editor/index.html
@@ -152,17 +152,17 @@
     <script src="libs/codemirror/addon/search/match-highlighter.js"></script>
     <script src="libs/codemirror/addon/selection/active-line.js"></script>
     <script src="libs/codemirror/addon/selection/mark-selection.js"></script>
+    <script src="libs/codemirror/addon/show-invisibles/show-invisibles.js"></script>
 
     <script src="init.js"></script>
     <script src="classes/UiDriver.js"></script>
     <script src="classes/Languages.js"></script>
     <script src="classes/Printer.js"></script>
     <script src="app.js"></script>
-
     <link rel="stylesheet" href="styles/app.css">
     <link rel="stylesheet" href="styles/app-print.css" />
   </head>
   <body>
-    <div class="editor"></div>
+    <div class="editor" id="code"></div>
   </body>
 </html>

--- a/src/editor/styles/app.css
+++ b/src/editor/styles/app.css
@@ -50,7 +50,7 @@ body {
 }
 
 .editor.show-tabs .cm-tab {
-    content: "\2192"
+    content: "\2192";
 }
 
 .editor.show-tabs .cm-tab::before

--- a/src/editor/styles/app.css
+++ b/src/editor/styles/app.css
@@ -50,9 +50,15 @@ body {
 }
 
 .editor.show-tabs .cm-tab {
-    background: url('../images/tab.png');
-    background-position: right;
-    background-repeat: no-repeat;
+    content: "\2192"
+}
+
+.editor.show-tabs .cm-tab::before
+{
+    content: "\2192";
+    position: relative;
+    left: 40%;
+    color: black;
 }
 
 /* Color of word highlight */

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -422,6 +422,16 @@ namespace EditorNS
         sendMessage("C_CMD_SET_LINE_WRAP", wrap);
     }
 
+    void Editor::setEOLVisible(const bool showeol)
+    {
+        sendMessage("C_CMD_SHOW_END_OF_LINE",showeol);
+    }
+
+    void Editor::setWhitespaceVisible(const bool showspace)
+    {
+        sendMessage("C_CMD_SHOW_WHITESPACE",showspace);
+    }
+
     QPair<int, int> Editor::cursorPosition()
     {
         QList<QVariant> cursor = sendMessageWithResult("C_FUN_GET_CURSOR").toList();

--- a/src/ui/include/EditorNS/editor.h
+++ b/src/ui/include/EditorNS/editor.h
@@ -211,6 +211,8 @@ namespace EditorNS
         Q_INVOKABLE void setSelectionsText(const QStringList &texts);
         Q_INVOKABLE QString language();
         Q_INVOKABLE void setLineWrap(const bool wrap);
+        Q_INVOKABLE void setEOLVisible(const bool showeol);
+        Q_INVOKABLE void setWhitespaceVisible(const bool showspace);
 
         /**
          * @brief Get the current cursor position

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -179,6 +179,7 @@ private slots:
     void on_actionGo_to_line_triggered();
     void on_actionInstall_Extension_triggered();
     void on_actionFull_Screen_toggled(bool on);
+    void on_actionShow_End_of_Line_triggered(bool on);
 
 private:
     static QList<MainWindow*> m_instances;

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -141,7 +141,7 @@ private slots:
     void on_actionInterpret_as_UTF_8_without_BOM_triggered();
     void on_actionInterpret_as_UTF_16BE_UCS_2_Big_Endian_triggered();
     void on_actionInterpret_as_UTF_16LE_UCS_2_Little_Endian_triggered();
-    void on_actionShow_Tabs_toggled(bool on);
+    void on_actionShow_Tabs_triggered(bool on);
     void on_actionConvert_to_triggered();
     void on_actionIndentation_Default_settings_triggered();
     void on_actionIndentation_Custom_triggered();
@@ -180,7 +180,7 @@ private slots:
     void on_actionInstall_Extension_triggered();
     void on_actionFull_Screen_toggled(bool on);
     void on_actionShow_End_of_Line_triggered(bool on);
-    void on_actionShow_All_Characters_triggered(bool on);
+    void on_actionShow_All_Characters_toggled(bool on);
 
 private:
     static QList<MainWindow*> m_instances;
@@ -258,6 +258,8 @@ private:
     void                fixKeyboardShortcuts();
     void                instantiateFrmSearchReplace();
     QUrl                stringToUrl(QString fileName, QString workingDirectory = QString());
+
+    void initUI();
 };
 
 #endif // MAINWINDOW_H

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -261,6 +261,7 @@ private:
     QUrl                stringToUrl(QString fileName, QString workingDirectory = QString());
 
     void initUI();
+    bool updateSymbols(bool on);
 };
 
 #endif // MAINWINDOW_H

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -180,6 +180,7 @@ private slots:
     void on_actionInstall_Extension_triggered();
     void on_actionFull_Screen_toggled(bool on);
     void on_actionShow_End_of_Line_triggered(bool on);
+    void on_actionShow_All_Characters_triggered(bool on);
 
 private:
     static QList<MainWindow*> m_instances;

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -181,6 +181,7 @@ private slots:
     void on_actionFull_Screen_toggled(bool on);
     void on_actionShow_End_of_Line_triggered(bool on);
     void on_actionShow_All_Characters_toggled(bool on);
+    void on_actionShow_Spaces_triggered(bool on);
 
 private:
     static QList<MainWindow*> m_instances;

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -127,7 +127,7 @@ MainWindow::MainWindow(const QString &workingDirectory, const QStringList &argum
     // Initialize UI from settings
     ui->actionWord_wrap->setChecked(m_settings->value("wordWrap", false).toBool());
     ui->actionShow_Tabs->setChecked(m_settings->value("tabsVisible", false).toBool());
-	ui->actionShow_End_of_Line->setChecked(m_settings->value("showEOL",false).toBool());
+    ui->actionShow_End_of_Line->setChecked(m_settings->value("showEOL",false).toBool());
     ui->actionShow_All_Characters->setChecked(m_settings->value("showAllSymbols",false).toBool());
 
     // Inserts at least an editor

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -642,8 +642,6 @@ void MainWindow::on_actionShow_End_of_Line_triggered(bool on)
 
 void MainWindow::on_actionShow_All_Characters_toggled(bool on)
 {
-#include <QDebug>
-    qDebug() << "Triggered";
     if(on) {
         ui->actionShow_End_of_Line->setChecked(true);
         ui->actionShow_Tabs->setChecked(true);

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -127,6 +127,7 @@ MainWindow::MainWindow(const QString &workingDirectory, const QStringList &argum
     // Initialize UI from settings
     ui->actionWord_wrap->setChecked(m_settings->value("wordWrap", false).toBool());
     ui->actionShow_Tabs->setChecked(m_settings->value("tabsVisible", false).toBool());
+	ui->actionShow_End_of_Line->setChecked(m_settings->value("showEOL",false).toBool());
 
     // Inserts at least an editor
     openCommandLineProvidedUrls(workingDirectory, arguments);
@@ -620,6 +621,15 @@ void MainWindow::on_customTabContextMenuRequested(QPoint point, EditorTabWidget 
 {
     m_tabContextMenu->exec(point);
 }
+#include <QDebug>
+void MainWindow::on_actionShow_End_of_Line_triggered(bool on)
+{
+    m_topEditorContainer->forEachEditor([&](const int /*tabWidgetId*/, const int /*editorId*/, EditorTabWidget */*tabWidget*/, Editor *editor) {
+        editor->setEOLVisible(on);
+        return true;
+    });
+    m_settings->setValue("showEOL",on);
+}
 
 bool MainWindow::reloadWithWarning(EditorTabWidget *tabWidget, int tab, QTextCodec *codec, bool bom)
 {
@@ -1012,6 +1022,7 @@ void MainWindow::on_editorAdded(EditorTabWidget *tabWidget, int tab)
     // Initialize editor with UI settings
     editor->setLineWrap(ui->actionWord_wrap->isChecked());
     editor->setTabsVisible(ui->actionShow_Tabs->isChecked());
+    editor->setEOLVisible(ui->actionShow_End_of_Line->isChecked());
     editor->setOverwrite(m_overwrite);
 }
 

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -631,12 +631,33 @@ void MainWindow::on_customTabContextMenuRequested(QPoint point, EditorTabWidget 
     m_tabContextMenu->exec(point);
 }
 
+void MainWindow::on_actionShow_Tabs_triggered(bool on)
+{
+    m_topEditorContainer->forEachEditor([&](const int /*tabWidgetId*/, const int /*editorId*/, EditorTabWidget */*tabWidget*/, Editor *editor) {
+        editor->setTabsVisible(on);
+        return true;
+    });
+    if(!on) ui->actionShow_All_Characters->setChecked(on);
+    m_settings->setValue("tabsVisible", on);
+}
+
+void MainWindow::on_actionShow_Spaces_triggered(bool on)
+{
+    m_topEditorContainer->forEachEditor([&](const int /*tabWidgetId*/, const int /*editorId*/, EditorTabWidget */*tabWidget*/, Editor *editor) {
+        editor->setWhitespaceVisible(on);
+        return true;
+    });
+    if(!on) ui->actionShow_All_Characters->setChecked(on);
+    m_settings->setValue("spacesVisible", on);
+}
+
 void MainWindow::on_actionShow_End_of_Line_triggered(bool on)
 {
     m_topEditorContainer->forEachEditor([&](const int /*tabWidgetId*/, const int /*editorId*/, EditorTabWidget */*tabWidget*/, Editor *editor) {
         editor->setEOLVisible(on);
         return true;
     });
+    if(!on) ui->actionShow_All_Characters->setChecked(on);
     m_settings->setValue("showEOL",on);
 }
 
@@ -645,9 +666,11 @@ void MainWindow::on_actionShow_All_Characters_toggled(bool on)
     if(on) {
         ui->actionShow_End_of_Line->setChecked(true);
         ui->actionShow_Tabs->setChecked(true);
+        ui->actionShow_Spaces->setChecked(true);
     }else {
         ui->actionShow_End_of_Line->setChecked(m_settings->value("showEOL",false).toBool());
         ui->actionShow_Tabs->setChecked(m_settings->value("tabsVisible",false).toBool());
+        ui->actionShow_Spaces->setChecked(m_settings->value("spacesVisible",false).toBool());
     }
 
     m_topEditorContainer->forEachEditor([&](const int /*tabWidgetId*/, const int /*editorId*/, EditorTabWidget */*tabWidget*/, Editor *editor) {
@@ -1051,14 +1074,9 @@ void MainWindow::on_editorAdded(EditorTabWidget *tabWidget, int tab)
 
     // Initialize editor with UI settings
     editor->setLineWrap(ui->actionWord_wrap->isChecked());
-    if(ui->actionShow_All_Characters->isChecked()) {
-        editor->setTabsVisible(true);
-        editor->setEOLVisible(true);
-        editor->setWhitespaceVisible(true);
-    }else {
-        editor->setTabsVisible(ui->actionShow_Tabs->isChecked());
-        editor->setEOLVisible(ui->actionShow_End_of_Line->isChecked());
-    }
+    editor->setTabsVisible(ui->actionShow_Tabs->isChecked());
+    editor->setEOLVisible(ui->actionShow_End_of_Line->isChecked());
+    editor->setWhitespaceVisible(ui->actionShow_Spaces->isChecked());
     editor->setOverwrite(m_overwrite);
 }
 
@@ -1820,15 +1838,6 @@ void MainWindow::on_actionInterpret_as_UTF_16BE_UCS_2_Big_Endian_triggered()
 void MainWindow::on_actionInterpret_as_UTF_16LE_UCS_2_Little_Endian_triggered()
 {
     m_docEngine->reinterpretEncoding(currentEditor(), QTextCodec::codecForName("UTF-16LE"), true);
-}
-
-void MainWindow::on_actionShow_Tabs_triggered(bool on)
-{
-    m_topEditorContainer->forEachEditor([&](const int /*tabWidgetId*/, const int /*editorId*/, EditorTabWidget */*tabWidget*/, Editor *editor) {
-        editor->setTabsVisible(on);
-        return true;
-    });
-    m_settings->setValue("tabsVisible", on);
 }
 
 void MainWindow::on_actionConvert_to_triggered()

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -631,14 +631,29 @@ void MainWindow::on_customTabContextMenuRequested(QPoint point, EditorTabWidget 
     m_tabContextMenu->exec(point);
 }
 
+bool MainWindow::updateSymbols(bool on)
+{
+    //Save the currently toggled symbols when deactivating Show_All_Characters using 
+    //one of the other available symbol actions.
+    if(!on && ui->actionShow_All_Characters->isChecked())
+    {
+        m_settings->setValue("tabsVisible",ui->actionShow_Tabs->isChecked());
+        m_settings->setValue("spacesVisible",ui->actionShow_Spaces->isChecked());
+        m_settings->setValue("showEOL",ui->actionShow_End_of_Line->isChecked());
+        ui->actionShow_All_Characters->setChecked(false);
+        return true;
+    }
+    return false;
+}
+
 void MainWindow::on_actionShow_Tabs_triggered(bool on)
 {
     m_topEditorContainer->forEachEditor([&](const int /*tabWidgetId*/, const int /*editorId*/, EditorTabWidget */*tabWidget*/, Editor *editor) {
         editor->setTabsVisible(on);
         return true;
     });
-    if(!on) ui->actionShow_All_Characters->setChecked(on);
-    m_settings->setValue("tabsVisible", on);
+    if(!updateSymbols(on))
+        m_settings->setValue("tabsVisible", on);
 }
 
 void MainWindow::on_actionShow_Spaces_triggered(bool on)
@@ -647,8 +662,8 @@ void MainWindow::on_actionShow_Spaces_triggered(bool on)
         editor->setWhitespaceVisible(on);
         return true;
     });
-    if(!on) ui->actionShow_All_Characters->setChecked(on);
-    m_settings->setValue("spacesVisible", on);
+    if(!updateSymbols(on))
+        m_settings->setValue("spacesVisible", on);
 }
 
 void MainWindow::on_actionShow_End_of_Line_triggered(bool on)
@@ -657,8 +672,8 @@ void MainWindow::on_actionShow_End_of_Line_triggered(bool on)
         editor->setEOLVisible(on);
         return true;
     });
-    if(!on) ui->actionShow_All_Characters->setChecked(on);
-    m_settings->setValue("showEOL",on);
+    if(!updateSymbols(on))
+        m_settings->setValue("showEOL",on);
 }
 
 void MainWindow::on_actionShow_All_Characters_toggled(bool on)

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -640,8 +640,19 @@ bool MainWindow::updateSymbols(bool on)
         m_settings->setValue("tabsVisible",ui->actionShow_Tabs->isChecked());
         m_settings->setValue("spacesVisible",ui->actionShow_Spaces->isChecked());
         m_settings->setValue("showEOL",ui->actionShow_End_of_Line->isChecked());
+        ui->actionShow_All_Characters->blockSignals(true);
         ui->actionShow_All_Characters->setChecked(false);
+        ui->actionShow_All_Characters->blockSignals(false);
+        m_settings->setValue("showAllSymbols",false);
         return true;
+    }else if(on && !ui->actionShow_All_Characters->isChecked())
+    {
+        bool showEOL = ui->actionShow_End_of_Line->isChecked();
+        bool showTabs = ui->actionShow_Tabs->isChecked();
+        bool showSpaces = ui->actionShow_Spaces->isChecked();
+        if(showEOL && showTabs && showSpaces) {
+            ui->actionShow_All_Characters->setChecked(true);
+        }
     }
     return false;
 }
@@ -683,9 +694,18 @@ void MainWindow::on_actionShow_All_Characters_toggled(bool on)
         ui->actionShow_Tabs->setChecked(true);
         ui->actionShow_Spaces->setChecked(true);
     }else {
-        ui->actionShow_End_of_Line->setChecked(m_settings->value("showEOL",false).toBool());
-        ui->actionShow_Tabs->setChecked(m_settings->value("tabsVisible",false).toBool());
-        ui->actionShow_Spaces->setChecked(m_settings->value("spacesVisible",false).toBool());
+        bool showEOL = m_settings->value("showEOL",false).toBool();
+        bool showTabs = m_settings->value("tabsVisible",false).toBool();
+        bool showSpaces = m_settings->value("spacesVisible",false).toBool();
+
+        if(showEOL && showTabs && showSpaces) {
+            showEOL = !showEOL;
+            showTabs = !showTabs;
+            showSpaces = !showSpaces;
+        }
+        ui->actionShow_End_of_Line->setChecked(showEOL);
+        ui->actionShow_Tabs->setChecked(showTabs);
+        ui->actionShow_Spaces->setChecked(showSpaces);
     }
 
     m_topEditorContainer->forEachEditor([&](const int /*tabWidgetId*/, const int /*editorId*/, EditorTabWidget */*tabWidget*/, Editor *editor) {

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -128,6 +128,7 @@ MainWindow::MainWindow(const QString &workingDirectory, const QStringList &argum
     ui->actionWord_wrap->setChecked(m_settings->value("wordWrap", false).toBool());
     ui->actionShow_Tabs->setChecked(m_settings->value("tabsVisible", false).toBool());
 	ui->actionShow_End_of_Line->setChecked(m_settings->value("showEOL",false).toBool());
+    ui->actionShow_All_Characters->setChecked(m_settings->value("showAllSymbols",false).toBool());
 
     // Inserts at least an editor
     openCommandLineProvidedUrls(workingDirectory, arguments);
@@ -621,7 +622,7 @@ void MainWindow::on_customTabContextMenuRequested(QPoint point, EditorTabWidget 
 {
     m_tabContextMenu->exec(point);
 }
-#include <QDebug>
+
 void MainWindow::on_actionShow_End_of_Line_triggered(bool on)
 {
     m_topEditorContainer->forEachEditor([&](const int /*tabWidgetId*/, const int /*editorId*/, EditorTabWidget */*tabWidget*/, Editor *editor) {
@@ -629,6 +630,18 @@ void MainWindow::on_actionShow_End_of_Line_triggered(bool on)
         return true;
     });
     m_settings->setValue("showEOL",on);
+}
+
+void MainWindow::on_actionShow_All_Characters_triggered(bool on)
+{
+    m_topEditorContainer->forEachEditor([&](const int /*tabWidgetId*/, const int /*editorId*/, EditorTabWidget */*tabWidget*/, Editor *editor) {
+        editor->setEOLVisible(ui->actionShow_End_of_Line->isChecked());
+        editor->setTabsVisible(ui->actionShow_Tabs->isChecked());
+        editor->setWhitespaceVisible(on);
+        return true;
+    });
+    m_settings->setValue("showAllSymbols",on);
+
 }
 
 bool MainWindow::reloadWithWarning(EditorTabWidget *tabWidget, int tab, QTextCodec *codec, bool bom)
@@ -1021,8 +1034,14 @@ void MainWindow::on_editorAdded(EditorTabWidget *tabWidget, int tab)
 
     // Initialize editor with UI settings
     editor->setLineWrap(ui->actionWord_wrap->isChecked());
-    editor->setTabsVisible(ui->actionShow_Tabs->isChecked());
-    editor->setEOLVisible(ui->actionShow_End_of_Line->isChecked());
+    if(ui->actionShow_All_Characters->isChecked()) {
+        editor->setTabsVisible(true);
+        editor->setEOLVisible(true);
+        editor->setWhitespaceVisible(true);
+    }else {
+        editor->setTabsVisible(ui->actionShow_Tabs->isChecked());
+        editor->setEOLVisible(ui->actionShow_End_of_Line->isChecked());
+    }
     editor->setOverwrite(m_overwrite);
 }
 

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -42,7 +42,7 @@
      <x>0</x>
      <y>0</y>
      <width>723</width>
-     <height>25</height>
+     <height>19</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">
@@ -170,6 +170,7 @@
       <string>Show Symbol</string>
      </property>
      <addaction name="actionShow_Tabs"/>
+     <addaction name="actionShow_Spaces"/>
      <addaction name="actionShow_End_of_Line"/>
      <addaction name="actionShow_All_Characters"/>
      <addaction name="separator"/>
@@ -1054,6 +1055,17 @@
    </property>
    <property name="shortcut">
     <string>F11</string>
+   </property>
+  </action>
+  <action name="actionShow_Spaces">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Show Spaces</string>
+   </property>
+   <property name="toolTip">
+    <string>Show Spaces</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
This is the notepadqq portion of the show-symbols feature.  I'm still debating on what to do about the CodeMirror addon.

I've more or less scrapped all the original code I was going to use, so the entire way the addon functions is different from the one I was initially going to use from CodeRaiser.

Pretty simple changes mostly, basically all this does is exposes the functionality of the addon to the notepadqq instance.