### PR TITLE
Show Containing Folder in <Browser/Terminal>

### DIFF
--- a/src/ui/frmpreferences.cpp
+++ b/src/ui/frmpreferences.cpp
@@ -48,7 +48,7 @@ frmPreferences::frmPreferences(TopEditorContainer *topEditorContainer, QWidget *
     loadAppearanceTab();
     loadTranslations();
     loadShortcuts();
-	loadExternalTools();
+    loadExternalTools();
 
     ui->chkSearch_SearchAsIType->setChecked(m_settings.Search.getSearchAsIType());
 }
@@ -111,7 +111,7 @@ void frmPreferences::on_buttonBox_accepted()
     m_settings.General.setWarnForDifferentIndentation(ui->chkWarnForDifferentIndentation->isChecked());
 
     saveExternalTools();
-	saveLanguages();
+    saveLanguages();
     saveAppearanceTab();
     saveTranslation();
     saveShortcuts();

--- a/src/ui/frmpreferences.cpp
+++ b/src/ui/frmpreferences.cpp
@@ -51,9 +51,6 @@ frmPreferences::frmPreferences(TopEditorContainer *topEditorContainer, QWidget *
 	loadExternalTools();
 
     ui->chkSearch_SearchAsIType->setChecked(m_settings.Search.getSearchAsIType());
-
-    ui->txtNodejs->setText(m_settings.Extensions.getRuntimeNodeJS());
-    ui->txtNpm->setText(m_settings.Extensions.getRuntimeNpm());
 }
 
 frmPreferences::~frmPreferences()
@@ -61,27 +58,22 @@ frmPreferences::~frmPreferences()
     delete ui;
 }
 
-<<<<<<< 150cbe89aa0c2fa495e40fc1c21d127fd85a99ba
-=======
-
-void frmPreferences::loadExternalTools(QSettings* s)
+void frmPreferences::loadExternalTools()
 {
-    ui->txtNodejs->setText(s->value("Extensions/Runtime_Nodejs", "").toString());
-    ui->txtNpm->setText(s->value("Extensions/Runtime_Npm", "").toString());
+    ui->txtNodejs->setText(m_settings.Extensions.getRuntimeNodeJS());
+    ui->txtNpm->setText(m_settings.Extensions.getRuntimeNpm());
 
-    ui->txtTerminalLaunchCmd->setText(s->value("ExternalTools/TerminalLaunchCmd", "").toString());
+    ui->txtTerminalLaunchCmd->setText(m_settings.ExternalTools.getTerminalLaunchCmd());
 }
 
-void frmPreferences::saveExternalTools(QSettings* s)
+void frmPreferences::saveExternalTools()
 {
-    s->setValue("Extensions/Runtime_Nodejs", ui->txtNodejs->text());
-    s->setValue("Extensions/Runtime_Npm", ui->txtNpm->text());
+    m_settings.Extensions.setRuntimeNodeJS(ui->txtNodejs->text());
+    m_settings.Extensions.setRuntimeNpm(ui->txtNpm->text());
 
-    s->setValue("ExternalTools/TerminalLaunchCmd", ui->txtTerminalLaunchCmd->text());
+    m_settings.ExternalTools.setTerminalLaunchCmd(ui->txtTerminalLaunchCmd->text());
 }
 
-
->>>>>>> Fixed some WS and annotation.
 void frmPreferences::resetShortcuts()
 {
     const int rows = m_keyGrabber->rowCount();
@@ -125,8 +117,6 @@ void frmPreferences::on_buttonBox_accepted()
     saveShortcuts();
 
     m_settings.Search.setSearchAsIType(ui->chkSearch_SearchAsIType->isChecked());
-    m_settings.Extensions.setRuntimeNodeJS(ui->txtNodejs->text());
-    m_settings.Extensions.setRuntimeNpm(ui->txtNpm->text());
 
     const Editor::Theme& newTheme = Editor::themeFromName(ui->cmbColorScheme->currentData().toString());
     const QString fontFamily = ui->cmbFontFamilies->isEnabled() ? ui->cmbFontFamilies->currentFont().family() : "";

--- a/src/ui/frmpreferences.cpp
+++ b/src/ui/frmpreferences.cpp
@@ -48,6 +48,7 @@ frmPreferences::frmPreferences(TopEditorContainer *topEditorContainer, QWidget *
     loadAppearanceTab();
     loadTranslations();
     loadShortcuts();
+	loadExternalTools();
 
     ui->chkSearch_SearchAsIType->setChecked(m_settings.Search.getSearchAsIType());
 
@@ -96,7 +97,8 @@ void frmPreferences::on_buttonBox_accepted()
     m_settings.General.setCheckVersionAtStartup(ui->chkCheckQtVersionAtStartup->isChecked());
     m_settings.General.setWarnForDifferentIndentation(ui->chkWarnForDifferentIndentation->isChecked());
 
-    saveLanguages();
+    saveExternalTools();
+	saveLanguages();
     saveAppearanceTab();
     saveTranslation();
     saveShortcuts();
@@ -109,9 +111,11 @@ void frmPreferences::on_buttonBox_accepted()
     const QString fontFamily = ui->cmbFontFamilies->isEnabled() ? ui->cmbFontFamilies->currentFont().family() : "";
     const int fontSize = ui->spnFontSize->isEnabled() ? ui->spnFontSize->value() : 0;
 
+    const bool extensionsEnabled = Extensions::ExtensionsLoader::extensionRuntimePresent();
+
     // Apply changes to currently opened editors
     for (MainWindow *w : MainWindow::instances()) {
-        w->showExtensionsMenu(Extensions::ExtensionsLoader::extensionRuntimePresent());
+        w->showExtensionsMenu(extensionsEnabled);
 
         w->topEditorContainer()->forEachEditor([&](const int, const int, EditorTabWidget *, Editor *editor) {
 

--- a/src/ui/frmpreferences.cpp
+++ b/src/ui/frmpreferences.cpp
@@ -61,6 +61,27 @@ frmPreferences::~frmPreferences()
     delete ui;
 }
 
+<<<<<<< 150cbe89aa0c2fa495e40fc1c21d127fd85a99ba
+=======
+
+void frmPreferences::loadExternalTools(QSettings* s)
+{
+    ui->txtNodejs->setText(s->value("Extensions/Runtime_Nodejs", "").toString());
+    ui->txtNpm->setText(s->value("Extensions/Runtime_Npm", "").toString());
+
+    ui->txtTerminalLaunchCmd->setText(s->value("ExternalTools/TerminalLaunchCmd", "").toString());
+}
+
+void frmPreferences::saveExternalTools(QSettings* s)
+{
+    s->setValue("Extensions/Runtime_Nodejs", ui->txtNodejs->text());
+    s->setValue("Extensions/Runtime_Npm", ui->txtNpm->text());
+
+    s->setValue("ExternalTools/TerminalLaunchCmd", ui->txtTerminalLaunchCmd->text());
+}
+
+
+>>>>>>> Fixed some WS and annotation.
 void frmPreferences::resetShortcuts()
 {
     const int rows = m_keyGrabber->rowCount();

--- a/src/ui/frmpreferences.ui
+++ b/src/ui/frmpreferences.ui
@@ -465,7 +465,7 @@
               <x>0</x>
               <y>0</y>
               <width>551</width>
-              <height>400</height>
+              <height>394</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -572,7 +572,7 @@
                    </widget>
                   </item>
                   <item>
-                   <widget class="QLineEdit" name="lineEdit"/>
+                   <widget class="QLineEdit" name="txtTerminalLaunchCmd"/>
                   </item>
                  </layout>
                 </item>
@@ -582,7 +582,7 @@
                    <number>1</number>
                   </property>
                   <property name="text">
-                   <string>&lt;html&gt;&lt;head/&gt;&lt;body style=&quot; font-size:8pt;&quot;&gt;&lt;p&gt;Specify the launch command for your preferred terminal program. Use %s as a placeholder for the directory path argument. Examples:&lt;/p&gt;&lt;p&gt;gnome-terminal --working-directory=%s&lt;br/&gt;xterm -e sh -c &amp;quot;cd %s &amp;amp;&amp;amp; exec bash&amp;quot;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Specify the launch command for your preferred terminal program. Use %s as a placeholder for the directory path argument. Examples:&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;gnome-terminal --working-directory=%s&lt;br/&gt;konsole --workdir=%s&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                   </property>
                   <property name="scaledContents">
                    <bool>false</bool>

--- a/src/ui/frmpreferences.ui
+++ b/src/ui/frmpreferences.ui
@@ -78,7 +78,7 @@
        </item>
        <item>
         <property name="text">
-         <string>Extensions</string>
+         <string>External Tools</string>
         </property>
        </item>
       </widget>
@@ -86,7 +86,7 @@
      <item>
       <widget class="QStackedWidget" name="stackedWidget">
        <property name="currentIndex">
-        <number>0</number>
+        <number>4</number>
        </property>
        <widget class="QWidget" name="page">
         <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -464,8 +464,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>403</width>
-              <height>196</height>
+              <width>551</width>
+              <height>400</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -524,13 +524,6 @@
                   </item>
                  </layout>
                 </item>
-                <item row="4" column="0" colspan="2">
-                 <widget class="QLabel" name="label_6">
-                  <property name="text">
-                   <string>WARNING: support for extensions is EXPERIMENTAL.</string>
-                  </property>
-                 </widget>
-                </item>
                 <item row="3" column="0">
                  <spacer name="verticalSpacer_6">
                   <property name="orientation">
@@ -546,6 +539,58 @@
                    </size>
                   </property>
                  </spacer>
+                </item>
+                <item row="4" column="0" colspan="2">
+                 <widget class="QLabel" name="label_6">
+                  <property name="text">
+                   <string>WARNING: support for extensions is EXPERIMENTAL.</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QGroupBox" name="groupBox">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="title">
+                <string>Terminal</string>
+               </property>
+               <layout class="QVBoxLayout" name="verticalLayout_10">
+                <item>
+                 <layout class="QHBoxLayout" name="horizontalLayout_4">
+                  <item>
+                   <widget class="QLabel" name="label_8">
+                    <property name="text">
+                     <string>Launch Command:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QLineEdit" name="lineEdit"/>
+                  </item>
+                 </layout>
+                </item>
+                <item>
+                 <widget class="QLabel" name="label_9">
+                  <property name="lineWidth">
+                   <number>1</number>
+                  </property>
+                  <property name="text">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body style=&quot; font-size:8pt;&quot;&gt;&lt;p&gt;Specify the launch command for your preferred terminal program. Use %s as a placeholder for the directory path argument. Examples:&lt;/p&gt;&lt;p&gt;gnome-terminal --working-directory=%s&lt;br/&gt;xterm -e sh -c &amp;quot;cd %s &amp;amp;&amp;amp; exec bash&amp;quot;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
+                  <property name="scaledContents">
+                   <bool>false</bool>
+                  </property>
+                  <property name="wordWrap">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
                 </item>
                </layout>
               </widget>

--- a/src/ui/include/frmpreferences.h
+++ b/src/ui/include/frmpreferences.h
@@ -60,7 +60,7 @@ private:
 
     void loadLanguages();
     void saveLanguages();
-	void loadExternalTools();
+    void loadExternalTools();
     void saveExternalTools();
     void loadAppearanceTab();
     void saveAppearanceTab();

--- a/src/ui/include/frmpreferences.h
+++ b/src/ui/include/frmpreferences.h
@@ -60,6 +60,8 @@ private:
 
     void loadLanguages();
     void saveLanguages();
+	void loadExternalTools();
+    void saveExternalTools();
     void loadAppearanceTab();
     void saveAppearanceTab();
     void loadTranslations();

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -184,6 +184,7 @@ private slots:
 
     void on_actionFile_Browser_triggered();
 
+    void on_actionFile_Browser_triggered();
     void on_actionTerminal_triggered();
 
 private:

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -182,6 +182,10 @@ private slots:
     void on_actionShow_Spaces_triggered(bool on);
     void on_actionToggle_Smart_Indent_toggled(bool on);
 
+    void on_actionFile_Browser_triggered();
+
+    void on_actionTerminal_triggered();
+
 private:
     static QList<MainWindow*> m_instances;
     Ui::MainWindow*       ui;

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -181,9 +181,6 @@ private slots:
     void on_actionShow_All_Characters_toggled(bool on);
     void on_actionShow_Spaces_triggered(bool on);
     void on_actionToggle_Smart_Indent_toggled(bool on);
-
-    void on_actionFile_Browser_triggered();
-
     void on_actionFile_Browser_triggered();
     void on_actionTerminal_triggered();
 

--- a/src/ui/include/nqqsettings.h
+++ b/src/ui/include/nqqsettings.h
@@ -100,6 +100,10 @@ public:
         NQQ_SETTING(RuntimeNpm,     QString, QString())
     END_CATEGORY(Extensions)
 
+    BEGIN_CATEGORY(ExternalTools)
+        NQQ_SETTING(TerminalLaunchCmd,  QString,    QString())
+    END_CATEGORY(ExternalTools)
+
     BEGIN_CATEGORY(Languages)
         NQQ_SETTING_WITH_KEY(IndentWithSpaces,      bool,   false)
         NQQ_SETTING_WITH_KEY(TabSize,               int,    4)

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2221,4 +2221,26 @@ void MainWindow::on_actionToggle_Smart_Indent_toggled(bool on)
         editor->setSmartIndent(on);
         return true;
     });
+void MainWindow::on_actionFile_Browser_triggered()
+{
+    const QUrl tabUrl = m_topEditorContainer->currentTabWidget()->
+                        currentEditor()->fileName();
+
+    if (!tabUrl.isValid())
+        return;
+
+    //Get parent directory
+    const QDir parent = QFileInfo(tabUrl.toLocalFile()).absoluteDir();
+
+    QDesktopServices::openUrl( QUrl(parent.absolutePath()) );
+}
+
+void MainWindow::on_actionTerminal_triggered()
+{
+    QStringList args;
+    //args << "-e" << "sh" << "-c" << "cd /home/s3rius/Documents; exec bash";
+    //QProcess::startDetached("xterm", args);
+
+    //args << "--working-directory=/home/s3rius/Documents";
+    //QProcess::startDetached("gnome-terminal", args);
 }

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2221,8 +2221,10 @@ void MainWindow::on_actionToggle_Smart_Indent_toggled(bool on)
         editor->setSmartIndent(on);
         return true;
     });
+}
+
 //Small helper to get the path of the parent directory.
-QString getParentOfUrl(const QUrl url){
+QString getParentOfUrl(const QUrl url) {
     if (!url.isValid())
         return QString();
 

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2221,6 +2221,7 @@ void MainWindow::on_actionToggle_Smart_Indent_toggled(bool on)
         editor->setSmartIndent(on);
         return true;
     });
+//Small helper to get the path of the parent directory.
 QString getParentOfUrl(const QUrl url){
     if(!url.isValid())
         return QString();

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2223,7 +2223,7 @@ void MainWindow::on_actionToggle_Smart_Indent_toggled(bool on)
     });
 //Small helper to get the path of the parent directory.
 QString getParentOfUrl(const QUrl url){
-    if(!url.isValid())
+    if (!url.isValid())
         return QString();
 
     const QDir parentDir = QFileInfo(url.toLocalFile()).absoluteDir();

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2244,7 +2244,7 @@ void MainWindow::on_actionFile_Browser_triggered()
 void MainWindow::on_actionTerminal_triggered()
 {
     //Example of a launch command: "gnome-terminal --working-directory=%s"
-    const QString launchCmd = m_settings->value("ExternalTools/TerminalLaunchCmd").toString();
+    const QString launchCmd = m_settings.ExternalTools.getTerminalLaunchCmd();
     const QString parent = getParentOfUrl(m_topEditorContainer->currentTabWidget()->
                                           currentEditor()->fileName());
 

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -1087,6 +1087,8 @@
    </property>
    <property name="text">
     <string>Enable Smart Indent</string>
+   </property>
+  </action>
   <action name="actionFile_Browser">
    <property name="text">
     <string>File Browser</string>

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -42,7 +42,7 @@
      <x>0</x>
      <y>0</y>
      <width>723</width>
-     <height>25</height>
+     <height>23</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">
@@ -54,6 +54,13 @@
       <string>Recent Files</string>
      </property>
     </widget>
+    <widget class="QMenu" name="menuShow_Containing_Folder_in">
+     <property name="title">
+      <string>Show Containing Folder in</string>
+     </property>
+     <addaction name="actionFile_Browser"/>
+     <addaction name="actionTerminal"/>
+    </widget>
     <addaction name="action_New"/>
     <addaction name="action_Open"/>
     <addaction name="actionOpen_Folder"/>
@@ -63,6 +70,7 @@
     <addaction name="actionSave_a_Copy_As"/>
     <addaction name="actionSave_All"/>
     <addaction name="actionRename"/>
+    <addaction name="menuShow_Containing_Folder_in"/>
     <addaction name="actionClose"/>
     <addaction name="actionC_lose_All"/>
     <addaction name="actionClose_All_BUT_Current_Document"/>
@@ -1079,6 +1087,14 @@
    </property>
    <property name="text">
     <string>Enable Smart Indent</string>
+  <action name="actionFile_Browser">
+   <property name="text">
+    <string>File Browser</string>
+   </property>
+  </action>
+  <action name="actionTerminal">
+   <property name="text">
+    <string>Terminal</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
![Image](http://storage9.static.itmages.com/i/16/0830/h_1472560352_5275010_e33222adce.png)

Adds two new options to the File menu to show the containing folder of the currently active tab in the system's file browser or terminal.

Since there is no standard way that I know of to detect the user's preferred terminal application, I added an option to the settings to choose the command that is run. (For example `gnome-terminal --working-directory=%s` for most Gnome users). I added this option under the "Extensions" tab which I've renamed to "External Tools".
