### PR TITLE
NqqSettings to replace QSettings

### DIFF
--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -1,11 +1,11 @@
 #include "include/EditorNS/editor.h"
 #include "include/notepadqq.h"
+#include "include/nqqsettings.h"
 #include <QWebFrame>
 #include <QVBoxLayout>
 #include <QMessageBox>
 #include <QDir>
 #include <QEventLoop>
-#include <QSettings>
 #include <QUrlQuery>
 #include <QRegularExpression>
 
@@ -17,9 +17,8 @@ namespace EditorNS
     Editor::Editor(QWidget *parent) :
         QWidget(parent)
     {
-        QSettings s;
 
-        QString themeName = s.value("Appearance/ColorScheme", "default").toString();
+        QString themeName = NqqSettings::getInstance().Appearance.getColorScheme();
         if (themeName == "")
             themeName = "default";
 
@@ -251,16 +250,15 @@ namespace EditorNS
         return setLanguageFromFileName(fileName().toString());
     }
 
-    void Editor::setIndentationMode(const QString &language)
+    void Editor::setIndentationMode(QString language)
     {
-        QSettings s;
-        QString keyPrefix = "Languages/" + language + "/";
+        NqqSettings& s = NqqSettings::getInstance();
 
-        if (s.value(keyPrefix + "useDefaultSettings", true).toBool())
-            keyPrefix = "Languages/";
+        if(s.Languages.getUseDefaultSettings(language))
+            language = "default";
 
-        setIndentationMode(!s.value(keyPrefix + "indentWithSpaces", false).toBool(),
-                           s.value(keyPrefix + "tabSize", 4).toInt());
+        setIndentationMode(!s.Languages.getIndentWithSpaces(language),
+                            s.Languages.getTabSize(language));
     }
 
     void Editor::setIndentationMode(const bool useTabs, const int size)

--- a/src/ui/Extensions/extension.cpp
+++ b/src/ui/Extensions/extension.cpp
@@ -6,7 +6,6 @@
 #include <QJsonObject>
 #include <QTime>
 #include <QDebug>
-#include <QSettings>
 
 namespace Extensions {
 

--- a/src/ui/Extensions/installextension.cpp
+++ b/src/ui/Extensions/installextension.cpp
@@ -5,7 +5,6 @@
 #include <QJsonObject>
 #include <QJsonParseError>
 #include <QProcess>
-#include <QSettings>
 #include <QDir>
 
 namespace Extensions {

--- a/src/ui/Search/frmsearchreplace.cpp
+++ b/src/ui/Search/frmsearchreplace.cpp
@@ -755,7 +755,7 @@ void frmSearchReplace::addToReplaceHistory(QString string)
     NqqSettings& s = NqqSettings::getInstance();
 
     auto history = s.Search.getReplaceHistory();
-    addToHistory(history, string, ui->cmbSearch);
+    addToHistory(history, string, ui->cmbReplace);
     s.Search.setReplaceHistory(history);
 }
 
@@ -764,7 +764,7 @@ void frmSearchReplace::addToFileHistory(QString string)
     NqqSettings& s = NqqSettings::getInstance();
 
     auto history = s.Search.getFileHistory();
-    addToHistory(history, string, ui->cmbSearch);
+    addToHistory(history, string, ui->cmbLookIn);
     s.Search.setFileHistory(history);
 }
 
@@ -773,6 +773,6 @@ void frmSearchReplace::addToFilterHistory(QString string)
     NqqSettings& s = NqqSettings::getInstance();
 
     auto history = s.Search.getFilterHistory();
-    addToHistory(history, string, ui->cmbSearch);
+    addToHistory(history, string, ui->cmbFilter);
     s.Search.setFilterHistory(history);
 }

--- a/src/ui/Search/frmsearchreplace.cpp
+++ b/src/ui/Search/frmsearchreplace.cpp
@@ -730,6 +730,17 @@ QStringList frmSearchReplace::fileFiltersFromUI()
     return filters;
 }
 
+/**
+ * @brief Helper function to modify a list of strings that serve as a history.
+ *        The provided string will be prepended to the history, and the history
+ *        will be given to the comboBox as the list of suggestions to display.
+ *        This only serves as a helper to reduce code duplication.
+ * @param history The current history list passed as a reference. This list will
+ *        have the string from the second parameter prepended to it after the function
+ *        finishes.
+ * @param string The string to add to the history.
+ * @param comboBox The QComboBox to receive the history as suggestions list.
+ */
 void addToHistory(QStringList& history, QString string, QComboBox *comboBox) {
     if(string.isEmpty())
         return;

--- a/src/ui/docengine.cpp
+++ b/src/ui/docengine.cpp
@@ -5,10 +5,10 @@
 #include <QTextCodec>
 #include <QCoreApplication>
 #include "include/mainwindow.h"
+#include "include/nqqsettings.h"
 
-DocEngine::DocEngine(QSettings *settings, TopEditorContainer *topEditorContainer, QObject *parent) :
+DocEngine::DocEngine(TopEditorContainer *topEditorContainer, QObject *parent) :
     QObject(parent),
-    m_settings(settings),
     m_topEditorContainer(topEditorContainer),
     m_fsWatcher(new QFileSystemWatcher(this))
 {
@@ -112,7 +112,7 @@ bool DocEngine::reloadDocument(EditorTabWidget *tabWidget, int tab, QTextCodec *
 bool DocEngine::loadDocuments(const QList<QUrl> &fileNames, EditorTabWidget *tabWidget, const bool reload, QTextCodec *codec, bool bom)
 {
     if(!fileNames.empty()) {
-        m_settings->setValue("lastSelectedDir", QFileInfo(fileNames[0].toLocalFile()).absolutePath());
+        NqqSettings::getInstance().General.setLastSelectedDir(QFileInfo(fileNames[0].toLocalFile()).absolutePath());
 
         // Used to know if the document that we're loading is
         // the first one in the list.

--- a/src/ui/frmpreferences.cpp
+++ b/src/ui/frmpreferences.cpp
@@ -275,7 +275,7 @@ void frmPreferences::loadShortcuts()
 
 
     //Build the interface
-    QWidget *container = ui->page_5;
+    QWidget *container = ui->pageShortcuts;
     QVBoxLayout *layout = new QVBoxLayout();
     QPushButton *resetDefaults = new QPushButton("Restore Defaults");
     QObject::connect(resetDefaults, &QPushButton::clicked, this, &frmPreferences::resetShortcuts);

--- a/src/ui/frmpreferences.cpp
+++ b/src/ui/frmpreferences.cpp
@@ -278,7 +278,7 @@ void frmPreferences::loadShortcuts()
     QWidget *container = ui->page_5;
     QVBoxLayout *layout = new QVBoxLayout();
     QPushButton *resetDefaults = new QPushButton("Restore Defaults");
-    QObject::connect(resetDefaults,SIGNAL(clicked()),this,SLOT(resetShortcuts()));
+    QObject::connect(resetDefaults, &QPushButton::clicked, this, &frmPreferences::resetShortcuts);
     resetDefaults->setFixedWidth(128);
     layout->addWidget(m_keyGrabber);
     layout->addWidget(resetDefaults);

--- a/src/ui/frmpreferences.ui
+++ b/src/ui/frmpreferences.ui
@@ -86,7 +86,7 @@
      <item>
       <widget class="QStackedWidget" name="stackedWidget">
        <property name="currentIndex">
-        <number>0</number>
+        <number>4</number>
        </property>
        <widget class="QWidget" name="page">
         <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -436,6 +436,7 @@
          </item>
         </layout>
        </widget>
+       <widget class="QWidget" name="page_5"/>
        <widget class="QWidget" name="page_6">
         <layout class="QVBoxLayout" name="verticalLayout_7">
          <property name="leftMargin">
@@ -463,8 +464,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>403</width>
-              <height>196</height>
+              <width>395</width>
+              <height>205</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_3">

--- a/src/ui/frmpreferences.ui
+++ b/src/ui/frmpreferences.ui
@@ -436,7 +436,7 @@
          </item>
         </layout>
        </widget>
-       <widget class="QWidget" name="page_5"/>
+       <widget class="QWidget" name="pageShortcuts"/>
        <widget class="QWidget" name="page_6">
         <layout class="QVBoxLayout" name="verticalLayout_7">
          <property name="leftMargin">

--- a/src/ui/include/EditorNS/editor.h
+++ b/src/ui/include/EditorNS/editor.h
@@ -304,7 +304,7 @@ namespace EditorNS
         void fullConstructor(const Theme &theme);
 
         void setIndentationMode(const bool useTabs, const int size);
-        void setIndentationMode(const QString &language);
+        void setIndentationMode(QString language);
 
     private slots:
         void on_javaScriptWindowObjectCleared();

--- a/src/ui/include/Search/frmsearchreplace.h
+++ b/src/ui/include/Search/frmsearchreplace.h
@@ -103,7 +103,6 @@ private:
      * @param operation
      */
     void displayThreadErrorMessageBox(const QString &message, int &operation);
-    void addToHistory(QString string, QString type, QComboBox *comboBox);
     void addToSearchHistory(QString string);
     void addToReplaceHistory(QString string);
     void addToFileHistory(QString string);

--- a/src/ui/include/docengine.h
+++ b/src/ui/include/docengine.h
@@ -2,7 +2,6 @@
 #define DOCENGINE_H
 
 #include <QObject>
-#include <QSettings>
 #include <QFileSystemWatcher>
 #include <QFile>
 #include <QUrl>
@@ -19,7 +18,7 @@ class DocEngine : public QObject
 {
     Q_OBJECT
 public:
-    explicit DocEngine(QSettings *settings, TopEditorContainer *topEditorContainer, QObject *parent = 0);
+    explicit DocEngine(TopEditorContainer *topEditorContainer, QObject *parent = 0);
     ~DocEngine();
 
     struct DecodedText {
@@ -61,7 +60,6 @@ public:
     static bool writeFromString(QIODevice *io, const DecodedText &write);
 
 private:
-    QSettings *m_settings;
     TopEditorContainer *m_topEditorContainer;
     QFileSystemWatcher *m_fsWatcher;
 

--- a/src/ui/include/frmpreferences.h
+++ b/src/ui/include/frmpreferences.h
@@ -4,9 +4,9 @@
 #include <QDialog>
 #include <QTreeWidgetItem>
 #include <QTableWidgetItem>
-#include "QSettings"
 #include "include/topeditorcontainer.h"
 #include "include/keygrabber.h"
+#include "include/nqqsettings.h"
 
 namespace Ui {
 class frmPreferences;
@@ -41,6 +41,7 @@ private slots:
     void on_cmbFontFamilies_currentFontChanged(const QFont &f);
 
 private:
+    NqqSettings& m_settings;
     Ui::frmPreferences *ui;
     TopEditorContainer *m_topEditorContainer;
     QMap<QString, QVariant> *m_langsTempSettings;

--- a/src/ui/include/frmpreferences.h
+++ b/src/ui/include/frmpreferences.h
@@ -41,27 +41,33 @@ private slots:
     void on_cmbFontFamilies_currentFontChanged(const QFont &f);
 
 private:
+
+    struct LanguageSettings {
+        QString langId;
+        int tabSize;
+        bool indentWithSpaces;
+        bool useDefaultSettings;
+    };
+    QList<LanguageSettings> m_tempLangSettings;
+
     NqqSettings& m_settings;
     Ui::frmPreferences *ui;
     TopEditorContainer *m_topEditorContainer;
-    QMap<QString, QVariant> *m_langsTempSettings;
     QMap<QString,QString> *m_shortcuts;
     QList<QMap<QString, QString>> m_langs;
-    QVariantMap *m_commonLanguageProperties;
     Editor *m_previewEditor;
     KeyGrabber *kg;
 
-    void loadLanguages(QSettings *s);
-    void saveLanguages(QSettings *s);
-    void setCurrentLanguageTempValue(QString key, QVariant value);
-    void loadAppearanceTab(QSettings *s);
-    void saveAppearanceTab(QSettings *s);
+    void loadLanguages();
+    void saveLanguages();
+    void loadAppearanceTab();
+    void saveAppearanceTab();
     bool extensionBrowseRuntime(QLineEdit *lineEdit);
     void checkExecutableExists(QLineEdit *path);
-    void loadTranslations(QSettings *s);
-    void saveTranslation(QSettings *s);
-    void loadShortcuts(QSettings *s);
-    void saveShortcuts(QSettings *s);
+    void loadTranslations();
+    void saveTranslation();
+    void loadShortcuts();
+    void saveShortcuts();
     void updatePreviewEditorFont();
 };
 

--- a/src/ui/include/frmpreferences.h
+++ b/src/ui/include/frmpreferences.h
@@ -53,21 +53,21 @@ private:
     NqqSettings& m_settings;
     Ui::frmPreferences *ui;
     TopEditorContainer *m_topEditorContainer;
-    QMap<QString,QString> *m_shortcuts;
-    QList<QMap<QString, QString>> m_langs;
+    QMap<QString,QString> m_shortcuts;
     Editor *m_previewEditor;
-    KeyGrabber *kg;
+    KeyGrabber *m_keyGrabber;
 
     void loadLanguages();
     void saveLanguages();
     void loadAppearanceTab();
     void saveAppearanceTab();
-    bool extensionBrowseRuntime(QLineEdit *lineEdit);
-    void checkExecutableExists(QLineEdit *path);
     void loadTranslations();
     void saveTranslation();
     void loadShortcuts();
     void saveShortcuts();
+
+    bool extensionBrowseRuntime(QLineEdit *lineEdit);
+    void checkExecutableExists(QLineEdit *path);
     void updatePreviewEditorFont();
 };
 

--- a/src/ui/include/frmpreferences.h
+++ b/src/ui/include/frmpreferences.h
@@ -50,12 +50,13 @@ private:
     };
     QList<LanguageSettings> m_tempLangSettings;
 
+    KeyGrabber *m_keyGrabber;
+    QMap<QString,QAction*> m_actions;
+
     NqqSettings& m_settings;
     Ui::frmPreferences *ui;
     TopEditorContainer *m_topEditorContainer;
-    QMap<QString,QString> m_shortcuts;
     Editor *m_previewEditor;
-    KeyGrabber *m_keyGrabber;
 
     void loadLanguages();
     void saveLanguages();

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -63,9 +63,7 @@ public:
     QSharedPointer<Editor> currentEditorSharedPtr();
     QAction*  addExtensionMenuItem(QString extensionId, QString text);
     void showExtensionsMenu(bool show);
-    void updateShortcuts();
     QList<QAction*> getActions();
-    //QString getDefaultShortcut(QString actionName);
 
 protected:
     void closeEvent(QCloseEvent *event);
@@ -203,9 +201,7 @@ private:
     FileSearchResultsWidget* m_fileSearchResultsWidget;
     QString               m_workingDirectory;
     QMap<QSharedPointer<Extensions::Extension>, QMenu*> m_extensionMenus;
-    //QMap<QString,QString>* m_defaultShortcuts;
 
-    void                defaultShortcuts();
     void                removeTabWidgetIfEmpty(EditorTabWidget *tabWidget);
     void                createStatusBar();
     int                 askIfWantToSave(EditorTabWidget *tabWidget, int tab, int reason);

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -197,7 +197,7 @@ private:
     QLabel*               m_statusBar_EOLstyle;
     QLabel*               m_statusBar_textFormat;
     QLabel*               m_statusBar_overtypeNotify;
-    NqqSettings*          m_settings;
+    NqqSettings&          m_settings;
     frmSearchReplace*     m_frmSearchReplace = 0;
     bool                  m_overwrite = false; // Overwrite mode vs Insert mode
     FileSearchResultsWidget* m_fileSearchResultsWidget;

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -4,7 +4,6 @@
 #include <QMainWindow>
 #include "include/topeditorcontainer.h"
 #include <QLabel>
-#include <QSettings>
 #include <QCloseEvent>
 #include "docengine.h"
 #include "include/Search/frmsearchreplace.h"
@@ -12,6 +11,7 @@
 #include "QtPrintSupport/QPrinter"
 #include "include/Search/filesearchresultswidget.h"
 #include "include/Extensions/extension.h"
+#include "include/nqqsettings.h"
 
 namespace Ui {
 class MainWindow;
@@ -65,7 +65,7 @@ public:
     void showExtensionsMenu(bool show);
     void updateShortcuts();
     QList<QAction*> getActions();
-    QString getDefaultShortcut(QString actionName);
+    //QString getDefaultShortcut(QString actionName);
 
 protected:
     void closeEvent(QCloseEvent *event);
@@ -197,13 +197,13 @@ private:
     QLabel*               m_statusBar_EOLstyle;
     QLabel*               m_statusBar_textFormat;
     QLabel*               m_statusBar_overtypeNotify;
-    QSettings*            m_settings;
+    NqqSettings*          m_settings;
     frmSearchReplace*     m_frmSearchReplace = 0;
     bool                  m_overwrite = false; // Overwrite mode vs Insert mode
     FileSearchResultsWidget* m_fileSearchResultsWidget;
     QString               m_workingDirectory;
     QMap<QSharedPointer<Extensions::Extension>, QMenu*> m_extensionMenus;
-    QMap<QString,QString>* m_defaultShortcuts;
+    //QMap<QString,QString>* m_defaultShortcuts;
 
     void                defaultShortcuts();
     void                removeTabWidgetIfEmpty(EditorTabWidget *tabWidget);

--- a/src/ui/include/nqqsettings.h
+++ b/src/ui/include/nqqsettings.h
@@ -1,0 +1,146 @@
+#ifndef NQQSETTINGS_H
+#define NQQSETTINGS_H
+
+#include <QSettings>
+#include <QString>
+#include <QList>
+#include <QAction>
+#include <QDebug>
+
+//Macros to make defining settings easier.
+#define NQQ_SETTING(Name, Type, Default) \
+    Type get##Name() const { return m_settings.value(#Name,Default).value<Type>(); } \
+    void set##Name(const Type& newValue) { m_settings.setValue(#Name, newValue); } \
+    Type reset##Name() { m_settings.setValue(#Name,Default); return Default; }
+
+#define NQQ_SETTING_C(Category, Name, Type, Default) \
+    Type get##Name() const { return m_settings.value(#Category"/"#Name,Default).value<Type>(); } \
+    void set##Name(const Type& newValue) { m_settings.setValue(#Category"/"#Name, newValue); } \
+    Type reset##Name() { m_settings.setValue(#Category"/"#Name,Default); return Default; }
+
+
+class NqqSettings{
+
+public:
+    //General settings here. Each entry follows the same pattern:
+    //          Name                            Type        Default Value
+    NQQ_SETTING(Localization,                   QString,    "en")
+    NQQ_SETTING(CheckVersionAtStartup,          bool,       true)
+    NQQ_SETTING(WarnForDifferentIndentation,    bool,       true)
+
+    NQQ_SETTING(WordWrap,                       bool,       false)
+    NQQ_SETTING(Zoom,                           qreal,      1.0)
+
+    NQQ_SETTING(ShowAllSymbols,                 bool,       false)
+    NQQ_SETTING(TabsVisible,                    bool,       false)
+    NQQ_SETTING(SpacesVisisble,                 bool,       false)
+    NQQ_SETTING(ShowEOL,                        bool,       false)
+
+    NQQ_SETTING(LastSelectedDir,                QString,    ".")
+    NQQ_SETTING(RecentDocuments,                QList<QVariant>, QList<QVariant>())
+
+
+    //If the items are supposed to appear in a group, this macro can be used instead.
+    //Same deal, just with an additional parameter denoting the group it belongs to.
+    NQQ_SETTING_C("Appearance", OverrideFontFamily, QString,    "")
+    NQQ_SETTING_C("Appearance", OverrideFontSize,   int,        0)
+
+
+
+    /*NqqSettings(QObject* parent = nullptr)
+        : m_settings(parent)
+    {}*/
+
+    //A few of the more involved settings can't be handled like above.
+
+    struct ActionItem {
+        QAction* action = nullptr;
+        QKeySequence defaultSequence;
+
+        ActionItem(QAction* a, QKeySequence ks)
+            : action(a), defaultSequence(ks) {}
+
+        ActionItem(){}
+    };
+
+    //Shortcuts:
+    QMap<QString, ActionItem> m_shortcuts;
+    void initShortcuts(const QList<QAction*>& actions){
+        for(QAction* a : actions){
+            if(!a->objectName().isEmpty()){
+                QString shortcut = m_settings.value("Shortcuts/" + a->objectName()).toString();
+
+                if(shortcut != "") a->setShortcut( shortcut );
+
+                m_shortcuts.insert( a->objectName(), ActionItem{a, a->shortcut()} );
+            }
+        }
+
+        qDebug() << "shortcuts init'd: " << m_shortcuts.size();
+    }
+
+    QKeySequence getShortcut(const QString& actionName) const {
+        auto it = m_shortcuts.find(actionName);
+
+        if(it != m_shortcuts.end())
+            return it.value().action->shortcut();
+        else
+            return QKeySequence();
+    }
+
+    QKeySequence getShortcut(const QAction* action) const {
+        return getShortcut(action->objectName());
+    }
+
+    void setShortcut(const QString& actionName, const QKeySequence& sequence){
+        auto it = m_shortcuts.find(actionName);
+
+        qDebug() << "Set Shortcut start";
+
+        if(it == m_shortcuts.end())
+            return;
+
+        it.value().action->setShortcut(sequence);
+        m_settings.setValue("Shortcuts/" + actionName, sequence.toString());
+
+        qDebug() << "Set Shortcut finish";
+    }
+
+    void setShortcut(const QAction* action, const QKeySequence& sequence){
+        setShortcut(action->objectName(), sequence);
+    }
+
+    const ActionItem& getShortcutInfo(const QString& actionName){
+        return m_shortcuts[actionName];
+    }
+
+    const QMap<QString, ActionItem>& getAllShortcuts() const {
+        return m_shortcuts;
+    }
+
+    /*void resetShortcut(){
+        auto it = m_shortcuts.find(actionName);
+
+        if(it != m_shortcuts.end())
+            it.value().action->setShortcut(it.value().defaultSequence);
+    }*/
+
+    void resetAllShortcuts(){
+        for(auto&& it : m_shortcuts)
+            it.action->setShortcut( it.defaultSequence );
+    }
+
+
+    static NqqSettings& getInstance(){
+        static NqqSettings settings;
+        return settings;
+    }
+
+    //Not private for now since not NqqSettings can't handle everything yet.
+    QSettings m_settings;
+
+private:
+    NqqSettings(){}
+};
+
+#endif // NQQSETTINGS_H

--- a/src/ui/include/nqqsettings.h
+++ b/src/ui/include/nqqsettings.h
@@ -122,9 +122,14 @@ public:
         void initShortcuts(const QList<QAction*>& actions){
             for(QAction* a : actions){
                 if(a->objectName().isEmpty())
-                    return;
+                    continue;
 
-                QKeySequence shortcut = _m_settings.value("Shortcuts/" + a->objectName()).toString();
+                const QString key = "Shortcuts/" + a->objectName();
+
+                //Only update the current shortcut if it's actually set in the settings.
+                QKeySequence shortcut = _m_settings.contains(key) ?
+                                            _m_settings.value(key).toString() : a->shortcut();
+
                 _m_shortcuts.insert( a->objectName(), _ActionItem{a->shortcut(), shortcut} );
             }
         }

--- a/src/ui/include/nqqsettings.h
+++ b/src/ui/include/nqqsettings.h
@@ -78,7 +78,7 @@ public:
         NQQ_SETTING(LastSelectedDir,                QString,    ".")
         NQQ_SETTING(RecentDocuments,                QList<QVariant>, QList<QVariant>())
 
-        NQQ_SETTING(BackwardsCompatible,            bool,       false)
+        NQQ_SETTING(NotepadqqVersion,               QString,    QString())
     END_CATEGORY(General)
 
     BEGIN_CATEGORY(Appearance)

--- a/src/ui/include/nqqsettings.h
+++ b/src/ui/include/nqqsettings.h
@@ -5,9 +5,6 @@
 #include <QString>
 #include <QList>
 #include <QAction>
-#include <QDebug>
-
-
 
 /*
  * The use of NQQ_SETTING creates several functions:
@@ -29,7 +26,6 @@
  * This way they will be moved to the very bottom of the auto-complete list.
  *
  * */
-
 
 #define NQQ_SETTING(Name, Type, Default) \
     Type get##Name() const { return _m_settings.value(_m_category+#Name,Default).value<Type>(); } \

--- a/src/ui/include/nqqsettings.h
+++ b/src/ui/include/nqqsettings.h
@@ -9,49 +9,92 @@
 
 //Macros to make defining settings easier.
 #define NQQ_SETTING(Name, Type, Default) \
-    Type get##Name() const { return m_settings.value(#Name,Default).value<Type>(); } \
-    void set##Name(const Type& newValue) { m_settings.setValue(#Name, newValue); } \
-    Type reset##Name() { m_settings.setValue(#Name,Default); return Default; }
+    Type get##Name() const { return m_settings.value(m_category+#Name,Default).value<Type>(); } \
+    void set##Name(const Type& newValue) { m_settings.setValue(m_category+#Name, newValue); } \
+    Type reset##Name() { m_settings.setValue(m_category+#Name,Default); return Default; } \
+    bool has##Name() const { return m_settings.contains(m_category+#Name); }
 
-#define NQQ_SETTING_C(Category, Name, Type, Default) \
-    Type get##Name() const { return m_settings.value(#Category"/"#Name,Default).value<Type>(); } \
-    void set##Name(const Type& newValue) { m_settings.setValue(#Category"/"#Name, newValue); } \
-    Type reset##Name() { m_settings.setValue(#Category"/"#Name,Default); return Default; }
+#define NQQ_SETTING_WITH_KEY(Name, Type, Default) \
+    Type get##Name(const QString& key) const { return m_settings.value(m_category+key+"/"#Name,Default).value<Type>(); } \
+    void set##Name(const QString& key, const Type& newValue) { m_settings.setValue(m_category+key+"/"#Name, newValue); } \
+    Type reset##Name(const QString& key) { m_settings.setValue(m_category+key+"/"#Name,Default); return Default; } \
+    bool has##Name(const QString& key) const { return m_settings.contains(m_category+key+"/"#Name); }
 
+#define BEGIN_CATEGORY(Name) \
+    class _Category##Name { \
+    private: \
+    QSettings& m_settings; \
+    const QString m_category = #Name"/"; \
+    public: \
+    _Category##Name(QSettings& settings) : m_settings(settings) {} \
 
-class NqqSettings{
+#define BEGIN_GENERAL_CATEGORY(Name) \
+    class _Category##Name { \
+    private: \
+    QSettings& m_settings; \
+    const QString m_category; \
+    public: \
+    _Category##Name(QSettings& settings) : m_settings(settings) {} \
+
+#define END_CATEGORY(Name) \
+    }; _Category##Name Name = _Category##Name(m_settings);
+
+class NqqSettings {
 
 public:
-    //General settings here. Each entry follows the same pattern:
-    //          Name                            Type        Default Value
-    NQQ_SETTING(Localization,                   QString,    "en")
-    NQQ_SETTING(CheckVersionAtStartup,          bool,       true)
-    NQQ_SETTING(WarnForDifferentIndentation,    bool,       true)
 
-    NQQ_SETTING(WordWrap,                       bool,       false)
-    NQQ_SETTING(Zoom,                           qreal,      1.0)
+    BEGIN_GENERAL_CATEGORY(General)
+        NQQ_SETTING(Localization,                   QString,    "en")
+        NQQ_SETTING(CheckVersionAtStartup,          bool,       true)
+        NQQ_SETTING(WarnForDifferentIndentation,    bool,       true)
 
-    NQQ_SETTING(ShowAllSymbols,                 bool,       false)
-    NQQ_SETTING(TabsVisible,                    bool,       false)
-    NQQ_SETTING(SpacesVisisble,                 bool,       false)
-    NQQ_SETTING(ShowEOL,                        bool,       false)
+        NQQ_SETTING(WordWrap,                       bool,       false)
+        NQQ_SETTING(Zoom,                           qreal,      1.0)
 
-    NQQ_SETTING(LastSelectedDir,                QString,    ".")
-    NQQ_SETTING(RecentDocuments,                QList<QVariant>, QList<QVariant>())
+        NQQ_SETTING(ShowAllSymbols,                 bool,       false)
+        NQQ_SETTING(TabsVisible,                    bool,       false)
+        NQQ_SETTING(SpacesVisisble,                 bool,       false)
+        NQQ_SETTING(ShowEOL,                        bool,       false)
+
+        NQQ_SETTING(LastSelectedDir,                QString,    ".")
+        NQQ_SETTING(RecentDocuments,                QList<QVariant>, QList<QVariant>())
+    END_CATEGORY(General)
+
+    BEGIN_CATEGORY(Appearance)
+        NQQ_SETTING(ColorScheme,        QString,    "")
+        NQQ_SETTING(OverrideFontFamily, QString,    "")
+        NQQ_SETTING(OverrideFontSize,   int,        0)
+    END_CATEGORY(Appearance)
+
+    BEGIN_CATEGORY(Search)
+        NQQ_SETTING(SearchAsIType, bool, true)
+        NQQ_SETTING(SearchHistory, QStringList, QStringList())
+        NQQ_SETTING(ReplaceHistory, QStringList, QStringList())
+        NQQ_SETTING(FileHistory, QStringList, QStringList())
+        NQQ_SETTING(FilterHistory, QStringList, QStringList())
+
+    END_CATEGORY(Search)
+
+    BEGIN_CATEGORY(Extensions)
+        NQQ_SETTING(RuntimeNodeJS, QString, QString())
+        NQQ_SETTING(RuntimeNpm, QString, QString())
+    END_CATEGORY(Extensions)
+
+    BEGIN_CATEGORY(Languages)
+        NQQ_SETTING_WITH_KEY(IndentWithSpaces, bool, false)
+        NQQ_SETTING_WITH_KEY(TabSize, int, 4)
+        NQQ_SETTING_WITH_KEY(UseDefaultSettings, bool, true)
+    END_CATEGORY(Languages)
+
+    BEGIN_CATEGORY(MainWindow)
+        NQQ_SETTING(Geometry, QByteArray, QByteArray())
+        NQQ_SETTING(WindowState, QByteArray, QByteArray())
+    END_CATEGORY(MainWindow)
 
 
-    //If the items are supposed to appear in a group, this macro can be used instead.
-    //Same deal, just with an additional parameter denoting the group it belongs to.
-    NQQ_SETTING_C("Appearance", OverrideFontFamily, QString,    "")
-    NQQ_SETTING_C("Appearance", OverrideFontSize,   int,        0)
-
-
-
-    /*NqqSettings(QObject* parent = nullptr)
-        : m_settings(parent)
-    {}*/
 
     //A few of the more involved settings can't be handled like above.
+    BEGIN_CATEGORY(Shortcuts)
 
     struct ActionItem {
         QAction* action = nullptr;
@@ -95,15 +138,11 @@ public:
     void setShortcut(const QString& actionName, const QKeySequence& sequence){
         auto it = m_shortcuts.find(actionName);
 
-        qDebug() << "Set Shortcut start";
-
         if(it == m_shortcuts.end())
             return;
 
         it.value().action->setShortcut(sequence);
         m_settings.setValue("Shortcuts/" + actionName, sequence.toString());
-
-        qDebug() << "Set Shortcut finish";
     }
 
     void setShortcut(const QAction* action, const QKeySequence& sequence){
@@ -130,17 +169,23 @@ public:
             it.action->setShortcut( it.defaultSequence );
     }
 
+    END_CATEGORY(Shortcuts)
+
+
+
 
     static NqqSettings& getInstance(){
         static NqqSettings settings;
         return settings;
     }
 
-    //Not private for now since not NqqSettings can't handle everything yet.
+private:
     QSettings m_settings;
+    //QString m_category;
 
 private:
     NqqSettings(){}
+    NqqSettings& operator=(NqqSettings&) = delete;
 };
 
 #endif // NQQSETTINGS_H

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -43,10 +43,10 @@ int main(int argc, char *argv[])
 
     forceDefaultSettings();
 
-    //QSettings settings;
-    NqqSettings settings;
+    NqqSettings& settings = NqqSettings::getInstance();
 
-    QString langCode = settings.getLocalization();
+
+    QString langCode = settings.General.getLocalization();
 
     if (translator.load(QLocale(langCode),
                         QString("%1").arg(qApp->applicationName().toLower()),
@@ -123,7 +123,7 @@ int main(int argc, char *argv[])
     qDebug() << QString("Started in " + QString::number(__aet_elapsed / 1000 / 1000) + "msec").toStdString().c_str();
 #endif
 
-    if (Notepadqq::oldQt() && settings.getCheckVersionAtStartup()) {
+    if (Notepadqq::oldQt() && settings.General.getCheckVersionAtStartup()) {
         Notepadqq::showQtVersionWarning(true, w);
     }
 
@@ -143,18 +143,20 @@ void checkQtVersion()
 
 void forceDefaultSettings()
 {
-    QSettings settings;
+    NqqSettings& s = NqqSettings::getInstance();
 
     // Use tabs to indent makefile by default
-    if (!settings.contains("Languages/makefile/useDefaultSettings")) {
-        settings.setValue("Languages/makefile/useDefaultSettings", false);
-        settings.setValue("Languages/makefile/indentWithSpaces", false);
+    if(!s.Languages.hasUseDefaultSettings("makefile")) {
+        s.Languages.setUseDefaultSettings("makefile", false);
+        s.Languages.setIndentWithSpaces("makefile",true);
     }
 
     // Use two spaces to indent ruby by default
-    if (!settings.contains("Languages/ruby/useDefaultSettings")) {
-        settings.setValue("Languages/ruby/useDefaultSettings", false);
-        settings.setValue("Languages/ruby/tabSize", 2);
-        settings.setValue("Languages/ruby/indentWithSpaces", true);
+    if(!s.Languages.hasUseDefaultSettings("ruby")) {
+        s.Languages.setUseDefaultSettings("ruby", false);
+        s.Languages.setTabSize("ruby", 2);
+        s.Languages.setIndentWithSpaces("ruby",true);
     }
+
+
 }

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -150,7 +150,7 @@ void forceDefaultSettings()
     // Use tabs to indent makefile by default
     if(!s.Languages.hasUseDefaultSettings("makefile")) {
         s.Languages.setUseDefaultSettings("makefile", false);
-        s.Languages.setIndentWithSpaces("makefile",true);
+        s.Languages.setIndentWithSpaces("makefile", false);
     }
 
     // Use two spaces to indent ruby by default

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -4,9 +4,9 @@
 #include "include/EditorNS/editor.h"
 #include "include/singleapplication.h"
 #include "include/Extensions/extensionsloader.h"
+#include "include/nqqsettings.h"
 #include <QObject>
 #include <QFile>
-#include <QSettings>
 #include <QtGlobal>
 #include <QTranslator>
 
@@ -43,9 +43,10 @@ int main(int argc, char *argv[])
 
     forceDefaultSettings();
 
-    QSettings settings;
+    //QSettings settings;
+    NqqSettings settings;
 
-    QString langCode = settings.value("Localization", "en").toString();
+    QString langCode = settings.getLocalization();
 
     if (translator.load(QLocale(langCode),
                         QString("%1").arg(qApp->applicationName().toLower()),
@@ -122,7 +123,7 @@ int main(int argc, char *argv[])
     qDebug() << QString("Started in " + QString::number(__aet_elapsed / 1000 / 1000) + "msec").toStdString().c_str();
 #endif
 
-    if (Notepadqq::oldQt() && settings.value("checkQtVersionAtStartup", true).toBool()) {
+    if (Notepadqq::oldQt() && settings.getCheckVersionAtStartup()) {
         Notepadqq::showQtVersionWarning(true, w);
     }
 

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -41,9 +41,11 @@ int main(int argc, char *argv[])
 
     QSettings::setDefaultFormat(QSettings::IniFormat);
 
-    forceDefaultSettings();
 
+    NqqSettings::ensureBackwardsCompatibility();
     NqqSettings& settings = NqqSettings::getInstance();
+
+    forceDefaultSettings();
 
 
     QString langCode = settings.General.getLocalization();

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -44,6 +44,7 @@ int main(int argc, char *argv[])
 
     NqqSettings::ensureBackwardsCompatibility();
     NqqSettings& settings = NqqSettings::getInstance();
+    settings.General.setNotepadqqVersion(POINTVERSION);
 
     forceDefaultSettings();
 

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -29,7 +29,10 @@
 #include <QDesktopServices>
 #include <QJsonArray>
 
+
 QList<MainWindow*> MainWindow::m_instances = QList<MainWindow*>();
+
+
 
 MainWindow::MainWindow(const QString &workingDirectory, const QStringList &arguments, QWidget *parent) :
     QMainWindow(parent),
@@ -41,14 +44,15 @@ MainWindow::MainWindow(const QString &workingDirectory, const QStringList &argum
     ui->setupUi(this);
     setAttribute(Qt::WA_DeleteOnClose);
 
+
     MainWindow::m_instances.append(this);
 
     // Gets company name from QCoreApplication::setOrganizationName(). Same for app name.
-    m_settings = new QSettings(this);
+    m_settings = &NqqSettings::getInstance();
 
     setCentralWidget(m_topEditorContainer);
 
-    m_docEngine = new DocEngine(m_settings, m_topEditorContainer);
+    m_docEngine = new DocEngine(&m_settings->m_settings, m_topEditorContainer);
     connect(m_docEngine, &DocEngine::fileOnDiskChanged, this, &MainWindow::on_fileOnDiskChanged);
     connect(m_docEngine, &DocEngine::documentSaved, this, &MainWindow::on_documentSaved);
     connect(m_docEngine, &DocEngine::documentReloaded, this, &MainWindow::on_documentReloaded);
@@ -133,7 +137,7 @@ MainWindow::MainWindow(const QString &workingDirectory, const QStringList &argum
     // an EditorTabWidget within m_topEditorContainer.
 
     // Set zoom from settings
-    qreal zoom = m_settings->value("zoom", 1).toReal();
+    qreal zoom = m_settings->getZoom();
     for (int i = 0; i < m_topEditorContainer->count(); i++) {
         m_topEditorContainer->tabWidget(i)->setZoomFactor(zoom);
     }
@@ -159,6 +163,9 @@ MainWindow::MainWindow(const QString &workingDirectory, const QStringList &argum
     //this->topEditorContainer->addTabWidget()->addEditorTab(false, "test");
     defaultShortcuts();
     updateShortcuts();
+
+    m_settings->initShortcuts( getActions() );
+
     emit Notepadqq::getInstance().newWindow(this);
 }
 
@@ -195,8 +202,8 @@ TopEditorContainer *MainWindow::topEditorContainer()
 
 void MainWindow::initUI()
 {
-    bool showAll = m_settings->value("showAllSymbols", false).toBool();
-    ui->actionWord_wrap->setChecked(m_settings->value("wordWrap", false).toBool());
+    bool showAll = m_settings->getShowAllSymbols();
+    ui->actionWord_wrap->setChecked(m_settings->getWordWrap());
 
     // Simply emitting a signal here initializes actionShow_Tab and
     // actionShow_End_of_Line, due to how action_Show_All_Characters works.
@@ -206,10 +213,11 @@ void MainWindow::initUI()
 
 void MainWindow::restoreWindowSettings()
 {
-    m_settings->beginGroup("MainWindow");
-    restoreGeometry(m_settings->value("geometry").toByteArray());
-    restoreState(m_settings->value("windowState").toByteArray());
-    m_settings->endGroup();
+    QSettings* settings = &m_settings->m_settings;
+    settings->beginGroup("MainWindow");
+    restoreGeometry(settings->value("geometry").toByteArray());
+    restoreState(settings->value("windowState").toByteArray());
+    settings->endGroup();
 }
 
 void MainWindow::loadIcons()
@@ -348,37 +356,55 @@ void MainWindow::createStatusBar()
 //Store the default shortcuts on startup
 void MainWindow::defaultShortcuts()
 {
-    m_defaultShortcuts = new QMap<QString,QString>();
+    /*m_defaultShortcuts = new QMap<QString,QString>();
     foreach(QAction* a, getActions()) {
         if(!a->objectName().isEmpty()) m_defaultShortcuts->insert(a->objectName(),a->shortcut().toString());
-    }
+
+    }*/
+
+    //m_settings->initShortcuts( getActions() );
+
 }
 
-QString MainWindow::getDefaultShortcut(QString actionName)
+/*QString MainWindow::getDefaultShortcut(QString actionName)
 {
     return m_defaultShortcuts->value(actionName);
-}
+}*/
 
 void MainWindow::updateShortcuts()
 {
+    /*QSettings* settings = &m_settings->m_settings;
+
     QList<QMenu*> lst;
     QString action;
     QString shortcut;
-    lst = ui->menuBar->findChildren<QMenu*>();
-    m_settings->beginGroup("Shortcuts");
-    foreach (QAction* a, getActions())
+    lst = ui->menuBar->findChildren<QMenu*>();*/
+
+    /*for(auto&& it : m_settings->getAllShortcuts()){
+        action = it.action->objectName();
+
+        shortcut = it.action->shortcut().toString()
+    }*/
+
+
+
+
+
+
+    //settings->beginGroup("Shortcuts");
+    /*foreach (QAction* a, getActions())
     {
         action = a->objectName();
-        if(m_settings->contains(action)){
-            shortcut = m_settings->value(action).toString();
+        if(settings->contains(action)){
+            shortcut = settings->value(action).toString();
             a->setShortcut(shortcut);
 
             //Initialize settings built into the editor by default
         }else if(!a->shortcut().isEmpty()) {
-            m_settings->setValue(action,a->shortcut().toString());
+            settings->setValue(action,a->shortcut().toString());
         }
-    }
-    m_settings->endGroup();
+    }*/
+    //settings->endGroup();
 }
 
 //Return a list of all available action items in the menu
@@ -636,13 +662,13 @@ bool MainWindow::updateSymbols(bool on)
     // Save the currently toggled symbols when deactivating Show_All_Characters using
     // one of the other available symbol actions.
     if (!on && ui->actionShow_All_Characters->isChecked()) {
-        m_settings->setValue("tabsVisible", ui->actionShow_Tabs->isChecked());
-        m_settings->setValue("spacesVisible", ui->actionShow_Spaces->isChecked());
-        m_settings->setValue("showEOL", ui->actionShow_End_of_Line->isChecked());
+        m_settings->setTabsVisible(ui->actionShow_Tabs->isChecked());
+        m_settings->setSpacesVisisble(ui->actionShow_Spaces->isChecked());
+        m_settings->setShowEOL(ui->actionShow_End_of_Line->isChecked());
         ui->actionShow_All_Characters->blockSignals(true);
         ui->actionShow_All_Characters->setChecked(false);
         ui->actionShow_All_Characters->blockSignals(false);
-        m_settings->setValue("showAllSymbols", false);
+        m_settings->setShowAllSymbols(false);
         return true;
 
     } else if (on && !ui->actionShow_All_Characters->isChecked()) {
@@ -664,7 +690,7 @@ void MainWindow::on_actionShow_Tabs_triggered(bool on)
         return true;
     });
     if (!updateSymbols(on)) {
-        m_settings->setValue("tabsVisible", on);
+        m_settings->setTabsVisible(on);
     }
 }
 
@@ -675,7 +701,7 @@ void MainWindow::on_actionShow_Spaces_triggered(bool on)
         return true;
     });
     if (!updateSymbols(on)) {
-        m_settings->setValue("spacesVisible", on);
+        m_settings->setSpacesVisisble(on);
     }
 }
 
@@ -686,7 +712,7 @@ void MainWindow::on_actionShow_End_of_Line_triggered(bool on)
         return true;
     });
     if (!updateSymbols(on)) {
-        m_settings->setValue("showEOL", on);
+        m_settings->setShowEOL(on);
     }
 }
 
@@ -698,9 +724,9 @@ void MainWindow::on_actionShow_All_Characters_toggled(bool on)
         ui->actionShow_Spaces->setChecked(true);
 
     } else {
-        bool showEOL = m_settings->value("showEOL", false).toBool();
-        bool showTabs = m_settings->value("tabsVisible", false).toBool();
-        bool showSpaces = m_settings->value("spacesVisible", false).toBool();
+        bool showEOL = m_settings->getShowEOL();
+        bool showTabs = m_settings->getTabsVisible();
+        bool showSpaces = m_settings->getSpacesVisisble();
 
         if (showEOL && showTabs && showSpaces) {
             showEOL = !showEOL;
@@ -720,7 +746,7 @@ void MainWindow::on_actionShow_All_Characters_toggled(bool on)
         return true;
     });
 
-    m_settings->setValue("showAllSymbols", on);
+    m_settings->setShowAllSymbols(on);
 }
 
 bool MainWindow::reloadWithWarning(EditorTabWidget *tabWidget, int tab, QTextCodec *codec, bool bom)
@@ -788,7 +814,7 @@ void MainWindow::on_action_Open_triggered()
 {
     QUrl defaultUrl = currentEditor()->fileName();
     if (defaultUrl.isEmpty())
-            defaultUrl = QUrl::fromLocalFile(m_settings->value("lastSelectedDir", ".").toString());
+            defaultUrl = QUrl::fromLocalFile(m_settings->getLastSelectedDir());
 
     QList<QUrl> fileNames = QFileDialog::getOpenFileUrls(
                 this,
@@ -801,8 +827,7 @@ void MainWindow::on_action_Open_triggered()
         m_docEngine->loadDocuments(fileNames,
                                    m_topEditorContainer->currentTabWidget());
 
-        m_settings->setValue("lastSelectedDir",
-                             QFileInfo(fileNames[0].toLocalFile()).absolutePath());
+        m_settings->setLastSelectedDir(QFileInfo(fileNames[0].toLocalFile()).absolutePath());
     }
 }
 
@@ -810,7 +835,7 @@ void MainWindow::on_actionOpen_Folder_triggered()
 {
     QUrl defaultUrl = currentEditor()->fileName();
     if (defaultUrl.isEmpty())
-            defaultUrl = QUrl::fromLocalFile(m_settings->value("lastSelectedDir", ".").toString());
+            defaultUrl = QUrl::fromLocalFile(m_settings->getLastSelectedDir());
 
     // Select directory
     QString folder = QFileDialog::getExistingDirectory(this, tr("Open Folder"), defaultUrl.toLocalFile(), 0);
@@ -834,7 +859,7 @@ void MainWindow::on_actionOpen_Folder_triggered()
             m_docEngine->loadDocuments(fileNames,
                                        m_topEditorContainer->currentTabWidget());
 
-            m_settings->setValue("lastSelectedDir", folder);
+            m_settings->setLastSelectedDir(folder);
 
         }
 
@@ -989,8 +1014,7 @@ int MainWindow::saveAs(EditorTabWidget *tabWidget, int tab, bool copy)
                 0, 0);
 
     if (filename != "") {
-        m_settings->setValue("lastSelectedDir",
-                           QFileInfo(filename).absolutePath());
+        m_settings->setLastSelectedDir(QFileInfo(filename).absolutePath());
         // Write
         return m_docEngine->saveDocument(tabWidget, tab, QUrl::fromLocalFile(filename), copy);
     } else {
@@ -1003,7 +1027,7 @@ QUrl MainWindow::getSaveDialogDefaultFileName(EditorTabWidget *tabWidget, int ta
     QUrl docFileName = tabWidget->editor(tab)->fileName();
 
     if (docFileName.isEmpty()) {
-        return QUrl::fromLocalFile(m_settings->value("lastSelectedDir", ".").toString()
+        return QUrl::fromLocalFile(m_settings->getLastSelectedDir()
                 + "/" + tabWidget->tabText(tab));
     } else {
         return docFileName;
@@ -1117,8 +1141,8 @@ void MainWindow::on_editorAdded(EditorTabWidget *tabWidget, int tab)
     editor->setEOLVisible(ui->actionShow_End_of_Line->isChecked());
     editor->setWhitespaceVisible(ui->actionShow_Spaces->isChecked());
     editor->setOverwrite(m_overwrite);
-    editor->setFont(m_settings->value("Appearance/OverrideFontFamily", "").toString(),
-                    m_settings->value("Appearance/OverrideFontSize", 0).toInt());
+    editor->setFont(m_settings->getOverrideFontFamily(),
+                    m_settings->getOverrideFontSize());
 }
 
 void MainWindow::on_cursorActivity()
@@ -1308,10 +1332,12 @@ void MainWindow::closeEvent(QCloseEvent *event)
         }
     }
 
-    m_settings->beginGroup("MainWindow");
-    m_settings->setValue("geometry", saveGeometry());
-    m_settings->setValue("windowState", saveState());
-    m_settings->endGroup();
+    QSettings* settings = &m_settings->m_settings;
+
+    settings->beginGroup("MainWindow");
+    settings->setValue("geometry", saveGeometry());
+    settings->setValue("windowState", saveState());
+    settings->endGroup();
 
     // Disconnect signals to avoid handling events while
     // the UI is being destroyed.
@@ -1500,8 +1526,8 @@ void MainWindow::on_actionPlain_text_triggered()
 
 void MainWindow::on_actionRestore_Default_Zoom_triggered()
 {
-    m_topEditorContainer->currentTabWidget()->setZoomFactor(1);
-    m_settings->setValue("zoom", 1);
+    const qreal newZoom = m_settings->resetZoom();
+    m_topEditorContainer->currentTabWidget()->setZoomFactor(newZoom);
 }
 
 void MainWindow::on_actionZoom_In_triggered()
@@ -1509,7 +1535,7 @@ void MainWindow::on_actionZoom_In_triggered()
     qreal curZoom = currentEditor()->zoomFactor();
     qreal newZoom = curZoom + 0.25;
     m_topEditorContainer->currentTabWidget()->setZoomFactor(newZoom);
-    m_settings->setValue("zoom", newZoom);
+    m_settings->setZoom(newZoom);
 }
 
 void MainWindow::on_actionZoom_Out_triggered()
@@ -1517,7 +1543,7 @@ void MainWindow::on_actionZoom_Out_triggered()
     qreal curZoom = currentEditor()->zoomFactor();
     qreal newZoom = curZoom - 0.25;
     m_topEditorContainer->currentTabWidget()->setZoomFactor(newZoom);
-    m_settings->setValue("zoom", newZoom);
+    m_settings->setZoom(newZoom);
 }
 
 void MainWindow::on_editorMouseWheel(EditorTabWidget *tabWidget, int tab, QWheelEvent *ev)
@@ -1530,7 +1556,7 @@ void MainWindow::on_editorMouseWheel(EditorTabWidget *tabWidget, int tab, QWheel
         // Increment/Decrement zoom factor by 0.1 at each step.
         qreal newZoom = curZoom + diff;
         tabWidget->setZoomFactor(newZoom);
-        m_settings->setValue("zoom", newZoom);
+        m_settings->setZoom(newZoom);
     }
 }
 
@@ -1640,7 +1666,7 @@ void MainWindow::on_documentLoaded(EditorTabWidget *tabWidget, int tab, bool was
     const int MAX_RECENT_ENTRIES = 10;
 
     QUrl newUrl = editor->fileName();
-    QList<QVariant> recentDocs = m_settings->value("recentDocuments", QList<QVariant>()).toList();
+    QList<QVariant> recentDocs = m_settings->getRecentDocuments();
     recentDocs.insert(0, QVariant(newUrl));
 
     // Remove duplicates
@@ -1652,12 +1678,12 @@ void MainWindow::on_documentLoaded(EditorTabWidget *tabWidget, int tab, bool was
     while (recentDocs.count() > MAX_RECENT_ENTRIES)
         recentDocs.removeLast();
 
-    m_settings->setValue("recentDocuments", QVariant(recentDocs));
+    m_settings->setRecentDocuments(recentDocs);
 
     updateRecentDocsInMenu();
 
     if (!wasAlreadyOpened) {
-        if (m_settings->value("warnForDifferentIndentation", true).toBool()) {
+        if (m_settings->getWarnForDifferentIndentation()) {
             checkIndentationMode(editor);
         }
     }
@@ -1704,7 +1730,7 @@ void MainWindow::checkIndentationMode(Editor *editor)
 
 void MainWindow::updateRecentDocsInMenu()
 {
-    QList<QVariant> recentDocs = m_settings->value("recentDocuments", QList<QVariant>()).toList();
+    QList<QVariant> recentDocs = m_settings->getRecentDocuments();
 
     ui->menuRecent_Files->clear();
 
@@ -1789,18 +1815,18 @@ void MainWindow::on_actionWord_wrap_toggled(bool on)
         editor->setLineWrap(on);
         return true;
     });
-    m_settings->setValue("wordWrap", on);
+    m_settings->setWordWrap(on);
 }
 
 void MainWindow::on_actionEmpty_Recent_Files_List_triggered()
 {
-    m_settings->remove("recentDocuments");
+    m_settings->resetRecentDocuments();
     updateRecentDocsInMenu();
 }
 
 void MainWindow::on_actionOpen_All_Recent_Files_triggered()
 {
-    QList<QVariant> recentDocs = m_settings->value("recentDocuments", QList<QVariant>()).toList();
+    QList<QVariant> recentDocs = m_settings->getRecentDocuments();
 
     QList<QUrl> convertedList;
     for (QVariant doc : recentDocs) {

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -160,15 +160,18 @@ MainWindow::MainWindow(const QString &workingDirectory, const QStringList &argum
 
     //Registers all actions so that NqqSettings knows their default and current shortcuts.
     const QList<QAction*> allActions = getActions();
+
     m_settings.Shortcuts.initShortcuts( allActions );
 
     //At this point, all actions still have their default shortcuts so we set all actions'
     //shortcuts from settings.
     for(QAction* a : allActions){
-        if(!a->objectName().isEmpty()){
-            QKeySequence shortcut = m_settings.Shortcuts.getShortcut(a->objectName());
-            a->setShortcut( shortcut );
-        }
+        if(a->objectName().isEmpty())
+            continue;
+
+        QKeySequence shortcut = m_settings.Shortcuts.getShortcut(a->objectName());
+
+        a->setShortcut( shortcut );
     }
 
     emit Notepadqq::getInstance().newWindow(this);

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -38,9 +38,9 @@ MainWindow::MainWindow(const QString &workingDirectory, const QStringList &argum
     QMainWindow(parent),
     ui(new Ui::MainWindow),
     m_topEditorContainer(new TopEditorContainer(this)),
+    m_settings(NqqSettings::getInstance()),
     m_fileSearchResultsWidget(new FileSearchResultsWidget()),
-    m_workingDirectory(workingDirectory),
-    m_settings(NqqSettings::getInstance())
+    m_workingDirectory(workingDirectory)
 {
     ui->setupUi(this);
     setAttribute(Qt::WA_DeleteOnClose);

--- a/src/ui/nqqsettings.cpp
+++ b/src/ui/nqqsettings.cpp
@@ -1,1 +1,63 @@
 #include "include/nqqsettings.h"
+
+void NqqSettings::ensureBackwardsCompatibility()
+{
+    QSettings s;
+
+    const QStringList keys = s.allKeys();
+
+    //If this string is in the settings we either have the new ini settings
+    if(keys.contains("BackwardsCompatible"))
+            return;
+
+    qDebug() << "Old settings detected. Replacing keys.";
+
+    auto replace = [&](const QString& newKey, const QString& oldKey) {
+        s.setValue(newKey, s.value(oldKey));
+        s.remove(oldKey);
+    };
+
+
+    for(const QString key : keys){
+        if(key.isEmpty()) return;
+
+        QString newKey = key;
+
+        if(!key.contains('/')) {
+            //Key is from the [General] section. All keys here just need their first letter fixed.
+            newKey[0] = newKey[0].toUpper();
+        }
+
+        else if(key == "Extensions/Runtime_Nodejs")
+            newKey = "Extensions/RuntimeNodeJS";
+        else if(key == "Extensions/Runtime_Npm")
+            newKey = "Extensions/RuntimeNpm";
+        else if(key.startsWith("MainWindow/") || key.startsWith(("Search/"))) {
+            //Only capitalize first letter after the '/'
+            const int c = key.indexOf('/');
+            newKey[c+1] = newKey[c+1].toUpper();
+        }else if(key.startsWith("Languages/")) {
+            //Capitalize first letter after the second '/'
+            int c = key.indexOf('/',10);
+
+            //If there is no second '/', we found the settings for the 'default' language.
+            //They'll be migrated to Languages/default.
+            if(c==-1) {
+                newKey.replace("Languages/", "Languages/default/");
+                c = newKey.indexOf('/',10);
+            }
+
+            newKey[c+1] = newKey[c+1].toUpper();
+        }else
+            continue;
+
+        replace(newKey, key);
+    }
+
+    s.setValue("BackwardsCompatible", true);
+}
+
+NqqSettings&NqqSettings::getInstance(){
+    static NqqSettings settings;
+    return settings;
+}

--- a/src/ui/nqqsettings.cpp
+++ b/src/ui/nqqsettings.cpp
@@ -1,0 +1,3 @@
+#include "include/nqqsettings.h"
+
+NqqSettings NqqSettings::s_settings;

--- a/src/ui/nqqsettings.cpp
+++ b/src/ui/nqqsettings.cpp
@@ -1,3 +1,1 @@
 #include "include/nqqsettings.h"
-
-NqqSettings NqqSettings::s_settings;

--- a/src/ui/nqqsettings.cpp
+++ b/src/ui/nqqsettings.cpp
@@ -1,5 +1,9 @@
 #include "include/nqqsettings.h"
 
+#ifdef QT_DEBUG
+#include <QDebug>
+#endif
+
 void NqqSettings::ensureBackwardsCompatibility()
 {
     QSettings s;
@@ -10,7 +14,9 @@ void NqqSettings::ensureBackwardsCompatibility()
     if(keys.contains("BackwardsCompatible"))
             return;
 
+ #ifdef QT_DEBUG
     qDebug() << "Old settings detected. Replacing keys.";
+#endif
 
     auto replace = [&](const QString& newKey, const QString& oldKey) {
         s.setValue(newKey, s.value(oldKey));

--- a/src/ui/nqqsettings.cpp
+++ b/src/ui/nqqsettings.cpp
@@ -71,8 +71,6 @@ void NqqSettings::ensureBackwardsCompatibility()
 
         replace(newKey, key);
     }
-
-    s.setValue("BackwardsCompatible", true);
 }
 
 NqqSettings&NqqSettings::getInstance(){

--- a/src/ui/nqqsettings.cpp
+++ b/src/ui/nqqsettings.cpp
@@ -1,4 +1,5 @@
 #include "include/nqqsettings.h"
+#include "include/notepadqq.h"
 
 #ifdef QT_DEBUG
 #include <QDebug>
@@ -8,14 +9,25 @@ void NqqSettings::ensureBackwardsCompatibility()
 {
     QSettings s;
 
+
+    //Check the Nqq version, if it's above 0.53.x we're using the old settings.
+    const QString nqqVersion = s.value("NotepadqqVersion").toString();
+    const QStringList versionList = nqqVersion.split(".");
+
+    //Only proceed with checking version if the key seems valid
+    if(versionList.size()==3){
+        const int minor = versionList[1].toInt();
+        const int revision = versionList[2].toInt();
+
+        //return if we're above x.53.0
+        if(minor>53 || (minor==53 && revision>0))
+            return;
+    }
+
     const QStringList keys = s.allKeys();
 
-    //If this string is in the settings we either have the new ini settings
-    if(keys.contains("BackwardsCompatible"))
-            return;
-
  #ifdef QT_DEBUG
-    qDebug() << "Old settings detected. Replacing keys.";
+    qDebug() << "Old Nqq version detected. Replacing keys.";
 #endif
 
     auto replace = [&](const QString& newKey, const QString& oldKey) {

--- a/src/ui/ui.pro
+++ b/src/ui/ui.pro
@@ -85,7 +85,8 @@ SOURCES += main.cpp\
     globals.cpp \
     Extensions/Stubs/menuitemstub.cpp \
     Extensions/installextension.cpp \
-    keygrabber.cpp
+    keygrabber.cpp \
+    nqqsettings.cpp
 
 HEADERS  += include/mainwindow.h \
     include/topeditorcontainer.h \
@@ -126,7 +127,8 @@ HEADERS  += include/mainwindow.h \
     include/globals.h \
     include/Extensions/Stubs/menuitemstub.h \
     include/Extensions/installextension.h \
-    include/keygrabber.h
+    include/keygrabber.h \
+    include/nqqsettings.h
 
 FORMS    += mainwindow.ui \
     frmabout.ui \


### PR DESCRIPTION
I thought of NqqSettings as a replacement for QSettings where:

* only one instance exists, just like the Notepadqq class.
* settings are type-safe.
* the details of each setting (save string, default value, etc) are all centralized and easy to see/change.
* we don't have to care about providing default values with every settings->value() call.

How it currently works:

* New settings are added to the nqqsettings.h files as a macro: `NQQ_SETTING(SettingName, SettingType, DefaultValue)`. The compiler then auto-generates a few functions: `getSetting`, `setSetting` and `resetSetting`. 
* A few things such as language settings or shortcuts are a bit more complicated because there are so many individual keys that are saved. They need to be implemented by hand.

Currently I've replaced most QSetting calls in `mainwindow.cpp` and transitioned the whole shortcut stuff to NqqSettings as a proof of concept.

The direct impact on code:

* Creating a new Settings objects is now done with `NqqSettings& settings = NqqSettings::getInstance()` or similar.
* Fetching settings went from `settings->value("WordWrap", false).toBool()` to `settings->getWordWrap()`.
* Setting settings went from `settings->setValue("WordWrap, true)` to `settings->setWordWrap(true)`.

As I said, there are some ugly workarounds in the code simply so I could get it to compile and run properly. Once we have the details worked out these bits will look cleaner.