### PR TITLE
Allow smart indentation to be enabled or disabled by the user.

### DIFF
--- a/src/editor/app.js
+++ b/src/editor/app.js
@@ -417,6 +417,12 @@ UiDriver.registerEventHandler("C_CMD_SET_OVERWRITE", function(msg, data, prevRet
     editor.toggleOverwrite(data);
 });
 
+UiDriver.registerEventHandler("C_CMD_SET_SMART_INDENT", function(msg, data, prevReturn) {
+    editor.options.smartIndent = data;
+
+    return data;
+});
+
 UiDriver.registerEventHandler("C_CMD_SET_FOCUS", function(msg, data, prevReturn) {
     editor.focus();
 });

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -301,6 +301,11 @@ namespace EditorNS
         return m_customIndentationMode;
     }
 
+    void Editor::setSmartIndent(bool enabled)
+    {
+        sendMessage("C_CMD_SET_SMART_INDENT", enabled);
+    }
+
     void Editor::setValue(const QString &value)
     {
         sendMessage("C_CMD_SET_VALUE", value);

--- a/src/ui/include/EditorNS/editor.h
+++ b/src/ui/include/EditorNS/editor.h
@@ -204,6 +204,7 @@ namespace EditorNS
         void setCustomIndentationMode(const bool useTabs);
         void clearCustomIndentationMode();
         bool isUsingCustomIndentationMode() const;
+        Q_INVOKABLE void setSmartIndent(bool enabled);
 
         Q_INVOKABLE qreal zoomFactor() const;
         Q_INVOKABLE void setZoomFactor(const qreal &factor);

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -181,6 +181,8 @@ private slots:
     void on_actionShow_All_Characters_toggled(bool on);
     void on_actionShow_Spaces_triggered(bool on);
 
+    void on_actionToggle_Smart_Indent_toggled(bool arg1);
+
 private:
     static QList<MainWindow*> m_instances;
     Ui::MainWindow*       ui;

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2217,10 +2217,8 @@ void MainWindow::on_actionFull_Screen_toggled(bool on)
 
 void MainWindow::on_actionToggle_Smart_Indent_toggled(bool arg1)
 {
-    for (MainWindow *w : MainWindow::instances()) {
-        w->topEditorContainer()->forEachEditor([&](const int, const int, EditorTabWidget *, Editor *editor) {
-            editor->setSmartIndent(arg1);
-            return true;
-        });
-    }
+    m_topEditorContainer->forEachEditor([&](const int, const int, EditorTabWidget *, Editor *editor) {
+        editor->setSmartIndent(arg1);
+        return true;
+    });
 }

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1093,6 +1093,7 @@ void MainWindow::on_editorAdded(EditorTabWidget *tabWidget, int tab)
     editor->setOverwrite(m_overwrite);
     editor->setFont(m_settings.Appearance.getOverrideFontFamily(),
                     m_settings.Appearance.getOverrideFontSize());
+    editor->setSmartIndent(ui->actionToggle_Smart_Indent->isChecked());
 }
 
 void MainWindow::on_cursorActivity()

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2213,3 +2213,13 @@ void MainWindow::on_actionFull_Screen_toggled(bool on)
         }
     }
 }
+
+void MainWindow::on_actionToggle_Smart_Indent_toggled(bool arg1)
+{
+    for (MainWindow *w : MainWindow::instances()) {
+        w->topEditorContainer()->forEachEditor([&](const int, const int, EditorTabWidget *, Editor *editor) {
+            editor->setSmartIndent(arg1);
+            return true;
+        });
+    }
+}

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -42,7 +42,7 @@
      <x>0</x>
      <y>0</y>
      <width>723</width>
-     <height>25</height>
+     <height>23</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">
@@ -109,6 +109,8 @@
      </property>
      <addaction name="actionIndentation_Default_settings"/>
      <addaction name="actionIndentation_Custom"/>
+     <addaction name="separator"/>
+     <addaction name="actionToggle_Smart_Indent"/>
     </widget>
     <widget class="QMenu" name="menuLine_Operations">
      <property name="title">
@@ -1066,6 +1068,17 @@
    </property>
    <property name="toolTip">
     <string>Show Spaces</string>
+   </property>
+  </action>
+  <action name="actionToggle_Smart_Indent">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Enable Smart Indent</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Requested in #253, #170.

Adds a new menu option `Edit->Indentation->Enable Smart Identation`. It is enabled by default. 

If disabled, codemirror will fall back to the "prev"-style of indentation and disregard any smart indent coming from the language modes.

Right now the setting won't be saved, but will be set to true every time Nqq is opened. I think this is a sensible default.

This is a per-window setting right now. I'm not sure if this is the best choice but we're a bit inconsistent with this anyways. But that's a story of another Issue.