### PR TITLE
Replaced the shortcuts table with a tree.

### DIFF
--- a/src/ui/frmpreferences.cpp
+++ b/src/ui/frmpreferences.cpp
@@ -94,8 +94,7 @@ void frmPreferences::on_buttonBox_accepted()
 {
     if(m_keyGrabber->hasConflicts()){
         //Try our best to show the error to the user immediately.
-        ui->stackedWidget->setCurrentWidget( ui->pageShortcuts );
-        ui->treeWidget->setCurrentItem( ui->treeWidget->topLevelItem( ui->stackedWidget->currentIndex() ) );
+        ui->treeWidget->setCurrentItem(ui->treeWidget->topLevelItem(ui->stackedWidget->indexOf(ui->pageShortcuts)));
         m_keyGrabber->scrollToConflict();
 
         QMessageBox msgBox;

--- a/src/ui/frmpreferences.cpp
+++ b/src/ui/frmpreferences.cpp
@@ -93,16 +93,16 @@ void frmPreferences::on_treeWidget_currentItemChanged(QTreeWidgetItem *current, 
 void frmPreferences::on_buttonBox_accepted()
 {
     if(m_keyGrabber->hasConflicts()){
+        //Try our best to show the error to the user immediately.
+        ui->treeWidget->setCurrentItem( ui->treeWidget->topLevelItem(4) );
+        m_keyGrabber->scrollToConflict();
+
         QMessageBox msgBox;
         msgBox.setWindowTitle(QCoreApplication::applicationName());
         msgBox.setIcon(QMessageBox::Warning);
         msgBox.setText("<h3>" + tr("Keyboard shortcut conflict") + "</h3>");
         msgBox.setInformativeText(tr("Two or more actions share the same shortcut. These conflicts must be resolved before your changes can be saved."));
         msgBox.exec();
-
-        ui->treeWidget->setCurrentItem( ui->treeWidget->topLevelItem(4) );
-        m_keyGrabber->scrollToConflict();
-
         return;
     }
 

--- a/src/ui/frmpreferences.cpp
+++ b/src/ui/frmpreferences.cpp
@@ -94,7 +94,8 @@ void frmPreferences::on_buttonBox_accepted()
 {
     if(m_keyGrabber->hasConflicts()){
         //Try our best to show the error to the user immediately.
-        ui->treeWidget->setCurrentItem( ui->treeWidget->topLevelItem(4) );
+        ui->stackedWidget->setCurrentWidget( ui->pageShortcuts );
+        ui->treeWidget->setCurrentItem( ui->treeWidget->topLevelItem( ui->stackedWidget->currentIndex() ) );
         m_keyGrabber->scrollToConflict();
 
         QMessageBox msgBox;

--- a/src/ui/frmpreferences.cpp
+++ b/src/ui/frmpreferences.cpp
@@ -70,7 +70,7 @@ void frmPreferences::resetShortcuts()
         item.setText(seq.toString());
     }
 
-    m_keyGrabber->findConflicts();
+    m_keyGrabber->checkForConflicts();
 }
 
 void frmPreferences::updatePreviewEditorFont()
@@ -92,12 +92,17 @@ void frmPreferences::on_treeWidget_currentItemChanged(QTreeWidgetItem *current, 
 
 void frmPreferences::on_buttonBox_accepted()
 {
-    if(m_keyGrabber->findConflicts()){
+    if(m_keyGrabber->hasConflicts()){
         QMessageBox msgBox;
         msgBox.setWindowTitle(QCoreApplication::applicationName());
         msgBox.setIcon(QMessageBox::Warning);
+        msgBox.setText("<h3>" + tr("Keyboard shortcut conflict") + "</h3>");
         msgBox.setInformativeText(tr("Two or more actions share the same shortcut. These conflicts must be resolved before your changes can be saved."));
         msgBox.exec();
+
+        ui->treeWidget->setCurrentItem( ui->treeWidget->topLevelItem(4) );
+        m_keyGrabber->scrollToConflict();
+
         return;
     }
 
@@ -278,7 +283,7 @@ void frmPreferences::loadShortcuts()
     //addMenus() intentionally skips the Language menu since it would just clutter up everything.
     m_keyGrabber->addMenus(menus);
     m_keyGrabber->expandAll();
-    m_keyGrabber->findConflicts();
+    m_keyGrabber->checkForConflicts();
 
     // Build the interface
     QWidget *container = ui->pageShortcuts;

--- a/src/ui/frmpreferences.cpp
+++ b/src/ui/frmpreferences.cpp
@@ -92,6 +92,15 @@ void frmPreferences::on_treeWidget_currentItemChanged(QTreeWidgetItem *current, 
 
 void frmPreferences::on_buttonBox_accepted()
 {
+    if(m_keyGrabber->findConflicts()){
+        QMessageBox msgBox;
+        msgBox.setWindowTitle(QCoreApplication::applicationName());
+        msgBox.setIcon(QMessageBox::Warning);
+        msgBox.setInformativeText(tr("Two or more actions share the same shortcut. These conflicts must be resolved before your changes can be saved."));
+        msgBox.exec();
+        return;
+    }
+
 
     m_settings.General.setCheckVersionAtStartup(ui->chkCheckQtVersionAtStartup->isChecked());
     m_settings.General.setWarnForDifferentIndentation(ui->chkWarnForDifferentIndentation->isChecked());

--- a/src/ui/frmpreferences.cpp
+++ b/src/ui/frmpreferences.cpp
@@ -62,15 +62,15 @@ frmPreferences::~frmPreferences()
 
 void frmPreferences::resetShortcuts()
 {
-    const int rows = m_keyGrabber->rowCount();
+    auto& bindings = m_keyGrabber->getAllBindings();
 
-    for (int i = 0; i < rows; i++) {
-        const QString& actionName = m_keyGrabber->item(i, 0)->data(Qt::UserRole).toString();
-        const QKeySequence seq = m_settings.Shortcuts.getDefaultShortcut(actionName);
-        m_keyGrabber->item(i, 1)->setText(seq.toString());
+    for (auto& item : bindings) {
+        const QString& objName = item.getAction()->objectName();
+        const QKeySequence seq = m_settings.Shortcuts.getDefaultShortcut(objName);
+        item.setText(seq.toString());
     }
 
-    m_keyGrabber->checkConflicts();
+    m_keyGrabber->findConflicts();
 }
 
 void frmPreferences::updatePreviewEditorFont()
@@ -262,17 +262,14 @@ void frmPreferences::loadShortcuts()
 {
     MainWindow* mw = qobject_cast<MainWindow*>(parent());
 
-    auto&& allActions = mw->getActions();
-
-    // getActions() also returns actions like separators or menu entries that don't have any
-    // shortcuts. We can remove them based on their objectName and iconText.
-    for (auto&& action : allActions) {
-        if (!action->objectName().isEmpty() && !action->iconText().isEmpty())
-            m_actions[action->objectName()] = action;
-    }
-
     m_keyGrabber = new KeyGrabber();
 
+    const auto& menus = mw->getMenus();
+
+    //addMenus() intentionally skips the Language menu since it would just clutter up everything.
+    m_keyGrabber->addMenus(menus);
+    m_keyGrabber->expandAll();
+    m_keyGrabber->findConflicts();
 
     // Build the interface
     QWidget *container = ui->pageShortcuts;
@@ -283,31 +280,18 @@ void frmPreferences::loadShortcuts()
     layout->addWidget(m_keyGrabber);
     layout->addWidget(resetDefaults);
     container->setLayout(layout);
-
-    // Add all shortcuts to the table
-    for (auto&& action : m_actions) {
-        m_keyGrabber->insertRow(0);
-        m_keyGrabber->setItem(0, 0, new QTableWidgetItem(action->iconText()));
-        m_keyGrabber->setItem(0, 1, new QTableWidgetItem(action->shortcut().toString()));
-        m_keyGrabber->item(0, 0)->setData(Qt::UserRole, action->objectName());
-    }
-
-    m_keyGrabber->sortItems(0);
-    m_keyGrabber->checkConflicts();
 }
 
 void frmPreferences::saveShortcuts()
 {
-    const int rows = m_keyGrabber->rowCount();
+    auto& bindings = m_keyGrabber->getAllBindings();
 
-    for (int i = 0; i < rows; i++) {
-        const QString& actionName = m_keyGrabber->item(i, 0)->data(Qt::UserRole).toString();
-        QAction *action = m_actions[actionName];
-        QKeySequence seq = m_keyGrabber->item(i, 1)->text();
+    for (auto& item : bindings) {
+        const QString& objName = item.getAction()->objectName();
+        QKeySequence seq = item.text();
 
-        // Save new shortcut in settings as well as apply it to the QAction* object.
-        m_settings.Shortcuts.setShortcut(action->objectName(), seq);
-        action->setShortcut(seq);
+        m_settings.Shortcuts.setShortcut(objName, seq);
+        item.getAction()->setShortcut(seq);
     }
 }
 

--- a/src/ui/include/frmpreferences.h
+++ b/src/ui/include/frmpreferences.h
@@ -51,7 +51,6 @@ private:
     QList<LanguageSettings> m_tempLangSettings;
 
     KeyGrabber *m_keyGrabber;
-    QMap<QString, QAction*> m_actions;
 
     NqqSettings& m_settings;
     Ui::frmPreferences *ui;

--- a/src/ui/include/keygrabber.h
+++ b/src/ui/include/keygrabber.h
@@ -11,9 +11,19 @@ public:
 
     /**
      * @brief findConflicts Checks the entire tree for conflicting shortcuts.
-     * @return true if conflicts were found, false otherwise.
      */
-    bool findConflicts();
+    void checkForConflicts();
+
+    /**
+     * @brief hasConflicts
+     * @return true if there is at least one conflict in the keyboard mapping.
+     */
+    bool hasConflicts() const;
+
+    /**
+     * @brief scrollToConflict Moves the view to the first conflicting action.
+     */
+    void scrollToConflict();
 
     /**
      * @brief addMenus Traverses the list of menus and adds the contained actions to
@@ -64,6 +74,7 @@ private:
 
     QList<NodeItem> m_allActions;
     bool m_testingForConflicts = false;
+    QTreeWidgetItem* m_firstConflict = nullptr;
 };
 
 #endif

--- a/src/ui/include/keygrabber.h
+++ b/src/ui/include/keygrabber.h
@@ -1,22 +1,69 @@
 #ifndef __KEYGRABBER_H__
 #define __KEYGRABBER_H__
-#include <QTableWidget>
+
+#include <QTreeWidget>
 #include <QKeyEvent>
-class KeyGrabber : public QTableWidget {
+
+class KeyGrabber : public QTreeWidget {
 Q_OBJECT
 public:
     KeyGrabber(QWidget* parent = 0);
-    void checkConflicts();
+
+    /**
+     * @brief findConflicts Checks the entire tree for conflicting shortcuts.
+     * @return true if conflicts were found, false otherwise.
+     */
+    bool findConflicts();
+
+    /**
+     * @brief addMenus Traverses the list of menus and adds the contained actions to
+     *        the tree.
+     * @param listOfMenus
+     */
+    void addMenus(const QList<const QMenu*>& listOfMenus);
+
+    /**
+     * @brief Convenience class that contains the tree item and corresponding
+     *        action, as well as a few functions to modify it from outside.
+     *        This way, users of KeyGrabber do not have to interact with the
+     *        QTreeWidget objects themselves.
+     */
+    struct NodeItem {
+    private:
+        friend class KeyGrabber;
+        QTreeWidgetItem* treeItem;
+        QAction* action;
+
+    public:
+        QAction* getAction() { return action; }
+
+        void setText(QString seq) { treeItem->setText(1,seq); }
+        QString text() const { return treeItem->text(1); }
+
+        NodeItem(QAction* a, QTreeWidgetItem* item) : treeItem(item), action(a) {}
+    };
+
+    /**
+     * @brief getAllBindings Returns a list of NodeItems, one for each action/keysquence
+     *        pair.
+     */
+    QList<NodeItem>& getAllBindings();
 
 protected:
     void keyPressEvent(QKeyEvent* key);
-    void paintEvent(QPaintEvent* event);
 
 public slots:
-    void itemChanged(QTableWidgetItem* item);
+    void itemChanged(QTreeWidgetItem* item);
 
 private:
-    QSet<int> m_conflicts;
+    /**
+     * @brief populateNode traverses the given QMenu recursively and adds its children to
+     *        the rootItem as new nodes.
+     */
+    void populateNode(QTreeWidgetItem*& rootItem, const QMenu*);
+
+    QList<NodeItem> m_allActions;
+    bool m_testingForConflicts = false;
 };
 
 #endif

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -63,7 +63,9 @@ public:
     QSharedPointer<Editor> currentEditorSharedPtr();
     QAction*  addExtensionMenuItem(QString extensionId, QString text);
     void showExtensionsMenu(bool show);
-    QList<QAction*> getActions();
+
+    QList<QAction*> getActions() const;
+    QList<const QMenu*> getMenus() const ;
 
 protected:
     void closeEvent(QCloseEvent *event);

--- a/src/ui/keygrabber.cpp
+++ b/src/ui/keygrabber.cpp
@@ -10,9 +10,22 @@ KeyGrabber::KeyGrabber(QWidget* parent) : QTreeWidget(parent)
     setColumnCount(2);
     setColumnWidth(0, 400);
     setAlternatingRowColors(true);
-    setHeaderLabels(QStringList() << "Action" << "Keyboard Shortcut");
+    setHeaderLabels(QStringList() << tr("Action") << tr("Keyboard Shortcut"));
 
     connect(this, &QTreeWidget::itemChanged, this, &KeyGrabber::itemChanged);
+}
+
+bool KeyGrabber::hasConflicts() const
+{
+    return m_firstConflict != nullptr;
+}
+
+void KeyGrabber::scrollToConflict()
+{
+    if(!m_firstConflict)
+        return;
+
+    scrollTo(indexFromItem(m_firstConflict));
 }
 
 void KeyGrabber::itemChanged(QTreeWidgetItem*)
@@ -23,10 +36,10 @@ void KeyGrabber::itemChanged(QTreeWidgetItem*)
         return;
     }
 
-    findConflicts();
+    checkForConflicts();
 }
 
-bool KeyGrabber::findConflicts()
+void KeyGrabber::checkForConflicts()
 {
     m_testingForConflicts = true;
 
@@ -40,7 +53,7 @@ bool KeyGrabber::findConflicts()
     for(const auto& n : allNodes)
         n.treeItem->setBackground(1, QBrush());
 
-    bool foundConflict = false;
+    m_firstConflict = nullptr;
 
     for (int i=0; i<allNodes.count()-1; ++i) {
         QTreeWidgetItem* current = allNodes[i].treeItem;
@@ -52,13 +65,13 @@ bool KeyGrabber::findConflicts()
         if(current->text(1) == next->text(1)){
             current->setBackground(1, QBrush(QColor(255,100,100,64)));
             next->setBackground(1, QBrush(QColor(255,100,100,64)));
-            foundConflict = true;
+
+            if(!m_firstConflict)
+                m_firstConflict = current;
         }
     }
 
     m_testingForConflicts = false;
-
-    return foundConflict;
 }
 
 void KeyGrabber::addMenus(const QList<const QMenu*>& listOfMenus)

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -358,8 +358,12 @@ void MainWindow::createStatusBar()
     scrollArea->setFixedHeight(frame->height());
 }
 
+QList<const QMenu*> MainWindow::getMenus() const {
+    return ui->menuBar->findChildren<const QMenu*>(QString(), Qt::FindDirectChildrenOnly);
+}
+
 //Return a list of all available action items in the menu
-QList<QAction*> MainWindow::getActions()
+QList<QAction*> MainWindow::getActions() const
 {
     const QList<const QMenu*> list = ui->menuBar->findChildren<const QMenu*>();
     QList<QAction*> allActions;


### PR DESCRIPTION
![image](http://pix.toile-libre.org/upload/original/1473076743.png)

Since the number of menu actions grows slowly but steadily, reorganizing them into a tree is probably an easier way for users to find the actions they want to change. Other than that, functionality has not changed.

On that note - should the user get a MsgBox telling them to resolve key conflicts when they attempt to press Accept with conflicts present?