### PR TITLE
Code cleanup and small fixes for Search

### DIFF
--- a/src/ui/Search/dlgsearching.cpp
+++ b/src/ui/Search/dlgsearching.cpp
@@ -42,5 +42,5 @@ QString dlgSearching::text() const
 
 void dlgSearching::on_btnCancel_clicked()
 {
-    reject();
+    accept();
 }

--- a/src/ui/Search/filesearchresultswidget.cpp
+++ b/src/ui/Search/filesearchresultswidget.cpp
@@ -83,11 +83,15 @@ void FileSearchResultsWidget::addSearchResult(const FileSearchResult::SearchResu
 void FileSearchResultsWidget::on_doubleClicked(const QModelIndex &index)
 {
     int type = SearchResultsItemDelegate::rowItemType(index);
-
+    QPoint start = SearchResultsItemDelegate::resultRowStartData(index);
+    QPoint end   = SearchResultsItemDelegate::resultRowEndData(index);
     if (type == SearchResultsItemDelegate::ResultTypeMatch) {
         emit resultMatchClicked(
                     SearchResultsItemDelegate::fileResultRowData(index.parent()),
-                    SearchResultsItemDelegate::resultRowData(index));
+                    start.x(),
+                    start.y(),
+                    end.x(),
+                    end.y());
     }
 }
 

--- a/src/ui/Search/filesearchresultswidget.cpp
+++ b/src/ui/Search/filesearchresultswidget.cpp
@@ -35,8 +35,7 @@ void FileSearchResultsWidget::setupActions()
 void FileSearchResultsWidget::addSearchResult(const FileSearchResult::SearchResult &searchResult)
 {
     // Row, in the model, relative to this search
-    QList<QStandardItem *> searchRow;
-    searchRow << new QStandardItem();
+    QStandardItem *searchRow = new QStandardItem();
 
     // Total number of matches in all the files
     int totalFileMatches = 0;
@@ -48,28 +47,26 @@ void FileSearchResultsWidget::addSearchResult(const FileSearchResult::SearchResu
         totalFiles++;
 
         // Row, in the model, relative to this file
-        QList<QStandardItem *> fileRow;
-        fileRow << new QStandardItem();
+        QStandardItem *fileRow = new QStandardItem();
 
         int curFileMatches = 0;
 
         for (FileSearchResult::Result result : fileResult.results)
         {
-            QList<QStandardItem *> lineRow;
-            lineRow << new QStandardItem();
-            SearchResultsItemDelegate::fillResultRowItem(lineRow[0], result);
-            fileRow[0]->appendRow(lineRow);
+            QStandardItem *lineRow = new QStandardItem();
+            SearchResultsItemDelegate::fillResultRowItem(lineRow, result);
+            fileRow->appendRow(lineRow);
 
             curFileMatches++;
             totalFileMatches++;
         }
 
-        SearchResultsItemDelegate::fillFileResultRowItem(fileRow[0], fileResult, curFileMatches);
-        searchRow[0]->appendRow(fileRow);
+        SearchResultsItemDelegate::fillFileResultRowItem(fileRow, fileResult, curFileMatches);
+        searchRow->appendRow(fileRow);
     }
 
 
-    SearchResultsItemDelegate::fillSearchResultRowItem(searchRow[0], searchResult, totalFileMatches, totalFiles);
+    SearchResultsItemDelegate::fillSearchResultRowItem(searchRow, searchResult, totalFileMatches, totalFiles);
 
     QStandardItem *root = m_filesFindResultsModel->invisibleRootItem();
     root->insertRow(0, searchRow);

--- a/src/ui/Search/frmsearchreplace.cpp
+++ b/src/ui/Search/frmsearchreplace.cpp
@@ -263,7 +263,6 @@ void frmSearchReplace::handleReplaceInFiles(const FileSearchResult::SearchResult
     connect(m_session->threadReplace, SIGNAL(finished()), m_session->threadReplace, SLOT(deleteLater()));
     connect(m_session->threadReplace, &ReplaceInFilesWorker::error, this, &frmSearchReplace::handleError);
     connect(m_session->threadReplace, &ReplaceInFilesWorker::errorReadingFile, this, &frmSearchReplace::displayThreadErrorMessageBox, Qt::BlockingQueuedConnection);
-    connect(m_session->threadReplace, &ReplaceInFilesWorker::errorWritingFile, this, &frmSearchReplace::displayThreadErrorMessageBox, Qt::BlockingQueuedConnection);
     connect(m_session->threadReplace, &ReplaceInFilesWorker::progress, this, &frmSearchReplace::handleProgress);
     connect(m_session->threadReplace, &ReplaceInFilesWorker::resultReady, this, &frmSearchReplace::handleReplaceResult);
     connect(this, &frmSearchReplace::stopReplaceInFiles, m_session->threadReplace, &ReplaceInFilesWorker::stop, Qt::DirectConnection);

--- a/src/ui/Search/searchinfilesworker.cpp
+++ b/src/ui/Search/searchinfilesworker.cpp
@@ -16,7 +16,6 @@ SearchInFilesWorker::SearchInFilesWorker(QObject* parent, const QString &string,
 
 SearchInFilesWorker::~SearchInFilesWorker()
 {
-    qDebug() << "Finished";
 }
 
 void SearchInFilesWorker::run()

--- a/src/ui/Search/searchinfilesworker.cpp
+++ b/src/ui/Search/searchinfilesworker.cpp
@@ -174,15 +174,6 @@ bool SearchInFilesWorker::matchesWholeWord(const int &index, const int &matchLen
     return true;
 }
 
-FileSearchResult::SearchResult SearchInFilesWorker::getResult()
-{
-    QMutexLocker locker(&m_mutex);
-    FileSearchResult::SearchResult r;
-    r = m_result;
-
-    return r;
-}
-
 QVector<int> SearchInFilesWorker::getLinePositions(const QString &data)
 {
     const int dataSize = data.size();

--- a/src/ui/Search/searchresultsitemdelegate.cpp
+++ b/src/ui/Search/searchresultsitemdelegate.cpp
@@ -25,9 +25,12 @@ QString SearchResultsItemDelegate::getFileResultFormattedLine(const FileSearchRe
 
 void SearchResultsItemDelegate::fillResultRowItem(QStandardItem *item, const FileSearchResult::Result &result)
 {
+    QPoint start(result.matchStartLine, result.matchStartCol);
+    QPoint end(result.matchEndLine, result.matchEndCol);
     item->setText(getFileResultFormattedLine(result));
     item->setData(SearchResultsItemDelegate::ResultTypeMatch, SearchResultsItemDelegate::RESULT_TYPE_ROLE);
-    item->setData(result, SearchResultsItemDelegate::RESULT_DATA_ROLE);
+    item->setData(start, SearchResultsItemDelegate::RESULT_DATA_ROLE);
+    item->setData(end, SearchResultsItemDelegate::RESULT_DATA_EX_ROLE);
 }
 
 void SearchResultsItemDelegate::fillFileResultRowItem(QStandardItem *item, const FileSearchResult::FileResult &fileResult, const int matches)
@@ -36,7 +39,7 @@ void SearchResultsItemDelegate::fillFileResultRowItem(QStandardItem *item, const
                         .arg(fileResult.fileName.toHtmlEscaped())
                         .arg(matches));
     item->setData(SearchResultsItemDelegate::ResultTypeFile, SearchResultsItemDelegate::RESULT_TYPE_ROLE);
-    item->setData(fileResult, SearchResultsItemDelegate::RESULT_DATA_ROLE);
+    item->setData(fileResult.fileName, SearchResultsItemDelegate::RESULT_DATA_ROLE);
 }
 
 void SearchResultsItemDelegate::fillSearchResultRowItem(QStandardItem *item, const FileSearchResult::SearchResult &searchResult, const int totalFileMatches, const int totalFiles)
@@ -56,16 +59,22 @@ SearchResultsItemDelegate::ResultType SearchResultsItemDelegate::rowItemType(con
     return static_cast<ResultType>(type);
 }
 
-FileSearchResult::Result SearchResultsItemDelegate::resultRowData(const QModelIndex &index)
+QPoint SearchResultsItemDelegate::resultRowStartData(const QModelIndex &index)
 {
     QVariant data = index.data(SearchResultsItemDelegate::RESULT_DATA_ROLE);
-    return data.value<FileSearchResult::Result>();
+    return data.value<QPoint>();
 }
 
-FileSearchResult::FileResult SearchResultsItemDelegate::fileResultRowData(const QModelIndex &index)
+QPoint SearchResultsItemDelegate::resultRowEndData(const QModelIndex &index)
+{
+    QVariant data = index.data(SearchResultsItemDelegate::RESULT_DATA_EX_ROLE);
+    return data.value<QPoint>();
+}
+
+QString SearchResultsItemDelegate::fileResultRowData(const QModelIndex &index)
 {
     QVariant data = index.data(SearchResultsItemDelegate::RESULT_DATA_ROLE);
-    return data.value<FileSearchResult::FileResult>();
+    return data.value<QString>();
 }
 
 void SearchResultsItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem & option, const QModelIndex &index) const

--- a/src/ui/Search/searchstring.cpp
+++ b/src/ui/Search/searchstring.cpp
@@ -4,7 +4,6 @@
 QString SearchString::toRaw(const QString &data, const SearchHelpers::SearchMode &searchMode, const SearchHelpers::SearchOptions &searchOptions)
 {
     QString rawSearch = data;
-
     if (searchMode == SearchHelpers::SearchMode::SpecialChars) {
         rawSearch = toRegex(data, searchOptions.MatchWholeWord);
         rawSearch = rawSearch.replace("\\\\", "\\");
@@ -17,12 +16,10 @@ QString SearchString::toRaw(const QString &data, const SearchHelpers::SearchMode
 
 QString SearchString::toRegex(const QString &data, bool matchWholeWord)
 {
-    // Transform it into a regex, but make sure to escape special chars
     QString regex = QRegularExpression::escape(data);
-
-    if (matchWholeWord)
+    if (matchWholeWord) {
         regex = "\\b" + regex + "\\b";
-
+    }
     return regex;
 }
 

--- a/src/ui/Search/searchstring.cpp
+++ b/src/ui/Search/searchstring.cpp
@@ -10,7 +10,6 @@ QString SearchString::toRaw(const QString &data, const SearchHelpers::SearchMode
     } else if (searchMode == SearchHelpers::SearchMode::PlainText){
         rawSearch = toRegex(data, searchOptions.MatchWholeWord);
     }
-
     return rawSearch;
 }
 
@@ -25,7 +24,7 @@ QString SearchString::toRegex(const QString &data, bool matchWholeWord)
 
 QString SearchString::unescape(const QString &data)
 { 
-    int dataLength = data.size();
+    const int dataLength = data.size();
     QString unescaped;
     QChar c;
     for (int i = 0; i < dataLength; i++) {

--- a/src/ui/Search/searchstring.cpp
+++ b/src/ui/Search/searchstring.cpp
@@ -1,0 +1,59 @@
+#include "include/Search/searchstring.h"
+#include <QRegularExpression>
+
+QString SearchString::toRaw(const QString &data, const SearchHelpers::SearchMode &searchMode, const SearchHelpers::SearchOptions &searchOptions)
+{
+    QString rawSearch = data;
+
+    if (searchMode == SearchHelpers::SearchMode::SpecialChars) {
+        rawSearch = toRegex(data, searchOptions.MatchWholeWord);
+        rawSearch = rawSearch.replace("\\\\", "\\");
+    } else if (searchMode == SearchHelpers::SearchMode::PlainText){
+        rawSearch = toRegex(data, searchOptions.MatchWholeWord);
+    }
+
+    return rawSearch;
+}
+
+QString SearchString::toRegex(const QString &data, bool matchWholeWord)
+{
+    // Transform it into a regex, but make sure to escape special chars
+    QString regex = QRegularExpression::escape(data);
+
+    if (matchWholeWord)
+        regex = "\\b" + regex + "\\b";
+
+    return regex;
+}
+
+QString SearchString::unescape(const QString &data)
+{ 
+    int dataLength = data.size();
+    QString unescaped;
+    QChar c;
+    for (int i = 0; i < dataLength; i++) {
+        c = data[i];
+        if (c == '\\' && i != dataLength) {
+            i++;
+            if (data[i] == 'a') c = '\a';
+            else if (data[i] == 'b') c = '\b';
+            else if (data[i] == 'f') c = '\f';
+            else if (data[i] == 'n') c = '\n';
+            else if (data[i] == 'r') c = '\r';
+            else if (data[i] == 't') c = '\t';
+            else if (data[i] == 'v') c = '\v';
+            else if (data[i] == 'x' && i+2 <= dataLength) {
+                int nHex = data.mid(++i, 2).toInt(0, 16);
+                c = QChar(nHex);
+                i += 1;
+            } else if (data[i] == 'u' && i+4 <= dataLength) {
+                int nHex = data.mid(++i,4).toInt(0, 16);
+                c = QChar(nHex);
+                i += 3;
+            }
+        }
+        unescaped.append(c);
+    }
+    return unescaped;
+}
+

--- a/src/ui/include/Search/filesearchresultswidget.h
+++ b/src/ui/include/Search/filesearchresultswidget.h
@@ -14,6 +14,11 @@ class FileSearchResultsWidget : public QTreeView
 public:
     FileSearchResultsWidget(QWidget *parent = 0);
     ~FileSearchResultsWidget();
+   
+   /*
+    * @brief Add search results to the results widget.
+    * @param `searchResult`:  The search results to be added.
+    */
     void addSearchResult(const FileSearchResult::SearchResult &searchResult);
 
 private slots:
@@ -23,9 +28,18 @@ private:
     QStandardItemModel*   m_filesFindResultsModel;
     SearchResultsItemDelegate* m_treeViewHTMLDelegate;
     QAction* m_actionClear;
+
+   /*
+    * @brief Set up UI actions.
+    */
     void setupActions();
 
 signals:
+   /*
+    * @brief Handle match result being clicked.
+    * @param `file`:  The file result struct to use.
+    * @param `match`: The match result struct to use.
+    */
     void resultMatchClicked(const FileSearchResult::FileResult &file, const FileSearchResult::Result &match);
 
 protected:

--- a/src/ui/include/Search/filesearchresultswidget.h
+++ b/src/ui/include/Search/filesearchresultswidget.h
@@ -15,7 +15,7 @@ public:
     FileSearchResultsWidget(QWidget *parent = 0);
     ~FileSearchResultsWidget();
    
-   /*
+   /**
     * @brief Add search results to the results widget.
     * @param `searchResult`:  The search results to be added.
     */
@@ -29,13 +29,13 @@ private:
     SearchResultsItemDelegate* m_treeViewHTMLDelegate;
     QAction* m_actionClear;
 
-   /*
+   /**
     * @brief Set up UI actions.
     */
     void setupActions();
 
 signals:
-   /*
+   /**
     * @brief Handle match result being clicked.
     * @param `file`:  The file result struct to use.
     * @param `match`: The match result struct to use.

--- a/src/ui/include/Search/filesearchresultswidget.h
+++ b/src/ui/include/Search/filesearchresultswidget.h
@@ -40,7 +40,7 @@ signals:
     * @param `file`:  The file result struct to use.
     * @param `match`: The match result struct to use.
     */
-    void resultMatchClicked(const FileSearchResult::FileResult &file, const FileSearchResult::Result &match);
+    void resultMatchClicked(const QString &fileName, int startLine, int startCol, int endLine, int endCol);
 
 protected:
     void contextMenuEvent(QContextMenuEvent *e);

--- a/src/ui/include/Search/frmsearchreplace.h
+++ b/src/ui/include/Search/frmsearchreplace.h
@@ -40,9 +40,11 @@ protected:
 
 public slots:
     void displayThreadErrorMessageBox(const QString &message, int &operation);
+    void handleReplaceResult(int replaceCount, int fileCount, bool stopped);
     void handleSearchResult(const FileSearchResult::SearchResult &result);
     void handleError(const QString &e);
     void handleProgress(const QString &file, bool replace = false);
+    void handleReplaceInFiles(const FileSearchResult::SearchResult &result);
 
 private slots:
     void on_btnFindNext_clicked();
@@ -71,22 +73,23 @@ private:
     class SearchInFilesSession : public QObject {
     public:
         SearchInFilesSession(QObject *parent) : QObject(parent) { }
-
         SearchInFilesWorker*   threadSearch = nullptr;
         ReplaceInFilesWorker*  threadReplace = nullptr;
         dlgSearching*          msgBox = nullptr;
+        bool                   replaceMode = false;
     };
 
     SearchInFilesSession* m_session = nullptr;
     QList<SearchInFilesSession*> m_findInFilesPtrs;
 
     Editor*                currentEditor();
-    void handleSearchCleanup();
+    void sessionCleanup();
+    bool confirmReplaceInFiles(const QString &path, const QStringList &filters);
     void search(QString string, SearchHelpers::SearchMode searchMode, bool forward, SearchHelpers::SearchOptions searchOptions);
     void replace(QString string, QString replacement, SearchHelpers::SearchMode searchMode, bool forward, SearchHelpers::SearchOptions searchOptions);
     int replaceAll(QString string, QString replacement, SearchHelpers::SearchMode searchMode, SearchHelpers::SearchOptions searchOptions);
     int selectAll(QString string, SearchHelpers::SearchMode searchMode, SearchHelpers::SearchOptions searchOptions);
-    void searchInFiles(const QString &string, const QString &path, const QStringList &filters, const SearchHelpers::SearchMode &searchMode, const SearchHelpers::SearchOptions &searchOptions);
+    void searchReplaceInFiles(const QString &string, const QString &path, const QStringList &filters, const SearchHelpers::SearchMode &searchMode, const SearchHelpers::SearchOptions &searchOptions, bool replaceMode = false);
     void replaceInFiles(const QString &string, const QString &replacement, const QString &path, const QStringList &filters, const SearchHelpers::SearchMode &searchMode, const SearchHelpers::SearchOptions &searchOptions);
     void setCurrentTab(Tabs tab);
     void manualSizeAdjust();

--- a/src/ui/include/Search/frmsearchreplace.h
+++ b/src/ui/include/Search/frmsearchreplace.h
@@ -76,7 +76,6 @@ private:
         SearchInFilesWorker*   threadSearch = nullptr;
         ReplaceInFilesWorker*  threadReplace = nullptr;
         dlgSearching*          msgBox = nullptr;
-        bool                   replaceMode = false;
     };
 
     SearchInFilesSession* m_session = nullptr;

--- a/src/ui/include/Search/frmsearchreplace.h
+++ b/src/ui/include/Search/frmsearchreplace.h
@@ -25,25 +25,70 @@ public:
     enum Tabs { TabSearch, TabReplace, TabSearchInFiles };
     explicit frmSearchReplace(TopEditorContainer *topEditorContainer, QWidget *parent = 0);
     ~frmSearchReplace();
+
+   /*
+    * @brief Sets the currently displayed tab.
+    * @param `defaultTab`: The tab to change our display to.
+    */
     void show(Tabs defaultTab);
+   /*
+    * @brief Sets the search input text to value specified in `string`.
+    * @param `string`: Value to change the search input text to.
+    */
     void setSearchText(QString string);
 
-    /**
-     * @brief Runs a "find next" or "find prev", taking the options from the UI
-     * @param forward
-     */
+   /**
+    * @brief Runs a "find next" or "find prev", taking the options from the UI.
+    * @param `forward`: Direction in which to iterate.
+    */
     void findFromUI(bool forward, bool searchFromStart = false);
+   /**
+    * @brief Runs a "replace next" or "replace prev", taking the options from the UI.
+    * @param `forward`: Direction in which to iterate.
+    */
     void replaceFromUI(bool forward, bool searchFromStart = false);
-    void cleanFindInFilesPtrs();
 protected:
     void keyPressEvent(QKeyEvent *evt);
 
+signals:
+    void fileSearchResultFinished(FileSearchResult::SearchResult result);
+    void stopSearchInFiles();
+    void stopReplaceInFiles();
+
 public slots:
+   /**
+    * @brief Handle file error request from thread.
+    * @param `message`:   The message received from the working thread.
+    * @param `operation`: The referenced value from the thread awaiting reply.
+    */
     void displayThreadErrorMessageBox(const QString &message, int &operation);
+   /**
+    * @brief Display results from ReplaceInFilesWorker thread.
+    * @param `replaceCount`:  Number of occurrences replaced.
+    * @param `fileCount`:     Number of files changed.   
+    * @param `stopped`:       Bool value which determines how we display results.
+    */
     void handleReplaceResult(int replaceCount, int fileCount, bool stopped);
+   /*
+    * @brief Display results from SearchInFilesWorker thread.
+    * @param `result`: FileSearchResult::SearchResult struct to generate the display from.
+    */
     void handleSearchResult(const FileSearchResult::SearchResult &result);
+   /*
+    * @brief Handle general error message from thread.
+    * @param `e`: The error message received.
+    */
     void handleError(const QString &e);
+   /*
+    * @brief Handle progress report from thread.
+    * @param `file`: Current file being worked on.
+    * @param `replace`: Bool value which determines how we display progress.
+    */
     void handleProgress(const QString &file, bool replace = false);
+   /*
+    * @brief Starts ReplaceInFilesWorker thread if we started the search in replaceMode.
+    * @param `result`: FileSearchResult::SearchResult struct to work on.
+    */
     void handleReplaceInFiles(const FileSearchResult::SearchResult &result);
 
 private slots:
@@ -81,21 +126,93 @@ private:
     SearchInFilesSession* m_session = nullptr;
     QList<SearchInFilesSession*> m_findInFilesPtrs;
 
+   /*
+    * @brief Get the current editor.
+    */
     Editor*                currentEditor();
+   /*
+    * @brief Clean up Search in file sessions.
+    */
     void sessionCleanup();
+   /*
+    * @brief Ask for confirmation for replacing in files.
+    * @param `path`:    The directory path being worked on.
+    * @param `filters`: The filters that will be applied.
+    * @return `bool`:   The result of the request.
+    */
     bool confirmReplaceInFiles(const QString &path, const QStringList &filters);
+   /*
+    * @brief Perform a search within the current document.
+    * @param `string`:        The string to search for.
+    * @param `searchMode`:    Search mode to use.
+    * @param `forward`:       Direction in which to search.
+    * @param `searchOptions`: Search options to use.
+    */
     void search(QString string, SearchHelpers::SearchMode searchMode, bool forward, SearchHelpers::SearchOptions searchOptions);
+   /*
+    * @brief Perform a replace within the current document.
+    * @param `string`:        The string to search for.
+    * @param `replacement`:   The string which will replace `string`.
+    * @param `searchMode`:    Search mode to use.
+    * @param `forward`:       Direction in which to search.
+    * @param `searchOptions`: Search options to use.
+    */
     void replace(QString string, QString replacement, SearchHelpers::SearchMode searchMode, bool forward, SearchHelpers::SearchOptions searchOptions);
+   /*
+    * @brief Perform a full document replace within the current document.
+    * @param `string`:        The string to search for.
+    * @param `replacement`:   The string which will replace `string`.
+    * @param `searchMode`:    Search mode to use.
+    * @param `searchOptions`: Search options to use.
+    */
     int replaceAll(QString string, QString replacement, SearchHelpers::SearchMode searchMode, SearchHelpers::SearchOptions searchOptions);
+   /*
+    * @brief Select all instances of `string` within the current document.
+    * @param `string`:        The string to search for.
+    * @param `searchMode`:    Search mode to use.
+    * @param `forward`:       Direction in which to search.
+    * @param `searchOptions`: Search options to use.
+    */
     int selectAll(QString string, SearchHelpers::SearchMode searchMode, SearchHelpers::SearchOptions searchOptions);
+   /*
+    * @brief Perform a search or replacement of `string` within the selected `path`.
+    * @param `string`:        The string to be searched for.
+    * @param `path`:          The directory path to work in.
+    * @param `filters`:       File filters to limit the scope of the search/replacement.
+    * @param `searchMode`:    Search mode to use.
+    * @param `searchOptions`: Search options to use.
+    * @param `replaceMode`:   Replace found occurrences if true.
+    */
     void searchReplaceInFiles(const QString &string, const QString &path, const QStringList &filters, const SearchHelpers::SearchMode &searchMode, const SearchHelpers::SearchOptions &searchOptions, bool replaceMode = false);
-    void replaceInFiles(const QString &string, const QString &replacement, const QString &path, const QStringList &filters, const SearchHelpers::SearchMode &searchMode, const SearchHelpers::SearchOptions &searchOptions);
+   /*
+    * @brief Sets the current tab.
+    * @param `tab`: The tab to be set to.
+    */
     void setCurrentTab(Tabs tab);
+   /*
+    * @brief Adjust the size of the frmSearchReplace window.
+    */
     void manualSizeAdjust();
+   /*
+    * @brief Retrieve search options from UI.
+    * @return `SearchHelpers::SearchOptions`: The UI search options.
+    */
     SearchHelpers::SearchOptions searchOptionsFromUI();
+   /*
+    * @brief Retrieve search mode from UI.
+    * @return `SearchHelpers::SearchMode`: The UI search mode.
+    */
     SearchHelpers::SearchMode searchModeFromUI();
+   /*
+    * @brief Apply regex modifiers based on UI options.
+    * @param `searchOptions`: The search options to use.
+    * @return `QString`: Modified string based on `searchOptions`.
+    */
     QString regexModifiersFromSearchOptions(SearchHelpers::SearchOptions searchOptions);
-    FileSearchResult::Result buildResult(const QRegularExpressionMatch &match, QString *content);
+   /*
+    * @brief Retrieve file filters from UI.
+    * @return `QStringList`: List of current UI file filters.
+    */
     QStringList fileFiltersFromUI();
 
     /**
@@ -109,10 +226,6 @@ private:
     void addToReplaceHistory(QString string);
     void addToFileHistory(QString string);
     void addToFilterHistory(QString string);
-signals:
-    void fileSearchResultFinished(FileSearchResult::SearchResult result);
-    void stopSearchInFiles();
-    void stopReplaceInFiles();
 };
 
 #endif // FRMSEARCHREPLACE_H

--- a/src/ui/include/Search/frmsearchreplace.h
+++ b/src/ui/include/Search/frmsearchreplace.h
@@ -34,13 +34,15 @@ public:
      */
     void findFromUI(bool forward, bool searchFromStart = false);
     void replaceFromUI(bool forward, bool searchFromStart = false);
-
-    static QString rawSearchString(QString search, SearchHelpers::SearchMode searchMode, SearchHelpers::SearchOptions searchOptions);
-    static QString plainTextToRegex(QString text, bool matchWholeWord);
-
     void cleanFindInFilesPtrs();
 protected:
     void keyPressEvent(QKeyEvent *evt);
+
+public slots:
+    void displayThreadErrorMessageBox(const QString &message, int &operation);
+    void handleSearchResult(const FileSearchResult::SearchResult &result);
+    void handleError(const QString &e);
+    void handleProgress(const QString &file, bool replace = false);
 
 private slots:
     void on_btnFindNext_clicked();
@@ -70,17 +72,16 @@ private:
     public:
         SearchInFilesSession(QObject *parent) : QObject(parent) { }
 
-        QThread*               threadSearch = nullptr;
-        SearchInFilesWorker*   workerSearch = nullptr;
-        QThread*               threadReplace = nullptr;
-        ReplaceInFilesWorker*  workerReplace = nullptr;
+        SearchInFilesWorker*   threadSearch = nullptr;
+        ReplaceInFilesWorker*  threadReplace = nullptr;
         dlgSearching*          msgBox = nullptr;
     };
 
+    SearchInFilesSession* m_session = nullptr;
     QList<SearchInFilesSession*> m_findInFilesPtrs;
 
     Editor*                currentEditor();
-
+    void handleSearchCleanup();
     void search(QString string, SearchHelpers::SearchMode searchMode, bool forward, SearchHelpers::SearchOptions searchOptions);
     void replace(QString string, QString replacement, SearchHelpers::SearchMode searchMode, bool forward, SearchHelpers::SearchOptions searchOptions);
     int replaceAll(QString string, QString replacement, SearchHelpers::SearchMode searchMode, SearchHelpers::SearchOptions searchOptions);
@@ -102,13 +103,14 @@ private:
      * @param message
      * @param operation
      */
-    void displayThreadErrorMessageBox(const QString &message, int &operation);
     void addToSearchHistory(QString string);
     void addToReplaceHistory(QString string);
     void addToFileHistory(QString string);
     void addToFilterHistory(QString string);
 signals:
     void fileSearchResultFinished(FileSearchResult::SearchResult result);
+    void stopSearchInFiles();
+    void stopReplaceInFiles();
 };
 
 #endif // FRMSEARCHREPLACE_H

--- a/src/ui/include/Search/frmsearchreplace.h
+++ b/src/ui/include/Search/frmsearchreplace.h
@@ -26,12 +26,12 @@ public:
     explicit frmSearchReplace(TopEditorContainer *topEditorContainer, QWidget *parent = 0);
     ~frmSearchReplace();
 
-   /*
+   /**
     * @brief Sets the currently displayed tab.
     * @param `defaultTab`: The tab to change our display to.
     */
     void show(Tabs defaultTab);
-   /*
+   /**
     * @brief Sets the search input text to value specified in `string`.
     * @param `string`: Value to change the search input text to.
     */
@@ -69,23 +69,23 @@ public slots:
     * @param `stopped`:       Bool value which determines how we display results.
     */
     void handleReplaceResult(int replaceCount, int fileCount, bool stopped);
-   /*
+   /**
     * @brief Display results from SearchInFilesWorker thread.
     * @param `result`: FileSearchResult::SearchResult struct to generate the display from.
     */
     void handleSearchResult(const FileSearchResult::SearchResult &result);
-   /*
+   /**
     * @brief Handle general error message from thread.
     * @param `e`: The error message received.
     */
     void handleError(const QString &e);
-   /*
+   /**
     * @brief Handle progress report from thread.
     * @param `file`: Current file being worked on.
     * @param `replace`: Bool value which determines how we display progress.
     */
     void handleProgress(const QString &file, bool replace = false);
-   /*
+   /**
     * @brief Starts ReplaceInFilesWorker thread if we started the search in replaceMode.
     * @param `result`: FileSearchResult::SearchResult struct to work on.
     */
@@ -126,22 +126,22 @@ private:
     SearchInFilesSession* m_session = nullptr;
     QList<SearchInFilesSession*> m_findInFilesPtrs;
 
-   /*
+   /**
     * @brief Get the current editor.
     */
     Editor*                currentEditor();
-   /*
+   /**
     * @brief Clean up Search in file sessions.
     */
     void sessionCleanup();
-   /*
+   /**
     * @brief Ask for confirmation for replacing in files.
     * @param `path`:    The directory path being worked on.
     * @param `filters`: The filters that will be applied.
     * @return `bool`:   The result of the request.
     */
     bool confirmReplaceInFiles(const QString &path, const QStringList &filters);
-   /*
+   /**
     * @brief Perform a search within the current document.
     * @param `string`:        The string to search for.
     * @param `searchMode`:    Search mode to use.
@@ -149,7 +149,7 @@ private:
     * @param `searchOptions`: Search options to use.
     */
     void search(QString string, SearchHelpers::SearchMode searchMode, bool forward, SearchHelpers::SearchOptions searchOptions);
-   /*
+   /**
     * @brief Perform a replace within the current document.
     * @param `string`:        The string to search for.
     * @param `replacement`:   The string which will replace `string`.
@@ -158,7 +158,7 @@ private:
     * @param `searchOptions`: Search options to use.
     */
     void replace(QString string, QString replacement, SearchHelpers::SearchMode searchMode, bool forward, SearchHelpers::SearchOptions searchOptions);
-   /*
+   /**
     * @brief Perform a full document replace within the current document.
     * @param `string`:        The string to search for.
     * @param `replacement`:   The string which will replace `string`.
@@ -166,7 +166,7 @@ private:
     * @param `searchOptions`: Search options to use.
     */
     int replaceAll(QString string, QString replacement, SearchHelpers::SearchMode searchMode, SearchHelpers::SearchOptions searchOptions);
-   /*
+   /**
     * @brief Select all instances of `string` within the current document.
     * @param `string`:        The string to search for.
     * @param `searchMode`:    Search mode to use.
@@ -174,7 +174,7 @@ private:
     * @param `searchOptions`: Search options to use.
     */
     int selectAll(QString string, SearchHelpers::SearchMode searchMode, SearchHelpers::SearchOptions searchOptions);
-   /*
+   /**
     * @brief Perform a search or replacement of `string` within the selected `path`.
     * @param `string`:        The string to be searched for.
     * @param `path`:          The directory path to work in.
@@ -184,32 +184,32 @@ private:
     * @param `replaceMode`:   Replace found occurrences if true.
     */
     void searchReplaceInFiles(const QString &string, const QString &path, const QStringList &filters, const SearchHelpers::SearchMode &searchMode, const SearchHelpers::SearchOptions &searchOptions, bool replaceMode = false);
-   /*
+   /**
     * @brief Sets the current tab.
     * @param `tab`: The tab to be set to.
     */
     void setCurrentTab(Tabs tab);
-   /*
+   /**
     * @brief Adjust the size of the frmSearchReplace window.
     */
     void manualSizeAdjust();
-   /*
+   /**
     * @brief Retrieve search options from UI.
     * @return `SearchHelpers::SearchOptions`: The UI search options.
     */
     SearchHelpers::SearchOptions searchOptionsFromUI();
-   /*
+   /**
     * @brief Retrieve search mode from UI.
     * @return `SearchHelpers::SearchMode`: The UI search mode.
     */
     SearchHelpers::SearchMode searchModeFromUI();
-   /*
+   /**
     * @brief Apply regex modifiers based on UI options.
     * @param `searchOptions`: The search options to use.
     * @return `QString`: Modified string based on `searchOptions`.
     */
     QString regexModifiersFromSearchOptions(SearchHelpers::SearchOptions searchOptions);
-   /*
+   /**
     * @brief Retrieve file filters from UI.
     * @return `QStringList`: List of current UI file filters.
     */

--- a/src/ui/include/Search/replaceinfilesworker.h
+++ b/src/ui/include/Search/replaceinfilesworker.h
@@ -3,30 +3,39 @@
 
 #include <QObject>
 #include <QMutex>
+#include <QThread>
 #include "include/Search/filesearchresult.h"
 
 /**
  * @brief This worker handles the replacement of portions of text in files,
  *        based on a search result.
  */
-class ReplaceInFilesWorker : public QObject
+class ReplaceInFilesWorker : public QThread
 {
     Q_OBJECT
 public:
-    explicit ReplaceInFilesWorker(const FileSearchResult::SearchResult &searchResult, const QString &replacement);
+    explicit ReplaceInFilesWorker(QObject* parent, const FileSearchResult::SearchResult &searchResult, const QString &replacement);
     ~ReplaceInFilesWorker();
-
-    QPair<int, int> getResult();
-
+    void run();
 signals:
     /**
      * @brief The worker finished its work.
      * @param stopped if true, the worker did not complete its operations
      *        (e.g. because of an error or because it was manually stopped).
      */
-    void finished(bool stopped);
-    void error(QString string);
-    void progress(QString file);
+    void resultReady(int replaceCount, int fileCount, bool stopped);
+
+   /**
+    * @brief The worker has encountered an error.
+    * @param QString e: The error message.
+    */
+    void error(const QString &e);
+
+   /**
+    * @brief Tell main thread the current progress of the replace operation.
+    * @param QString file:  The current file being worked on.
+    */
+    void progress(QString file, const bool replace = true);
 
     /**
      * @brief Error reading a file. You can handle this signal
@@ -51,18 +60,16 @@ signals:
     void errorWritingFile(const QString &message, int &operation);
 
 public slots:
-    void run();
     void stop();
 
 private:
     FileSearchResult::SearchResult m_searchResult;
+    QMutex m_mutex;
     QString m_replacement;
     bool m_stop = false;
-    QMutex m_stopMutex;
-
-    QMutex m_resultMutex;
-    int m_numOfFilesReplaced = 0;
-    int m_numOfOccurrencesReplaced = 0;
+    int m_fileCount = 0;
+    int m_replaceCount = 0;
+    void sendResults();
 };
 
 #endif // REPLACEINFILESWORKER_H

--- a/src/ui/include/Search/replaceinfilesworker.h
+++ b/src/ui/include/Search/replaceinfilesworker.h
@@ -13,11 +13,14 @@
 class ReplaceInFilesWorker : public QThread
 {
     Q_OBJECT
+
 public:
     explicit ReplaceInFilesWorker(QObject* parent, const FileSearchResult::SearchResult &searchResult, const QString &replacement);
     ~ReplaceInFilesWorker();
     void run();
+
 signals:
+
     /**
      * @brief The worker finished its work.
      * @param stopped if true, the worker did not complete its operations
@@ -48,17 +51,6 @@ signals:
      */
     void errorReadingFile(const QString &message, int &operation);
 
-    /**
-     * @brief Error writing a file. You can handle this signal
-     *        and show a message box asking the user to abort/retry/ignore.
-     *        Assign the result of the message box to "operation".
-     *        Make sure to connect to this signal with
-     *        Qt::BlockingQueuedConnection
-     * @param message
-     * @param operation
-     */
-    void errorWritingFile(const QString &message, int &operation);
-
 public slots:
     void stop();
 
@@ -69,6 +61,11 @@ private:
     bool m_stop = false;
     int m_fileCount = 0;
     int m_replaceCount = 0;
+
+   /**
+    * @brief Build results from `m_fileCount` and `m_replaceCount` and emit
+    *        a signal containing them.
+    */
     void sendResults();
 };
 

--- a/src/ui/include/Search/searchinfilesworker.h
+++ b/src/ui/include/Search/searchinfilesworker.h
@@ -12,9 +12,8 @@ class SearchInFilesWorker : public QThread
 {
     Q_OBJECT
 public:
-    SearchInFilesWorker(QObject *parent, const QString &string, const QString &path, const QStringList &filters, const SearchHelpers::SearchMode &searchMode, const SearchHelpers::SearchOptions &searchOptions);
+    explicit SearchInFilesWorker(QObject *parent, const QString &string, const QString &path, const QStringList &filters, const SearchHelpers::SearchMode &searchMode, const SearchHelpers::SearchOptions &searchOptions);
     ~SearchInFilesWorker();
-    FileSearchResult::SearchResult getResult();
     void run();
 
 signals:

--- a/src/ui/include/Search/searchinfilesworker.h
+++ b/src/ui/include/Search/searchinfilesworker.h
@@ -1,20 +1,21 @@
 #ifndef SEARCHINFILESWORKER_H
 #define SEARCHINFILESWORKER_H
 
+#include "include/Search/filesearchresult.h"
+#include "include/Search/searchhelpers.h"
 #include <QObject>
 #include <QMutex>
 #include <QRegularExpression>
-#include "include/Search/filesearchresult.h"
-#include "include/Search/searchhelpers.h"
+#include <QThread>
 
-class SearchInFilesWorker : public QObject
+class SearchInFilesWorker : public QThread
 {
     Q_OBJECT
 public:
-    explicit SearchInFilesWorker(const QString &string, const QString &path, const QStringList &filters, const SearchHelpers::SearchMode &searchMode, const SearchHelpers::SearchOptions &searchOptions);
+    SearchInFilesWorker(QObject *parent, const QString &string, const QString &path, const QStringList &filters, const SearchHelpers::SearchMode &searchMode, const SearchHelpers::SearchOptions &searchOptions);
     ~SearchInFilesWorker();
-
     FileSearchResult::SearchResult getResult();
+    void run();
 
 signals:
 
@@ -24,8 +25,18 @@ signals:
      *        (e.g. because of an error or because it was manually stopped).
      */
     void finished(bool stopped);
+
+   /**
+    * @brief The worker encountered an error.
+    * @param QString string: The error message received.
+    */
     void error(QString string);
-    void progress(QString file);
+
+   /**
+    * @brief Report progress to main thread.
+    * @param QString file: The file currently being processed.
+    */
+    void progress(const QString& file, bool replace = false);
 
     /**
      * @brief Error reading a file. You can handle this signal
@@ -38,21 +49,27 @@ signals:
      */
     void errorReadingFile(const QString &message, int &operation);
 
+   /**
+    * @brief Report to main thread that results are ready to be processed.
+    */
+    void resultReady(const FileSearchResult::SearchResult &result);
+
 public slots:
-    void run();
+   /**
+    * @brief Stop the search
+    */
     void stop();
 
 private:
+    QMutex  m_mutex;
+    QRegularExpression m_regex;
     QString m_string;
     QString m_path;
     QStringList m_filters;
     SearchHelpers::SearchMode m_searchMode;
     SearchHelpers::SearchOptions m_searchOptions;
     FileSearchResult::SearchResult m_result;
-    QMutex m_resultMutex;
-    QMutex m_stopMutex;
     bool m_stop = false;
-    QRegularExpression m_regex;
 
     /**
      * @brief Build FileSearchResult::Result object using the parameters given.
@@ -102,13 +119,6 @@ private:
      * @return QVector<int> containing line beginning positions.
      */
     QVector<int> getLinePositions(const QString &data);
-
-    /**
-     * @brief Unescapes a string to allow searching for \n, \r, \t, etc.
-     * @param `data`
-     * @return QString with character sequences unescaped.
-     */
-    QString unescapeString(const QString &data);
 };
 
 #endif // SEARCHINFILESWORKER_H

--- a/src/ui/include/Search/searchinfilesworker.h
+++ b/src/ui/include/Search/searchinfilesworker.h
@@ -35,7 +35,7 @@ signals:
     * @brief Report progress to main thread.
     * @param QString file: The file currently being processed.
     */
-    void progress(const QString& file, bool replace = false);
+    void progress(const QString& file, const bool replace = false);
 
     /**
      * @brief Error reading a file. You can handle this signal

--- a/src/ui/include/Search/searchresultsitemdelegate.h
+++ b/src/ui/include/Search/searchresultsitemdelegate.h
@@ -1,11 +1,12 @@
 #ifndef SEARCHRESULTSITEMDELEGATE_H
 #define SEARCHRESULTSITEMDELEGATE_H
+
+#include "include/Search/filesearchresult.h"
 #include <QSize>
 #include <QPainter>
 #include <QStyleOptionViewItemV4>
 #include <QStyledItemDelegate>
 #include <QStandardItem>
-#include "include/Search/filesearchresult.h"
 
 class SearchResultsItemDelegate : public QStyledItemDelegate
 {
@@ -21,13 +22,30 @@ public:
         ResultTypeFile,
         ResultTypeMatch
     };
-
+   
+   /*
+    * @brief Get the current `index` row item type.
+    * @return `SearchResultsItemDelegate::ResultType`: The result type of `index`.
+    */
     static SearchResultsItemDelegate::ResultType rowItemType(const QModelIndex &index);
 
+   /*
+    * @brief Populate result items.
+    * @param `item`:             The item to populate.
+    * @param `result`:           The result to populate `item` with.
+    * @param `matches`:          Total number of matches within a file.
+    * @param `totalFileMatches`: Total number of matches from a search.
+    * @param `totalFiles`:       Total number of files matched within.
+    */
     static void fillResultRowItem(QStandardItem *item, const FileSearchResult::Result &result);
     static void fillFileResultRowItem(QStandardItem *item, const FileSearchResult::FileResult &fileResult, const int matches);
     static void fillSearchResultRowItem(QStandardItem *item, const FileSearchResult::SearchResult &searchResult, const int totalFileMatches, const int totalFiles);
 
+   /*
+    * @brief Retrieve result data.
+    * @param `index`: The index to use for retrieving result data.
+    * @return `FileSearchResult::Result/FileResult`: The data at `index`.
+    */
     static FileSearchResult::Result resultRowData(const QModelIndex &index);
     static FileSearchResult::FileResult fileResultRowData(const QModelIndex &index);
 

--- a/src/ui/include/Search/searchresultsitemdelegate.h
+++ b/src/ui/include/Search/searchresultsitemdelegate.h
@@ -16,6 +16,7 @@ public:
 
     static const int RESULT_TYPE_ROLE = Qt::UserRole + 1;
     static const int RESULT_DATA_ROLE = Qt::UserRole + 2;
+    static const int RESULT_DATA_EX_ROLE = Qt::UserRole + 3;
 
     enum ResultType {
         ResultTypeError,
@@ -46,8 +47,9 @@ public:
     * @param `index`: The index to use for retrieving result data.
     * @return `FileSearchResult::Result/FileResult`: The data at `index`.
     */
-    static FileSearchResult::Result resultRowData(const QModelIndex &index);
-    static FileSearchResult::FileResult fileResultRowData(const QModelIndex &index);
+    static QPoint resultRowStartData(const QModelIndex &index);
+    static QPoint resultRowEndData(const QModelIndex &index);
+    static QString fileResultRowData(const QModelIndex &index);
 
 protected:
     void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;

--- a/src/ui/include/Search/searchresultsitemdelegate.h
+++ b/src/ui/include/Search/searchresultsitemdelegate.h
@@ -23,13 +23,13 @@ public:
         ResultTypeMatch
     };
    
-   /*
+   /**
     * @brief Get the current `index` row item type.
     * @return `SearchResultsItemDelegate::ResultType`: The result type of `index`.
     */
     static SearchResultsItemDelegate::ResultType rowItemType(const QModelIndex &index);
 
-   /*
+   /**
     * @brief Populate result items.
     * @param `item`:             The item to populate.
     * @param `result`:           The result to populate `item` with.
@@ -41,7 +41,7 @@ public:
     static void fillFileResultRowItem(QStandardItem *item, const FileSearchResult::FileResult &fileResult, const int matches);
     static void fillSearchResultRowItem(QStandardItem *item, const FileSearchResult::SearchResult &searchResult, const int totalFileMatches, const int totalFiles);
 
-   /*
+   /**
     * @brief Retrieve result data.
     * @param `index`: The index to use for retrieving result data.
     * @return `FileSearchResult::Result/FileResult`: The data at `index`.

--- a/src/ui/include/Search/searchstring.h
+++ b/src/ui/include/Search/searchstring.h
@@ -1,0 +1,13 @@
+#ifndef __SEARCHSTRING_H__
+#define __SEARCHSTRING_H__
+#include "include/Search/searchhelpers.h"
+#include <QString>
+
+class SearchString {
+public:
+    static QString toRaw(const QString &data, const SearchHelpers::SearchMode &searchMode, const SearchHelpers::SearchOptions &searchOptions);
+    static QString toRegex(const QString &data, bool matchWholeWord);
+    static QString unescape(const QString &data);
+};
+
+#endif //__SEARCHSTRING_H_

--- a/src/ui/include/Search/searchstring.h
+++ b/src/ui/include/Search/searchstring.h
@@ -5,7 +5,7 @@
 
 class SearchString {
 public:
-   /*
+   /**
     * @brief Build a raw version of `data` to be used for the search.
     * @param `data`:          The string to be worked on.
     * @param `searchMode`:    The search mode to be used.
@@ -13,14 +13,14 @@ public:
     * @return `QString`:      Converted string based on `searchMode` and `searchOptions`
     */
     static QString toRaw(const QString &data, const SearchHelpers::SearchMode &searchMode, const SearchHelpers::SearchOptions &searchOptions);
-   /*
+   /**
     * @brief Convert string to its regex counterpart.
     * @param `data`:           The string to be worked on.
     * @param `matchWholeWord`: Whether to add boundary checks to converted string.
     * @return `QString`:       String converted for use in regex operations.
     */
     static QString toRegex(const QString &data, bool matchWholeWord);
-   /*
+   /**
     * @brief Unescape escape sequences in `data`
     * @param `data`:     The string to be worked on.
     * @return `QString`: `data` with escape sequences unescaped.

--- a/src/ui/include/Search/searchstring.h
+++ b/src/ui/include/Search/searchstring.h
@@ -5,8 +5,26 @@
 
 class SearchString {
 public:
+   /*
+    * @brief Build a raw version of `data` to be used for the search.
+    * @param `data`:          The string to be worked on.
+    * @param `searchMode`:    The search mode to be used.
+    * @param `searchOptions`: The search options to be used.
+    * @return `QString`:      Converted string based on `searchMode` and `searchOptions`
+    */
     static QString toRaw(const QString &data, const SearchHelpers::SearchMode &searchMode, const SearchHelpers::SearchOptions &searchOptions);
+   /*
+    * @brief Convert string to its regex counterpart.
+    * @param `data`:           The string to be worked on.
+    * @param `matchWholeWord`: Whether to add boundary checks to converted string.
+    * @return `QString`:       String converted for use in regex operations.
+    */
     static QString toRegex(const QString &data, bool matchWholeWord);
+   /*
+    * @brief Unescape escape sequences in `data`
+    * @param `data`:     The string to be worked on.
+    * @return `QString`: `data` with escape sequences unescaped.
+    */
     static QString unescape(const QString &data);
 };
 

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -167,7 +167,7 @@ private slots:
     void on_actionMove_Line_Up_triggered();
     void on_actionMove_Line_Down_triggered();
     void on_fileSearchResultFinished(FileSearchResult::SearchResult result);
-    void on_resultMatchClicked(const FileSearchResult::FileResult &file, const FileSearchResult::Result &match);
+    void on_resultMatchClicked(const QString &fileName, int startLine, int startCol, int endLine, int endCol);
     void on_actionTrim_Trailing_Space_triggered();
     void on_actionTrim_Leading_Space_triggered();
     void on_actionTrim_Leading_and_Trailing_Space_triggered();

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -177,7 +177,8 @@ MainWindow::MainWindow(const QString &workingDirectory, const QStringList &argum
 
         a->setShortcut(shortcut);
     }
-
+    //Register our meta types for signal/slot calls here.
+    qRegisterMetaType<FileSearchResult::SearchResult>("FileSearchResult::SearchResult");
     emit Notepadqq::getInstance().newWindow(this);
 }
 

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2339,9 +2339,9 @@ void MainWindow::on_actionMove_Line_Down_triggered()
     currentEditor()->sendMessage("C_CMD_MOVE_LINE_DOWN");
 }
 
-void MainWindow::on_resultMatchClicked(const FileSearchResult::FileResult &file, const FileSearchResult::Result &match)
+void MainWindow::on_resultMatchClicked(const QString &fileName, int startLine, int startCol, int endLine, int endCol)
 {
-    QUrl url = stringToUrl(file.fileName);
+    QUrl url = stringToUrl(fileName);
     m_docEngine->loadDocument(url,
                               m_topEditorContainer->currentTabWidget());
 
@@ -2353,7 +2353,7 @@ void MainWindow::on_resultMatchClicked(const FileSearchResult::FileResult &file,
     EditorTabWidget *tabW = m_topEditorContainer->tabWidget(pos.first);
     Editor *editor = tabW->editor(pos.second);
 
-    editor->setSelection(match.matchStartLine, match.matchStartCol, match.matchEndLine, match.matchEndCol);
+    editor->setSelection(startLine, startCol, endLine, endCol);
 
     editor->setFocus();
 }

--- a/src/ui/ui.pro
+++ b/src/ui/ui.pro
@@ -70,6 +70,7 @@ SOURCES += main.cpp\
     Search/filesearchresultswidget.cpp \
     Search/frmsearchreplace.cpp \
     Search/searchinfilesworker.cpp \
+    Search/searchstring.cpp \
     Search/replaceinfilesworker.cpp \
     Search/dlgsearching.cpp \
     Search/searchresultsitemdelegate.cpp \
@@ -115,6 +116,7 @@ HEADERS  += include/mainwindow.h \
     include/Search/searchinfilesworker.h \
     include/Search/replaceinfilesworker.h \
     include/Search/searchhelpers.h \
+    include/Search/searchstring.h \
     include/Search/dlgsearching.h \
     include/Search/searchresultsitemdelegate.h \
     include/Extensions/extension.h \


### PR DESCRIPTION
This request will be focused on cleaning up the code/bug fixing in frmSearchReplace, SearchInFilesWorker, ReplaceInFilesWorker, etc.  As well as fixing a few long-standing bugs in the process.

For the moment, I've gotten the search code quite a bit cleaner, and fixed a bug regarding threads not cleaning up properly.

I've still got to hook the threads for replaceInFiles... but so far its going very smoothly.  The end result should be something that's quite a bit easier to manage.

This change also allowed sending the results directly from the worker thread to the main thread via a signal, as well as getting rid of the thread/worker model.

This should be about 150 or so less lines of code while still getting the job done efficiently(At least judging by the current progress).

I'm also going to spend some time documenting the undocumented functions in the header files while I go through this, just to keep things clean and consistent.
