### PR TITLE
Implements Autosaving, Sessions Refactored.

### DIFF
--- a/src/ui/Sessions/autosave.cpp
+++ b/src/ui/Sessions/autosave.cpp
@@ -1,0 +1,84 @@
+#include "include/Sessions/autosave.h"
+#include "include/Sessions/persistentcache.h"
+#include "include/Sessions/sessions.h"
+
+#include <QTimer>
+#include <QDebug>
+
+#include "include/mainwindow.h"
+
+static QTimer g_autosaveTimer;
+
+// Interval between autosaves, in milliseconds.
+static const int AUTOSAVE_INTERVAL = 5000;
+
+using namespace Sessions;
+
+namespace Autosave {
+
+static void executeAutosave() {
+    const auto& autosavePath = PersistentCache::autosaveDirPath();
+
+    QDir autosaveDir(autosavePath);
+
+    if (autosaveDir.exists())
+        autosaveDir.removeRecursively();
+
+    int i = 0;
+    for (const auto& window : MainWindow::instances()) {
+        qDebug() << "autosave window #" << i;
+
+        const QString cachePath = autosavePath + QString("/window_%1").arg(i);
+        const QString sessPath = autosavePath + QString("/window_%1/window.xml").arg(i);
+
+        saveSession(window, sessPath, cachePath);
+
+        i++;
+    }
+}
+
+void restoreFromAutosave()
+{
+    qDebug() << "restore from autosave";
+
+    const auto& autosavePath = PersistentCache::autosaveDirPath();
+
+    QDir autosaveDir(autosavePath);
+    autosaveDir.setFilter(QDir::Dirs | QDir::NoDotAndDotDot);
+    const auto& dirs = autosaveDir.entryInfoList();
+
+    for (const auto& dirInfo : dirs) {
+        qDebug() << "Dir: " << dirInfo.filePath();
+
+        const auto sessPath = dirInfo.filePath() + "/window.xml";
+
+        MainWindow *b = new MainWindow(QStringList(), 0);
+
+        loadSession(b, sessPath);
+
+        b->show();
+    }
+
+
+}
+
+void enableAutosave()
+{
+    if (g_autosaveTimer.isActive())
+        return;
+
+    qDebug() << "enable";
+
+    QObject::connect(&g_autosaveTimer, &QTimer::timeout, &executeAutosave);
+
+    g_autosaveTimer.setInterval(AUTOSAVE_INTERVAL);
+    g_autosaveTimer.start(AUTOSAVE_INTERVAL);
+}
+
+void disableAutosave()
+{
+    qDebug() << "disable";
+    g_autosaveTimer.stop();
+}
+
+} // namespace Autosave

--- a/src/ui/Sessions/persistentcache.cpp
+++ b/src/ui/Sessions/persistentcache.cpp
@@ -8,25 +8,18 @@ QString PersistentCache::cacheSessionPath() {
 
 QString PersistentCache::cacheDirPath() {
     static QString tabpath = QFileInfo(QSettings().fileName()).dir().absolutePath().append("/tabCache");
-
-    // Create the directory if it does not yet exist.
-    // Does nothing if the dir exists.
-    QDir().mkpath(tabpath);
-
     return tabpath;
 }
 
-bool PersistentCache::clearCacheDir() {
-    QDir cacheDir(cacheDirPath());
-    cacheDir.removeRecursively(); // Clear cache
-    cacheDir = cacheDirPath(); // Recreate cache folder
-
-    return cacheDir.exists();
+QString PersistentCache::autosaveDirPath() {
+    static QString path = QFileInfo(QSettings().fileName()).dir().absolutePath().append("/autosaveCache");
+    return path;
 }
 
-QUrl PersistentCache::createValidCacheName(const QString& fileName){
+QUrl PersistentCache::createValidCacheName(const QDir& parent, const QString &fileName)
+{
     QUrl cacheFile;
-    QString partialPath = cacheDirPath() + "/" + fileName;
+    QString partialPath = parent.absolutePath() + "/" + fileName;
     QFileInfo fileInfo;
 
     // To prevent name collision, a random suffix will be appended to each file.

--- a/src/ui/Sessions/sessions.cpp
+++ b/src/ui/Sessions/sessions.cpp
@@ -1,5 +1,16 @@
 #include "include/Sessions/sessions.h"
 
+#include <QFileInfo>
+#include <QXmlStreamReader>
+#include <QXmlStreamWriter>
+#include <QFile>
+
+#include <vector>
+
+#include "include/mainwindow.h"
+#include "include/Sessions/persistentcache.h"
+
+
 /* Session XML structure:
  *
  * <Notepadqq>
@@ -23,6 +34,83 @@
  * -> int active - optional, value is "1" if this tab is the open one in the tabview, otherwise "0".
  *
  * */
+
+
+struct TabData {
+    QString filePath;
+    QString cacheFilePath;
+    int scrollX = 0;
+    int scrollY = 0;
+    bool active = false;
+    qint64 lastModified = 0;
+};
+
+struct ViewData {
+    std::vector<TabData> tabs;
+};
+
+/**
+ * @brief Provides a convenience class to read session .xml files.
+ */
+class SessionReader {
+public:
+
+    SessionReader(QFile& input)
+        : m_reader(&input) { }
+
+    /**
+     * @brief Completely read the session data
+     * @param outSuccess pass a pointer to bool here to be informed about whether
+     *        the reading process has encountered any errors.
+     * @return The data read from the session file.
+     */
+    std::vector<ViewData> readData(bool* outSuccess=nullptr);
+
+    QString getError();
+
+private:
+
+    /**
+     * @brief Helper functions to read specific parts of the xml structure
+     */
+    std::vector<ViewData> readViewData();
+    std::vector<TabData> readTabData();
+
+    QXmlStreamReader m_reader;
+};
+
+
+/**
+ * @brief Provides a convenience class to write session .xml files.
+ *
+ * Note that a SessionWriter object must be successfully destroyed
+ * in order to complete the writing process. (Aka the destructor must
+ * be called)
+ */
+class SessionWriter {
+public:
+
+    SessionWriter(QFile& destination);
+
+    ~SessionWriter();
+
+    /**
+     * @brief Write ViewData to the session file. ViewData is the representation of a
+     *        TabWidget and its tabs.
+     *
+     * @param The ViewData to be written.
+     */
+    void addViewData(const ViewData& vd);
+
+
+private:
+    /**
+     * @brief Helper function to write specific parts of the xml structure
+     */
+    void addTabData(const TabData& td);
+
+    QXmlStreamWriter m_writer;
+};
 
 std::vector<ViewData> SessionReader::readData(bool* outSuccess) {
     std::vector<ViewData> result;
@@ -135,3 +223,230 @@ void SessionWriter::addTabData(const TabData& td){
 
     m_writer.writeEndElement();
 }
+
+namespace Sessions {
+
+bool saveSession(MainWindow *window, QString sessionPath, QString cacheDirPath)
+{
+    const auto& editorContainer = window->topEditorContainer();
+    const auto& docEngine = window->getDocEngine();
+    const bool cacheModifiedFiles = !cacheDirPath.isEmpty();
+
+    QDir cacheDir;
+
+    if (cacheModifiedFiles) {
+        cacheDir = QDir(cacheDirPath);
+
+        bool success = false;
+
+        if (cacheDir.exists())
+            success = cacheDir.removeRecursively();
+
+        success |= cacheDir.mkpath(cacheDirPath);
+
+        if(!success)
+            return false;
+
+        qDebug() << "Writing to: " << cacheDir.absolutePath();
+    }
+
+
+    std::vector<ViewData> viewData;
+
+    //Loop through all tabwidgets and their tabs
+    const int tabWidgetsCount = editorContainer->count();
+    for (int i = 0; i < tabWidgetsCount; i++) {
+        EditorTabWidget *tabWidget = editorContainer->tabWidget(i);
+        const int tabCount = tabWidget->count();
+
+        viewData.push_back( ViewData() );
+        ViewData& currentViewData = viewData.back();
+
+        for (int j = 0; j < tabCount; j++) {
+            Editor* editor = tabWidget->editor(j);
+            bool isClean = editor->isClean();
+            bool isOrphan = editor->fileName().isEmpty();
+
+            if (isOrphan && !cacheModifiedFiles)
+                continue; // Don't save temporary files if we're not caching tabs
+
+            TabData td;
+
+            if (!isClean && cacheModifiedFiles) {
+                // Tab is dirty, meaning it needs to be cached.
+                QUrl cacheFilePath = PersistentCache::createValidCacheName(cacheDir, tabWidget->tabText(j));
+
+                td.cacheFilePath = cacheFilePath.toLocalFile();
+
+                if (docEngine->saveDocument(tabWidget, j, cacheFilePath, true) != MainWindow::saveFileResult_Saved) {
+                    return false;
+                }
+            } else if (isOrphan) {
+                // Since we didn't cache the file and it is an orphan, we won't save it in the session.
+                continue;
+            }
+            // Else tab is an openened unmodified file, we don't have to do anything special.
+
+            td.filePath = !isOrphan ? editor->fileName().toLocalFile() : "";
+
+            // Finally save other misc information about the tab.
+            const auto& scrollPos = editor->scrollPosition();
+            td.scrollX = scrollPos.first;
+            td.scrollY = scrollPos.second;
+
+            td.active = tabWidget->currentEditor() == editor;
+
+            // If we're caching and there's a file opened in the tab we want to inform the
+            // user whether the file's contents have changed since Nqq was last opened.
+            // For this we save and later compare the modification date.
+            if (!isOrphan && cacheModifiedFiles) {
+                // As a special case, if the file has *already* changed we set the modification
+                // time to 1 so we always trigger the warning.
+                if (editor->fileOnDiskChanged())
+                    td.lastModified = 1;
+                else
+                    td.lastModified = QFileInfo(td.filePath).lastModified().toMSecsSinceEpoch();
+            }
+
+            currentViewData.tabs.push_back( td );
+
+        } // end for
+    } // end for
+
+    // Write all information to a session file
+    QFile file(sessionPath);
+    file.open(QIODevice::WriteOnly);
+
+    if (!file.isOpen())
+        return false;
+
+    SessionWriter sessionWriter(file);
+
+    for (const auto& view : viewData)
+        sessionWriter.addViewData(view);
+
+    return true;
+}
+
+void loadSession(MainWindow *window, QString sessionPath)
+{
+    const auto& editorContainer = window->topEditorContainer();
+    const auto& docEngine = window->getDocEngine();
+
+    QFile file(sessionPath);
+    file.open(QIODevice::ReadOnly);
+
+    if (!file.isOpen())
+        return;
+
+    SessionReader reader(file);
+
+    bool success = false;
+    const auto& views = reader.readData(&success);
+
+    if (!success || views.empty()) {
+        return;
+    }
+
+    //m_dontUpdateRecentDocs = true;
+
+    int viewCounter = 0;
+    for (const auto& view : views) {
+        // Each new view must be created if it does not yet exist.
+        EditorTabWidget* tabW = editorContainer->tabWidget(viewCounter);
+        int activeIndex = 0;
+
+        if (!tabW)
+            tabW = editorContainer->addTabWidget();
+
+        viewCounter++;
+
+        for (const TabData& tab : view.tabs) {
+            const QFileInfo fileInfo(tab.filePath);
+            const bool fileExists = fileInfo.exists();
+            const bool cacheFileExists = QFileInfo(tab.cacheFilePath).exists();
+
+            const QUrl fileUrl = QUrl::fromLocalFile(tab.filePath);
+            const QUrl cacheFileUrl = QUrl::fromLocalFile(tab.cacheFilePath);
+
+            // This is the file to load the document from
+            const QUrl& loadUrl = cacheFileExists ? cacheFileUrl : fileUrl;
+
+            const bool success = docEngine->loadDocumentSilent(loadUrl, tabW);
+
+            if (!success)
+                continue;
+
+            int idx = tabW->findOpenEditorByUrl(loadUrl);
+
+            if (idx == -1)
+                continue;
+
+            // DocEngine sets the editor's fileName to loadUrl since this is where the file
+            // was loaded from. Since loadUrl could point to a cached file we reset it here.
+            Editor* editor = tabW->editor(idx);
+
+            if (cacheFileExists) {
+                editor->markDirty();
+                editor->setLanguageFromFileName();
+                // Since we loaded from cache we want to unmonitor the cache file.
+                docEngine->unmonitorDocument(editor);
+            }
+
+            if (fileExists) {
+                editor->setFileName(fileUrl);
+                docEngine->monitorDocument(editor);
+            } else {
+                editor->setFileName(QUrl());
+                tabW->setTabText(idx, window->getNewDocumentName());
+            }
+
+            // If we're loading an existing file from cache we want to inform the user whether
+            // the file has changed since Nqq was last closed. For this we can compare the
+            // file's last modification date.
+            if (fileExists && cacheFileExists && tab.lastModified != 0) {
+                auto lastModified = fileInfo.lastModified().toMSecsSinceEpoch();
+
+                if(lastModified > tab.lastModified)
+                    editor->setFileOnDiskChanged(true);
+            }
+
+            if(tab.active) activeIndex = idx;
+
+            editor->setScrollPosition(tab.scrollX, tab.scrollY);
+            editor->clearFocus();
+
+        } // end for
+
+        tabW->clearFocus();
+
+        // In case a new tabwidget was created but no tabs were actually added to it,
+        // we'll attempt to re-use the widget for the next view.
+        if (tabW->count() == 0)
+            viewCounter--;
+        else // Otherwise we finish by making the right tab the currently open one.
+            tabW->setCurrentIndex(activeIndex);
+
+    } // end for
+
+    //m_dontUpdateRecentDocs = false;
+
+    // Stop if we haven't added any views at all, otherwise we have to clean up after ourselves.
+    if (viewCounter <= 0)
+        return;
+
+    // If the last tabwidget still has no tabs in it at this point, we'll have to delete it.
+    EditorTabWidget* lastTabW = editorContainer->tabWidget( editorContainer->count() -1);
+    window->removeTabWidgetIfEmpty(lastTabW);
+
+    // Give focus to the last tab of the first tab widget.
+    EditorTabWidget* firstTabW = editorContainer->tabWidget(0);
+    Editor* lastEditor = firstTabW->editor(lastTabW->count()-1);
+
+    lastEditor->setFocus();
+    window->refreshEditorUiInfo(lastEditor);
+
+    return;
+}
+
+} // namespace Sessions

--- a/src/ui/Sessions/sessions.cpp
+++ b/src/ui/Sessions/sessions.cpp
@@ -234,6 +234,7 @@ bool saveSession(MainWindow *window, QString sessionPath, QString cacheDirPath)
 
     QDir cacheDir;
 
+    // Clear the cache directory by deleting and recreating it.
     if (cacheModifiedFiles) {
         cacheDir = QDir(cacheDirPath);
 
@@ -246,10 +247,7 @@ bool saveSession(MainWindow *window, QString sessionPath, QString cacheDirPath)
 
         if(!success)
             return false;
-
-        qDebug() << "Writing to: " << cacheDir.absolutePath();
     }
-
 
     std::vector<ViewData> viewData;
 
@@ -348,8 +346,6 @@ void loadSession(MainWindow *window, QString sessionPath)
         return;
     }
 
-    //m_dontUpdateRecentDocs = true;
-
     int viewCounter = 0;
     for (const auto& view : views) {
         // Each new view must be created if it does not yet exist.
@@ -428,8 +424,6 @@ void loadSession(MainWindow *window, QString sessionPath)
             tabW->setCurrentIndex(activeIndex);
 
     } // end for
-
-    //m_dontUpdateRecentDocs = false;
 
     // Stop if we haven't added any views at all, otherwise we have to clean up after ourselves.
     if (viewCounter <= 0)

--- a/src/ui/docengine.cpp
+++ b/src/ui/docengine.cpp
@@ -144,7 +144,7 @@ bool DocEngine::loadDocuments(const QList<QUrl> &fileNames, EditorTabWidget *tab
                             tabW->setCurrentIndex(openPos.second);
                         }
 
-                        emit documentLoaded(tabW, openPos.second, true);
+                        emit documentLoaded(tabW, openPos.second, true, rememberLastSelectedDir);
                         continue;
                     }
                 }
@@ -238,7 +238,7 @@ bool DocEngine::loadDocuments(const QList<QUrl> &fileNames, EditorTabWidget *tab
                 if (reload) {
                     emit documentReloaded(tabWidget, tabIndex);
                 } else {
-                    emit documentLoaded(tabWidget, tabIndex, false);
+                    emit documentLoaded(tabWidget, tabIndex, false, rememberLastSelectedDir);
                 }
 
             } else if (fileNames[i].isEmpty()) {

--- a/src/ui/frmpreferences.cpp
+++ b/src/ui/frmpreferences.cpp
@@ -6,6 +6,7 @@
 #include "include/Extensions/extensionsloader.h"
 #include "include/notepadqq.h"
 #include "include/keygrabber.h"
+#include "include/Sessions/autosave.h"
 #include <QFileDialog>
 #include <QSortFilterProxyModel>
 #include <QInputDialog>
@@ -44,6 +45,7 @@ frmPreferences::frmPreferences(TopEditorContainer *topEditorContainer, QWidget *
     ui->chkCheckQtVersionAtStartup->setChecked(m_settings.General.getCheckVersionAtStartup());
     ui->chkWarnForDifferentIndentation->setChecked(m_settings.General.getWarnForDifferentIndentation());
     ui->chkRememberSession->setChecked(m_settings.General.getRememberTabsOnExit());
+    ui->chkEnableAutosave->setChecked(m_settings.General.getEnableAutosaving());
 
     loadLanguages();
     loadAppearanceTab();
@@ -111,6 +113,12 @@ void frmPreferences::on_buttonBox_accepted()
     m_settings.General.setCheckVersionAtStartup(ui->chkCheckQtVersionAtStartup->isChecked());
     m_settings.General.setWarnForDifferentIndentation(ui->chkWarnForDifferentIndentation->isChecked());
     m_settings.General.setRememberTabsOnExit(ui->chkRememberSession->isChecked());
+    m_settings.General.setEnableAutosaving(ui->chkEnableAutosave->isChecked());
+
+    if (m_settings.General.getEnableAutosaving())
+        Autosave::enableAutosave();
+    else
+        Autosave::disableAutosave();
 
     saveLanguages();
     saveAppearanceTab();

--- a/src/ui/frmpreferences.ui
+++ b/src/ui/frmpreferences.ui
@@ -121,6 +121,13 @@
           </widget>
          </item>
          <item>
+          <widget class="QCheckBox" name="chkEnableAutosave">
+           <property name="text">
+            <string>Enable Autosaving</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <layout class="QFormLayout" name="formLayout">
            <item row="0" column="0">
             <widget class="QLabel" name="localizationLabel">
@@ -471,8 +478,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>403</width>
-              <height>196</height>
+              <width>356</width>
+              <height>205</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_3">

--- a/src/ui/include/Sessions/autosave.h
+++ b/src/ui/include/Sessions/autosave.h
@@ -3,9 +3,20 @@
 
 namespace Autosave {
 
+/**
+ * @brief restoreFromAutosave Reads the autosave sessions and recreates
+ *        all windows and their tabs.
+ */
 void restoreFromAutosave();
 
+/**
+ * @brief enableAutosave Starts periodic autosaving.
+ */
 void enableAutosave();
+
+/**
+ * @brief disableAutosave Stops periodic autosaving.
+ */
 void disableAutosave();
 
 } // namespace Autosave

--- a/src/ui/include/Sessions/autosave.h
+++ b/src/ui/include/Sessions/autosave.h
@@ -1,0 +1,14 @@
+#ifndef AUTOSAVE_H
+#define AUTOSAVE_H
+
+namespace Autosave {
+
+void restoreFromAutosave();
+
+void enableAutosave();
+void disableAutosave();
+
+} // namespace Autosave
+
+
+#endif // AUTOSAVE_H

--- a/src/ui/include/Sessions/persistentcache.h
+++ b/src/ui/include/Sessions/persistentcache.h
@@ -13,23 +13,22 @@ public:
     static QString cacheSessionPath();
 
     /**
-     * @brief Returns the path to where the cache is located.
-     *        Note the the cache directory will be created if it does not yet exist.
+     * @brief Returns the path to the directory that contains the tab cache.
      */
     static QString cacheDirPath();
 
     /**
-     * @brief Deletes the contents of the cache directory.
+     * @brief Returns the path to the directory that contains the autosave cache.
      */
-    static bool clearCacheDir();
+    static QString autosaveDirPath();
 
     /**
-     * @brief Generates a QUrl to a location within the cache directory.
-     * @param fileName The file name for the file. This must be a *file name*,
-     *        not a *file path*.
-     * @return QUrl to a location within the cache directory, file guaranteed not to exist yet.
+     * @brief Generates a QUrl to a file within the a directory.
+     * @param parent The parent directory for the file.
+     * @param fileName The file name for the file.
+     * @return QUrl to a location within the the directory, file guaranteed not to exist yet.
      */
-    static QUrl createValidCacheName(const QString& fileName);
+    static QUrl createValidCacheName(const QDir& parent, const QString& fileName);
 };
 
 #endif // PERSISTENTCACHE_H

--- a/src/ui/include/Sessions/sessions.h
+++ b/src/ui/include/Sessions/sessions.h
@@ -2,86 +2,29 @@
 #define SESSIONS_H
 
 #include <QString>
-#include <QXmlStreamReader>
-#include <QXmlStreamWriter>
-#include <QFile>
 
-#include <vector>
+class MainWindow;
 
-struct TabData {
-    QString filePath;
-    QString cacheFilePath;
-    int scrollX = 0;
-    int scrollY = 0;
-    bool active = false;
-    qint64 lastModified = 0;
-};
-
-struct ViewData {
-    std::vector<TabData> tabs;
-};
+namespace Sessions {
 
 /**
- * @brief Provides a convenience class to read session .xml files.
+ * @brief Saves a session as an XML file
+ * @param window The MainWindow whose tabs will be saved.
+ * @param sessionPath Path to where the XML file should be created.
+ * @param cacheDirPath Path to the directory where modified files will be written to. If
+ *        left empty, no files will be cached. All prior files inside the cache directory
+ *        will be deleted.
+ * @return Whether the save has been successful.
  */
-class SessionReader {
-public:
-
-    SessionReader(QFile& input)
-        : m_reader(&input) { }
-
-    /**
-     * @brief Completely read the session data
-     * @param outSuccess pass a pointer to bool here to be informed about whether
-     *        the reading process has encountered any errors.
-     * @return The data read from the session file.
-     */
-    std::vector<ViewData> readData(bool* outSuccess=nullptr);
-
-    QString getError();
-
-private:
-
-    /**
-     * @brief Helper functions to read specific parts of the xml structure
-     */
-    std::vector<ViewData> readViewData();
-    std::vector<TabData> readTabData();
-
-    QXmlStreamReader m_reader;
-};
-
+bool saveSession(MainWindow* window, QString sessionPath, QString cacheDirPath=QString());
 
 /**
- * @brief Provides a convenience class to write session .xml files.
- *
- * Note that a SessionWriter object must be successfully destroyed
- * in order to complete the writing process. (Aka the destructor must
- * be called)
+ * @brief Loads a session XML file and restores all its tabs in the specified window.
+ * @param window The MainWindow which will receive all loaded tabs.
+ * @param sessionPath Path to where the XML file is located.
  */
-class SessionWriter {
-public:
+void loadSession(MainWindow* window, QString sessionPath);
 
-    SessionWriter(QFile& destination);
-
-    ~SessionWriter();
-
-    /**
-     * @brief Write ViewData to the session file. ViewData is the representation of a
-     *        TabWidget and its tabs.
-     *
-     * @param The ViewData to be written.
-     */
-    void addViewData(const ViewData& vd);
-
-
-private:
-    /**
-     * @brief Helper function to write specific parts of the xml structure
-     */
-    void addTabData(const TabData& td);
-
-    QXmlStreamWriter m_writer;
-};
+} // namespace Autosave
 
 #endif // SESSIONS_H

--- a/src/ui/include/docengine.h
+++ b/src/ui/include/docengine.h
@@ -152,7 +152,15 @@ signals:
 
     void documentReloaded(EditorTabWidget *tabWidget, int tab);
 
-    void documentLoaded(EditorTabWidget *tabWidget, int tab, bool wasAlreadyOpened);
+    /**
+     * @brief The document has been successfully loaded.
+     * @param tabWidget The TabWidget that contains the loaded doc.
+     * @param tab The tab index of the loaded doc.
+     * @param wasAlreadyOpened True if the document was only reloaded.
+     * @param updateRecentDocuments True if the document should be remembered
+     *        as a recently opened file.
+     */
+    void documentLoaded(EditorTabWidget *tabWidget, int tab, bool wasAlreadyOpened, bool updateRecentDocuments);
 
 public slots:
 

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -57,6 +57,8 @@ public:
 
     TopEditorContainer *topEditorContainer();
 
+    void removeTabWidgetIfEmpty(EditorTabWidget *tabWidget);
+
     void openCommandLineProvidedUrls(const QString &workingDirectory, const QStringList &arguments);
 
     Editor*   currentEditor();
@@ -67,6 +69,12 @@ public:
     QList<QAction*> getActions() const;
     QList<const QMenu*> getMenus() const ;
 
+    DocEngine*  getDocEngine() const;
+    QString     getNewDocumentName();
+
+public slots:
+    void refreshEditorUiInfo(Editor *editor);
+
 protected:
     void closeEvent(QCloseEvent *event);
     void dragEnterEvent(QDragEnterEvent *e);
@@ -75,7 +83,6 @@ protected:
     void changeEvent(QEvent *e);
 
 private slots:
-    void refreshEditorUiInfo(Editor *editor);
     void refreshEditorUiCursorInfo(Editor *editor);
     void on_action_New_triggered();
     void on_customTabContextMenuRequested(QPoint point, EditorTabWidget *tabWidget, int tabIndex);
@@ -122,7 +129,7 @@ private slots:
     void on_bannerRemoved(QWidget *banner);
     void on_documentSaved(EditorTabWidget *tabWidget, int tab);
     void on_documentReloaded(EditorTabWidget *tabWidget, int tab);
-    void on_documentLoaded(EditorTabWidget *tabWidget, int tab, bool wasAlreadyOpened);
+    void on_documentLoaded(EditorTabWidget *tabWidget, int tab, bool wasAlreadyOpened, bool updateRecentDocs);
     void on_actionReload_from_Disk_triggered();
     void on_actionFind_Next_triggered();
     void on_actionFind_Previous_triggered();
@@ -209,34 +216,10 @@ private:
     QMap<QSharedPointer<Extensions::Extension>, QMenu*> m_extensionMenus;
 
     /**
-     * @brief Set to true to temporarily disallow updating recent docs. This is useful
-     *        for loading files that shouldn't be remembered (such as cache files).
-     */
-    bool                m_dontUpdateRecentDocs = false;
-
-    /**
-     * @brief Saves a session as an XML file
-     * @param filePath Path to where the XML file should be created.
-     * @param cacheModifiedFiles If true, dirty tabs will be written into the cache directory.
-     *        Only use this for the remember-my-tabs feature. Multiple sessions writing to
-     *        the cache directory will end up in data loss.
-     * @return Whether the save has been successful.
-     */
-    bool                saveSession(QString filePath, bool cacheModifiedFiles);
-
-    /**
-     * @brief Loads a session XML file and restores all its tabs in the current window.
-     * @param filePath Path to where the XML file is located.
-     */
-    void                loadSession(QString filePath);
-
-    /**
-     * @brief Functions specifically to save/restore tabs to/from cache. These utilize
-     *        the saveSession and loadSession functions and also save all unsaved progress
-     *        in the cache.
+     * @brief saveTabsToCache Saves tabs to cache. Utilizes the saveSession function and
+     *        saves all unsaved progress in the cache.
      */
     bool                saveTabsToCache();
-    void                restoreTabsFromCache();
 
     /**
      * @brief Acts like closing all tabs, asking to the user for input before discarding
@@ -247,7 +230,6 @@ private:
      */
     bool                finalizeAllTabs();
 
-    void                removeTabWidgetIfEmpty(EditorTabWidget *tabWidget);
     void                createStatusBar();
     int                 askIfWantToSave(EditorTabWidget *tabWidget, int tab, int reason);
 
@@ -292,7 +274,6 @@ private:
     QStringList         currentWordOrSelections();
     QString             currentWordOrSelection();
     void                currentWordOnlineSearch(const QString &searchUrl);
-    QString             getNewDocumentName();
 
     /**
      * @brief Workaround for this bug: https://bugs.launchpad.net/ubuntu/+source/appmenu-qt5/+bug/1313248

--- a/src/ui/include/nqqsettings.h
+++ b/src/ui/include/nqqsettings.h
@@ -76,6 +76,8 @@ public:
         NQQ_SETTING(ShowEOL,                        bool,       false)
 
         NQQ_SETTING(RememberTabsOnExit,             bool,       true)
+        NQQ_SETTING(EnableAutosaving,               bool,       false) // True if Nqq was closed normally, false otherwise.
+        NQQ_SETTING(ProperShutdown,                 bool,       true)
         NQQ_SETTING(LastSelectedDir,                QString,    ".")
         NQQ_SETTING(LastSelectedSessionDir,         QString,    QString())
         NQQ_SETTING(RecentDocuments,                QList<QVariant>, QList<QVariant>())

--- a/src/ui/include/nqqsettings.h
+++ b/src/ui/include/nqqsettings.h
@@ -76,8 +76,8 @@ public:
         NQQ_SETTING(ShowEOL,                        bool,       false)
 
         NQQ_SETTING(RememberTabsOnExit,             bool,       true)
-        NQQ_SETTING(EnableAutosaving,               bool,       false) // True if Nqq was closed normally, false otherwise.
-        NQQ_SETTING(ProperShutdown,                 bool,       true)
+        NQQ_SETTING(EnableAutosaving,               bool,       false)
+        NQQ_SETTING(ProperShutdown,                 bool,       true) // True if Nqq was closed normally, false otherwise.
         NQQ_SETTING(LastSelectedDir,                QString,    ".")
         NQQ_SETTING(LastSelectedSessionDir,         QString,    QString())
         NQQ_SETTING(RecentDocuments,                QList<QVariant>, QList<QVariant>())

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -9,6 +9,7 @@
 #include <QFile>
 #include <QtGlobal>
 #include <QTranslator>
+#include "include/Sessions/autosave.h"
 
 #ifdef QT_DEBUG
 #include <QElapsedTimer>
@@ -118,8 +119,22 @@ int main(int argc, char *argv[])
 #endif
     }
 
-    MainWindow *w = new MainWindow(QApplication::arguments(), 0);
-    w->show();
+    MainWindow *w;
+    if(settings.General.getEnableAutosaving() && !settings.General.getProperShutdown()) {
+        Autosave::restoreFromAutosave();
+    }
+
+    // If no autosave session was restored, or if the session was completely empty, we new up
+    // a new Window, otherwise there is at least one window open already.
+    if (MainWindow::instances().isEmpty()) {
+        w = new MainWindow(QApplication::arguments(), 0);
+        w->show();
+    } else {
+        w = MainWindow::instances().back();
+    }
+
+    if (settings.General.getEnableAutosaving())
+        Autosave::enableAutosave();
 
 #ifdef QT_DEBUG
     qint64 __aet_elapsed = __aet_timer.nsecsElapsed();
@@ -130,7 +145,11 @@ int main(int argc, char *argv[])
         Notepadqq::showQtVersionWarning(true, w);
     }
 
-    return a.exec();
+    settings.General.setProperShutdown(false);
+    const auto retVal = a.exec();
+    settings.General.setProperShutdown(true);
+
+    return retVal;
 }
 
 void checkQtVersion()

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -119,18 +119,19 @@ int main(int argc, char *argv[])
 #endif
     }
 
-    MainWindow *w;
     if(settings.General.getEnableAutosaving() && !settings.General.getProperShutdown()) {
         Autosave::restoreFromAutosave();
     }
 
     // If no autosave session was restored, or if the session was completely empty, we new up
     // a new Window, otherwise there is at least one window open already.
+    MainWindow* wnd = nullptr;
+
     if (MainWindow::instances().isEmpty()) {
-        w = new MainWindow(QApplication::arguments(), 0);
-        w->show();
+        wnd = new MainWindow(QApplication::arguments(), 0);
+        wnd->show();
     } else {
-        w = MainWindow::instances().back();
+        wnd = MainWindow::instances().back();
     }
 
     if (settings.General.getEnableAutosaving())
@@ -142,9 +143,11 @@ int main(int argc, char *argv[])
 #endif
 
     if (Notepadqq::oldQt() && settings.General.getCheckVersionAtStartup()) {
-        Notepadqq::showQtVersionWarning(true, w);
+        Notepadqq::showQtVersionWarning(true, wnd);
     }
 
+    // The ProperShutdown variable indicates whether Nqq was closed normally or crashed/etc.
+    // If it is 'false' then a.exec() never returned.
     settings.General.setProperShutdown(false);
     const auto retVal = a.exec();
     settings.General.setProperShutdown(true);

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -16,8 +16,9 @@
 #include "include/frmlinenumberchooser.h"
 #include "include/Extensions/Stubs/windowstub.h"
 #include "include/Extensions/installextension.h"
-#include <include/Sessions/persistentcache.h>
-#include <include/Sessions/sessions.h>
+#include "include/Sessions/persistentcache.h"
+#include "include/Sessions/sessions.h"
+#include "include/Sessions/autosave.h"
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QClipboard>
@@ -128,10 +129,12 @@ MainWindow::MainWindow(const QString &workingDirectory, const QStringList &argum
     // Initialize UI from settings
     initUI();
 
-
-    // We want to restore tabs only if the openeing window is the first one to be opened.
-    if (m_instances.size()==1 && m_settings.General.getRememberTabsOnExit()) {
-        restoreTabsFromCache();
+    // We want to restore tabs only if...
+    if (    m_instances.size()==1 && // this window is the first one to be opened,
+            m_settings.General.getRememberTabsOnExit() && // the Remember-tabs option is enabled
+            (m_settings.General.getProperShutdown() || !m_settings.General.getEnableAutosaving()) // and no restoration from the autosave feature is going on
+    ) {
+        Sessions::loadSession(this, PersistentCache::cacheSessionPath());
     }
 
     // Inserts at least an editor
@@ -362,212 +365,10 @@ void MainWindow::createStatusBar()
     scrollArea->setFixedHeight(frame->height());
 }
 
-
-bool MainWindow::saveSession(QString filePath, bool cacheModifiedFiles)
-{
-    std::vector<ViewData> viewData;
-
-    //Loop through all tabwidgets and their tabs
-    const int tabWidgetsCount = m_topEditorContainer->count();
-    for (int i = 0; i < tabWidgetsCount; i++) {
-        EditorTabWidget *tabWidget = m_topEditorContainer->tabWidget(i);
-        const int tabCount = tabWidget->count();
-
-        viewData.push_back( ViewData() );
-        ViewData& currentViewData = viewData.back();
-
-        for (int j = 0; j < tabCount; j++) {
-            Editor* editor = tabWidget->editor(j);
-            bool isClean = editor->isClean();
-            bool isOrphan = editor->fileName().isEmpty();
-
-            if (isOrphan && !cacheModifiedFiles)
-                continue; // Don't save temporary files if we're not caching tabs
-
-            TabData td;
-
-            if (!isClean && cacheModifiedFiles) {
-                // Tab is dirty, meaning it needs to be cached.
-                QUrl cacheFilePath = PersistentCache::createValidCacheName(tabWidget->tabText(j));
-
-                td.cacheFilePath = cacheFilePath.toLocalFile();
-
-                if (m_docEngine->saveDocument(tabWidget, j, cacheFilePath, true) != saveFileResult_Saved) {
-                    return false;
-                }
-            } else if (isOrphan) {
-                // Since we didn't cache the file and it is an orphan, we won't save it in the session.
-                continue;
-            }
-            // Else tab is an openened unmodified file, we don't have to do anything special.
-
-            td.filePath = !isOrphan ? editor->fileName().toLocalFile() : "" ;
-
-            // Finally save other misc information about the tab.
-            const auto& scrollPos = editor->scrollPosition();
-            td.scrollX = scrollPos.first;
-            td.scrollY = scrollPos.second;
-
-            td.active = tabWidget->currentEditor() == editor;
-
-            // If we're caching and there's a file opened in the tab we want to inform the
-            // user whether the file's contents have changed since Nqq was last opened.
-            // For this we save and later compare the modification date.
-            if (!isOrphan && cacheModifiedFiles) {
-                // As a special case, if the file has *already* changed we set the modification
-                // time to 1 so we always trigger the warning.
-                if (editor->fileOnDiskChanged())
-                    td.lastModified = 1;
-                else
-                    td.lastModified = QFileInfo(td.filePath).lastModified().toMSecsSinceEpoch();
-            }
-
-            currentViewData.tabs.push_back( td );
-
-        } // end for
-    } // end for
-
-    // Write all information to a session file
-    QFile file(filePath);
-    file.open(QIODevice::WriteOnly);
-
-    if (!file.isOpen())
-        return false;
-
-    SessionWriter sessionWriter(file);
-
-    for (const auto& view : viewData)
-        sessionWriter.addViewData(view);
-
-    return true;
-}
-
-void MainWindow::loadSession(QString filePath)
-{
-
-    QFile file(filePath);
-    file.open(QIODevice::ReadOnly);
-
-    if (!file.isOpen())
-        return;
-
-    SessionReader reader(file);
-
-    bool success = false;
-    const auto& views = reader.readData(&success);
-
-    if (!success || views.empty()) {
-        return;
-    }
-
-    m_dontUpdateRecentDocs = true;
-
-    int viewCounter = 0;
-    for (const auto& view : views) {
-        // Each new view must be created if it does not yet exist.
-        EditorTabWidget* tabW = m_topEditorContainer->tabWidget(viewCounter);
-        int activeIndex = 0;
-
-        if (!tabW)
-            tabW = m_topEditorContainer->addTabWidget();
-
-        viewCounter++;
-
-        for (const TabData& tab : view.tabs) {
-            const QFileInfo fileInfo(tab.filePath);
-            const bool fileExists = fileInfo.exists();
-            const bool cacheFileExists = QFileInfo(tab.cacheFilePath).exists();
-
-            const QUrl fileUrl = QUrl::fromLocalFile(tab.filePath);
-            const QUrl cacheFileUrl = QUrl::fromLocalFile(tab.cacheFilePath);
-
-            // This is the file to load the document from
-            const QUrl& loadUrl = cacheFileExists ? cacheFileUrl : fileUrl;
-
-            const bool success = m_docEngine->loadDocumentSilent(loadUrl, tabW);
-
-            if (!success)
-                continue;
-
-            int idx = tabW->findOpenEditorByUrl(loadUrl);
-
-            if (idx == -1)
-                continue;
-
-            // DocEngine sets the editor's fileName to loadUrl since this is where the file
-            // was loaded from. Since loadUrl could point to a cached file we reset it here.
-            Editor* editor = tabW->editor(idx);
-
-            if (cacheFileExists) {
-                editor->markDirty();
-                editor->setLanguageFromFileName();
-                // Since we loaded from cache we want to unmonitor the cache file.
-                m_docEngine->unmonitorDocument(editor);
-            }
-
-            if (fileExists) {
-                editor->setFileName(fileUrl);
-                m_docEngine->monitorDocument(editor);
-            } else {
-                editor->setFileName(QUrl());
-                tabW->setTabText(idx, getNewDocumentName());
-            }
-
-            // If we're loading an existing file from cache we want to inform the user whether
-            // the file has changed since Nqq was last closed. For this we can compare the
-            // file's last modification date.
-            if (fileExists && cacheFileExists && tab.lastModified != 0) {
-                auto lastModified = fileInfo.lastModified().toMSecsSinceEpoch();
-
-                if(lastModified > tab.lastModified)
-                    editor->setFileOnDiskChanged(true);
-            }
-
-            if(tab.active) activeIndex = idx;
-
-            editor->setScrollPosition(tab.scrollX, tab.scrollY);
-            editor->clearFocus();
-
-        } // end for
-
-        tabW->clearFocus();
-
-        // In case a new tabwidget was created but no tabs were actually added to it,
-        // we'll attempt to re-use the widget for the next view.
-        if (tabW->count() == 0)
-            viewCounter--;
-        else // Otherwise we finish by making the right tab the currently open one.
-            tabW->setCurrentIndex(activeIndex);
-
-    } // end for
-
-    m_dontUpdateRecentDocs = false;
-
-    // Stop if we haven't added any views at all, otherwise we have to clean up after ourselves.
-    if (viewCounter <= 0)
-        return;
-
-    // If the last tabwidget still has no tabs in it at this point, we'll have to delete it.
-    EditorTabWidget* lastTabW = m_topEditorContainer->tabWidget( m_topEditorContainer->count() -1);
-    removeTabWidgetIfEmpty(lastTabW);
-
-    // Give focus to the last tab of the first tab widget.
-    EditorTabWidget* firstTabW = m_topEditorContainer->tabWidget(0);
-    Editor* lastEditor = firstTabW->editor(lastTabW->count()-1);
-
-    lastEditor->setFocus();
-    refreshEditorUiInfo(lastEditor);
-
-    return;
-}
-
 bool MainWindow::saveTabsToCache()
 {
-    // If clearCacheDir() returns false, the cache directory is not writeable.
     // If saveSession() returns false, something went wrong. Most likely writing to the .xml file.
-    // In both cases we can present the same error message.
-    while (!PersistentCache::clearCacheDir() ||
-           !saveSession(PersistentCache::cacheSessionPath(), true)) {
+    while (!Sessions::saveSession(this, PersistentCache::cacheSessionPath(), PersistentCache::cacheDirPath())) {
         QMessageBox msgBox;
         msgBox.setWindowTitle(QCoreApplication::applicationName());
         msgBox.setText(tr("Error while trying to save this session. Please ensure the following directory is accessible:\n\n") + PersistentCache::cacheDirPath());
@@ -579,11 +380,6 @@ bool MainWindow::saveTabsToCache()
     }
 
     return true;
-}
-
-void MainWindow::restoreTabsFromCache()
-{
-    loadSession(PersistentCache::cacheSessionPath());
 }
 
 bool MainWindow::finalizeAllTabs()
@@ -606,6 +402,11 @@ bool MainWindow::finalizeAllTabs()
 
 QList<const QMenu*> MainWindow::getMenus() const {
     return ui->menuBar->findChildren<const QMenu*>(QString(), Qt::FindDirectChildrenOnly);
+}
+
+DocEngine* MainWindow::getDocEngine() const
+{
+    return m_docEngine;
 }
 
 //Return a list of all available action items in the menu
@@ -1826,13 +1627,13 @@ void MainWindow::on_documentReloaded(EditorTabWidget *tabWidget, int tab)
     }
 }
 
-void MainWindow::on_documentLoaded(EditorTabWidget *tabWidget, int tab, bool wasAlreadyOpened)
+void MainWindow::on_documentLoaded(EditorTabWidget *tabWidget, int tab, bool wasAlreadyOpened, bool updateRecentDocs)
 {
     Editor *editor = tabWidget->editor(tab);
 
     const int MAX_RECENT_ENTRIES = 10;
 
-    if(!m_dontUpdateRecentDocs){
+    if(updateRecentDocs){
         QUrl newUrl = editor->fileName();
         QList<QVariant> recentDocs = m_settings.General.getRecentDocuments();
         recentDocs.insert(0, QVariant(newUrl));
@@ -2449,18 +2250,19 @@ void MainWindow::on_actionLoad_Session_triggered()
                                m_settings.General.getLastSelectedSessionDir())
                                .toLocalFile();
 
-    QString fileName = QFileDialog::getOpenFileName(
+    QString filePath = QFileDialog::getOpenFileName(
                            this,
                            tr("Open Session..."),
                            recentFolder,
                            tr("Session file (*.xml);;Any file (*)"),
                            0, 0);
 
-    if (fileName.isEmpty())
+    if (filePath.isEmpty())
         return;
 
-    m_settings.General.setLastSelectedSessionDir(QFileInfo(fileName).dir().absolutePath());
-    loadSession(fileName);
+    m_settings.General.setLastSelectedSessionDir(QFileInfo(filePath).dir().absolutePath());
+
+    Sessions::loadSession(this, filePath);
 }
 
 void MainWindow::on_actionSave_Session_triggered()
@@ -2486,16 +2288,14 @@ void MainWindow::on_actionSave_Session_triggered()
     if (fileNames.empty())
         return;
 
-    QString fileName = fileNames[0];
+    QString filePath = fileNames[0];
 
-    if (fileName.isEmpty())
+    if (filePath.isEmpty())
         return;
 
-    m_settings.General.setLastSelectedSessionDir(QFileInfo(fileName).dir().absolutePath());
+    m_settings.General.setLastSelectedSessionDir(QFileInfo(filePath).dir().absolutePath());
 
-    // Do not try to cache sessions here. Only one session can ever be in the cache directory
-    // at any point in time.
-    if (saveSession(fileName, false)) {
+    if (Sessions::saveSession(this, filePath)) {
         QMessageBox msgBox;
         msgBox.setWindowTitle(QCoreApplication::applicationName());
         msgBox.setText(tr("Error while trying to save this session. Please try a different file name."));

--- a/src/ui/ui.pro
+++ b/src/ui/ui.pro
@@ -88,7 +88,8 @@ SOURCES += main.cpp\
     keygrabber.cpp \
     Sessions/sessions.cpp \
     Sessions/persistentcache.cpp \
-    nqqsettings.cpp
+    nqqsettings.cpp \
+    Sessions/autosave.cpp
 
 HEADERS  += include/mainwindow.h \
     include/topeditorcontainer.h \
@@ -132,7 +133,8 @@ HEADERS  += include/mainwindow.h \
     include/keygrabber.h \
     include/Sessions/sessions.h \
     include/Sessions/persistentcache.h \
-    include/nqqsettings.h
+    include/nqqsettings.h \
+    include/Sessions/autosave.h
 
 FORMS    += mainwindow.ui \
     frmabout.ui \


### PR DESCRIPTION
This PR seems larger than it actually is. Most additions/deletions come from moving the load/saveSession code from MainWindow into Sessions where it should have gone in the first place. A few of MainWindow's functions were made public to make this work.

How autosave works:
* If enabled (in the Settings) all windows will be periodically backed up. If Nqq isn't shut down properly, all windows and their tabs will be restored from that backup on next startup.
* All data is stored inside the .config/Notepadqq/autosaveCache directory.

Issues:
* The way it is right now the name "autosave" might be misleading since it is more of a "crash protection" right now. Autosave often implies that either the local file's are overwritten or the autosave can somehow be accessed.

* All windows are currently backed up every 5 seconds. What is annoying is that the system cannot detect whether any changes have been made to any of the tabs (aka whether making a new backup is necessary) which means you could leave Nqq running for days and it would dutifully re-backup every 5 seconds. I can't use `editor->isClean()` for this because I don't need to know whether any changes were made since the file was last saved but whether any changes were made since the last backup. This issue isn't a critical flaw but it's annoying that Nqq would potentially do so much unnecessary work.
References: #266, #128 