### PR TITLE
Language detection and a patch

### DIFF
--- a/src/ui/include/nqqsettings.h
+++ b/src/ui/include/nqqsettings.h
@@ -63,8 +63,7 @@ class NqqSettings {
 public:
 
     BEGIN_GENERAL_CATEGORY(General)
-        NQQ_SETTING(FirstRun,                       bool,       true)
-        NQQ_SETTING(Localization,                   QString,    "en")
+        NQQ_SETTING(Localization,                   QString,    "")
         NQQ_SETTING(CheckVersionAtStartup,          bool,       true)
         NQQ_SETTING(WarnForDifferentIndentation,    bool,       true)
 

--- a/src/ui/include/nqqsettings.h
+++ b/src/ui/include/nqqsettings.h
@@ -63,6 +63,7 @@ class NqqSettings {
 public:
 
     BEGIN_GENERAL_CATEGORY(General)
+        NQQ_SETTING(FirstRun,                       bool,       true)
         NQQ_SETTING(Localization,                   QString,    "en")
         NQQ_SETTING(CheckVersionAtStartup,          bool,       true)
         NQQ_SETTING(WarnForDifferentIndentation,    bool,       true)

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -48,7 +48,8 @@ int main(int argc, char *argv[])
 
     forceDefaultSettings();
 
-    //Initialize from system locale on first run
+    //Initialize from system locale on first run, if no system locale is
+    //set, our default will be used instead.
     if (settings.General.getFirstRun()) {
         QLocale locale;
         //ISO 639 dictates language code will always be 2 letters

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -50,13 +50,14 @@ int main(int argc, char *argv[])
 
     //Initialize from system locale on first run, if no system locale is
     //set, our default will be used instead.
-    if (settings.General.getFirstRun()) {
+    if (settings.General.getLocalization().isEmpty()) {
         QLocale locale;
         //ISO 639 dictates language code will always be 2 letters
         if (locale.name().size() >= 2) {
             settings.General.setLocalization(locale.name().left(2));
+        } else {
+            settings.General.setLocalization("en");
         }
-        settings.General.setFirstRun(false);
     }
 
     QString langCode = settings.General.getLocalization();
@@ -74,7 +75,6 @@ int main(int argc, char *argv[])
                                .arg(qApp->applicationName().toLower()))) {
         a.installTranslator(&translator);
     } else {
-        //Language translations probably don't exist, default to en
         settings.General.setLocalization("en");
     }
 

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -70,7 +70,7 @@ int main(int argc, char *argv[])
     } else if (translator.load(QLocale(langCode),
                                QString("%1").arg(qApp->applicationName().toLower()),
                                QString("_"),
-                               QString("%1/../share/%2/translations")
+                               QString("%1/../../share/%2/translations")
                                .arg(qApp->applicationDirPath())
                                .arg(qApp->applicationName().toLower()))) {
         a.installTranslator(&translator);


### PR DESCRIPTION
This resolves issue #281 in full.  It tries to detect default system locale by default, and if the translation for that locale doesn't exist defaults back to English. 

I'll need a couple of people to test this to make sure the patch @david-geiger sent in doesn't cause any issues for anyone else.  I used `export LANG=fr_CA.UTF-8` to test and it seemed to work okay on my end.