### PR TITLE
Add support for string literals in replace.

### DIFF
--- a/src/ui/Search/frmsearchreplace.cpp
+++ b/src/ui/Search/frmsearchreplace.cpp
@@ -147,6 +147,9 @@ void frmSearchReplace::search(QString string, SearchHelpers::SearchMode searchMo
 void frmSearchReplace::replace(QString string, QString replacement, SearchHelpers::SearchMode searchMode, bool forward, SearchHelpers::SearchOptions searchOptions) {
     if (!string.isEmpty()) {
         QString rawSearch = SearchString::toRaw(string, searchMode, searchOptions);
+        if (searchMode == SearchHelpers::SearchMode::SpecialChars) {
+            replacement = SearchString::unescape(replacement);
+        }
 
         Editor *editor = currentEditor();
 
@@ -166,6 +169,9 @@ void frmSearchReplace::replace(QString string, QString replacement, SearchHelper
 
 int frmSearchReplace::replaceAll(QString string, QString replacement, SearchHelpers::SearchMode searchMode, SearchHelpers::SearchOptions searchOptions) {
     QString rawSearch = SearchString::toRaw(string, searchMode, searchOptions);
+    if (searchMode == SearchHelpers::SearchMode::SpecialChars) {
+            replacement = SearchString::unescape(replacement);
+    }
 
     QList<QVariant> data = QList<QVariant>();
     data.append(rawSearch);


### PR DESCRIPTION
This is a really small change which basically hooks into SearchString::unescape and allows use of string literals for replacement text.  I believe this fixes #223.