### PR TITLE
Update translations, new support

### DIFF
--- a/notepadqq_it.ts
+++ b/notepadqq_it.ts
@@ -1,0 +1,1823 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="1.0" language="it_IT">
+<context>
+    <name>BannerFileChanged</name>
+    <message>
+        <location filename="../ui/EditorNS/bannerfilechanged.cpp" line="13"/>
+        <source>This file has been changed outside of Notepadqq.</source>
+        <translation>Questo file è stato modificato al di fuori di Notepadqq.</translation>
+    </message>
+    <message>
+        <location filename="../ui/EditorNS/bannerfilechanged.cpp" line="15"/>
+        <source>Reload</source>
+        <translation>Ricarica</translation>
+    </message>
+    <message>
+        <location filename="../ui/EditorNS/bannerfilechanged.cpp" line="18"/>
+        <source>Ignore</source>
+        <translation>Ignora</translation>
+    </message>
+</context>
+<context>
+    <name>BannerFileRemoved</name>
+    <message>
+        <location filename="../ui/EditorNS/bannerfileremoved.cpp" line="13"/>
+        <source>This file has been deleted from the file system.</source>
+        <translation>Questo file è stato eliminato dal file system.</translation>
+    </message>
+    <message>
+        <location filename="../ui/EditorNS/bannerfileremoved.cpp" line="15"/>
+        <source>Save</source>
+        <translation>Salva</translation>
+    </message>
+    <message>
+        <location filename="../ui/EditorNS/bannerfileremoved.cpp" line="18"/>
+        <source>Ignore</source>
+        <translation>Ignora</translation>
+    </message>
+</context>
+<context>
+    <name>BannerIndentationDetected</name>
+    <message>
+        <location filename="../ui/EditorNS/bannerindentationdetected.cpp" line="18"/>
+        <source>This file is indented with %1, but your current settings specify to use %2.</source>
+        <translation>Questo file è indentato con %1, ma le correnti impostazioni specificano di utilizzare %2.</translation>
+    </message>
+    <message>
+        <location filename="../ui/EditorNS/bannerindentationdetected.cpp" line="20"/>
+        <location filename="../ui/EditorNS/bannerindentationdetected.cpp" line="25"/>
+        <source>spaces</source>
+        <translation>spazi</translation>
+    </message>
+    <message>
+        <location filename="../ui/EditorNS/bannerindentationdetected.cpp" line="20"/>
+        <location filename="../ui/EditorNS/bannerindentationdetected.cpp" line="25"/>
+        <source>tabs</source>
+        <translation>tabulazioni</translation>
+    </message>
+    <message>
+        <location filename="../ui/EditorNS/bannerindentationdetected.cpp" line="22"/>
+        <source>Use spaces</source>
+        <translation>Usa spazi</translation>
+    </message>
+    <message>
+        <location filename="../ui/EditorNS/bannerindentationdetected.cpp" line="27"/>
+        <source>Use tabs</source>
+        <translation>Usa tabulazioni</translation>
+    </message>
+    <message>
+        <location filename="../ui/EditorNS/bannerindentationdetected.cpp" line="31"/>
+        <source>This file is indented with %1 spaces, but your current settings specify to use %2 spaces.</source>
+        <translation>Questo file è indentato con %1 spazi ma le correnti impostazioni specificano di utilizzarne %2.</translation>
+    </message>
+    <message>
+        <location filename="../ui/EditorNS/bannerindentationdetected.cpp" line="34"/>
+        <source>Use %1 spaces</source>
+        <translation>Usa %1 spazi</translation>
+    </message>
+    <message>
+        <location filename="../ui/EditorNS/bannerindentationdetected.cpp" line="38"/>
+        <source>Ignore</source>
+        <translation>Ignora</translation>
+    </message>
+</context>
+<context>
+    <name>DocEngine</name>
+    <message>
+        <location filename="../ui/docengine.cpp" line="33"/>
+        <source>new %1</source>
+        <translation>nuovo %1</translation>
+    </message>
+    <message>
+        <location filename="../ui/docengine.cpp" line="182"/>
+        <source>Error trying to open &quot;%1&quot;</source>
+        <translation>Riscontrato errore durante il tentativo di aprire &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../ui/docengine.cpp" line="257"/>
+        <location filename="../ui/docengine.cpp" line="452"/>
+        <source>Protocol not supported for file &quot;%1&quot;.</source>
+        <translation>Protocollo non supportato per il file &quot;%1&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../ui/docengine.cpp" line="412"/>
+        <source>Error trying to write to &quot;%1&quot;</source>
+        <translation>Riscontrato errore durante il tentativo di scrivere &quot;%1&quot;</translation>
+    </message>
+</context>
+<context>
+    <name>Extension</name>
+    <message>
+        <location filename="../ui/Extensions/extension.cpp" line="22"/>
+        <source>name missing or invalid</source>
+        <translation>nome mancante o non valido</translation>
+    </message>
+    <message>
+        <location filename="../ui/Extensions/extension.cpp" line="50"/>
+        <source>unable to read nqq-manifest.json</source>
+        <translation>impossibile leggere nqq-manifest.json</translation>
+    </message>
+    <message>
+        <location filename="../ui/Extensions/extension.cpp" line="97"/>
+        <source>failed to start. Check your runtime: %1</source>
+        <translation>Impossibile avviare. Controllare l&apos;ambiente di runtime: %1</translation>
+    </message>
+    <message>
+        <location filename="../ui/Extensions/extension.cpp" line="106"/>
+        <source>Failed to load %1: %2</source>
+        <translation>Caricamento fallito %1: %2</translation>
+    </message>
+</context>
+<context>
+    <name>Extensions::InstallExtension</name>
+    <message>
+        <location filename="../ui/Extensions/installextension.cpp" line="177"/>
+        <source>Error</source>
+        <translation>Errore</translation>
+    </message>
+    <message>
+        <location filename="../ui/Extensions/installextension.cpp" line="177"/>
+        <source>Unsupported runtime: %1</source>
+        <translation>Ambiente d&apos;esecuzione non supportato: %1</translation>
+    </message>
+</context>
+<context>
+    <name>FileSearchResultsWidget</name>
+    <message>
+        <location filename="../ui/Search/filesearchresultswidget.cpp" line="29"/>
+        <source>Clear</source>
+        <translation>Pulisci</translation>
+    </message>
+</context>
+<context>
+    <name>InstallExtension</name>
+    <message>
+        <location filename="../ui/Extensions/installextension.ui" line="14"/>
+        <source>Install Extension</source>
+        <translation>Installa estensione</translation>
+    </message>
+    <message>
+        <location filename="../ui/Extensions/installextension.ui" line="102"/>
+        <source>Cancel</source>
+        <translation>Annulla</translation>
+    </message>
+    <message>
+        <location filename="../ui/Extensions/installextension.ui" line="109"/>
+        <source>Install</source>
+        <translation>Installa</translation>
+    </message>
+    <message>
+        <location filename="../ui/Extensions/installextension.cpp" line="42"/>
+        <source>Version %1, %2</source>
+        <translation>Versione %1, %2</translation>
+    </message>
+    <message>
+        <location filename="../ui/Extensions/installextension.cpp" line="43"/>
+        <location filename="../ui/Extensions/installextension.cpp" line="52"/>
+        <source>unknown version</source>
+        <translation>versione sconosciuta</translation>
+    </message>
+    <message>
+        <location filename="../ui/Extensions/installextension.cpp" line="44"/>
+        <source>unknown author</source>
+        <translation>autore sconosciuto</translation>
+    </message>
+    <message>
+        <location filename="../ui/Extensions/installextension.cpp" line="54"/>
+        <source>(current version is %1)</source>
+        <translation>(la versione corrente è %1)</translation>
+    </message>
+    <message>
+        <location filename="../ui/Extensions/installextension.cpp" line="55"/>
+        <source>Update</source>
+        <translation>Aggiornare</translation>
+    </message>
+    <message>
+        <location filename="../ui/Extensions/installextension.cpp" line="104"/>
+        <location filename="../ui/Extensions/installextension.cpp" line="126"/>
+        <source>Error installing the extension</source>
+        <translation>Errore durante l&apos;installazione dell&apos;estensione</translation>
+    </message>
+    <message>
+        <location filename="../ui/Extensions/installextension.cpp" line="115"/>
+        <source>Extension installed</source>
+        <translation>Estensione installata</translation>
+    </message>
+    <message>
+        <location filename="../ui/Extensions/installextension.cpp" line="116"/>
+        <source>The extension has been successfully installed!</source>
+        <translation>L&apos;estensione è stata installata con successo!</translation>
+    </message>
+</context>
+<context>
+    <name>KeyGrabber</name>
+    <message>
+        <location filename="../ui/keygrabber.cpp" line="13"/>
+        <source>Action</source>
+        <translation>Azione</translation>
+    </message>
+    <message>
+        <location filename="../ui/keygrabber.cpp" line="13"/>
+        <source>Keyboard Shortcut</source>
+        <translation>Tasto scorciatoia</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="14"/>
+        <source>Notepadqq</source>
+        <translation>Notepadqq</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="50"/>
+        <source>&amp;File</source>
+        <translation>&amp;File</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="54"/>
+        <source>Recent Files</source>
+        <translation>File recenti</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="81"/>
+        <source>&amp;Edit</source>
+        <translation>&amp;Modifica</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="85"/>
+        <source>End of line</source>
+        <translation>Formato EOL</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="93"/>
+        <source>Copy to Clipboard</source>
+        <translation>Copia negli appunti</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="101"/>
+        <source>Convert Case to</source>
+        <translation>Converti caratteri</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="108"/>
+        <source>Indentation</source>
+        <translation>Indentazione</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="117"/>
+        <source>Line Operations</source>
+        <translation>Operazioni sulle linee</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="126"/>
+        <source>Blank Operations</source>
+        <translation>Operazioni sugli spazi</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="155"/>
+        <source>&amp;Search</source>
+        <translation>&amp;Cerca</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="168"/>
+        <source>&amp;View</source>
+        <translation>&amp;Visualizza</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="172"/>
+        <source>Show Symbol</source>
+        <translation>Simboli</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="184"/>
+        <source>Zoom</source>
+        <translation>Zoom</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="192"/>
+        <source>Move/Clone Current Document</source>
+        <translation>Sposta/Clona documento corrente</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="211"/>
+        <source>Encoding</source>
+        <translation>Codifica</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="229"/>
+        <source>&amp;Language</source>
+        <translation>&amp;Linguaggio</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="236"/>
+        <source>Se&amp;ttings</source>
+        <translation>&amp;Configurazione</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="242"/>
+        <source>&amp;?</source>
+        <translation>&amp;?</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="249"/>
+        <source>Run</source>
+        <translation>Esegui</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="256"/>
+        <source>&amp;Window</source>
+        <translation>&amp;Finestra</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="262"/>
+        <source>Extensions</source>
+        <translation>Estensioni</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="281"/>
+        <source>Toolbar</source>
+        <translation>Barra degli strumenti</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="325"/>
+        <source>Find result</source>
+        <translation>Risultato ricerca</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="349"/>
+        <source>&amp;Open...</source>
+        <translation>&amp;Apri...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="352"/>
+        <source>Ctrl+O</source>
+        <translation>Ctrl+O</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="357"/>
+        <source>&amp;New</source>
+        <translation>&amp;Nuovo</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="360"/>
+        <source>Ctrl+N</source>
+        <translation>Ctrl+N</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="365"/>
+        <source>Reload from Disk</source>
+        <translation>Ricarica dal disco</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="370"/>
+        <source>&amp;Save</source>
+        <translation>&amp;Salva</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="373"/>
+        <source>Ctrl+S</source>
+        <translation>Ctrl+S</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="378"/>
+        <source>Save &amp;As...</source>
+        <translation>Salva &amp;come...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="381"/>
+        <source>Save As...</source>
+        <translation>Salva come...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="384"/>
+        <source>Ctrl+Alt+S</source>
+        <translation>Ctrl+Alt+S</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="389"/>
+        <source>Save a Copy As...</source>
+        <translation>Salva una copia come...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="394"/>
+        <source>Sav&amp;e All</source>
+        <translation>Salva&amp; tutto</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="397"/>
+        <source>Ctrl+Shift+S</source>
+        <translation>Ctrl+Shift+S</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="402"/>
+        <source>Rename...</source>
+        <translation>Rinomina...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="407"/>
+        <source>Close</source>
+        <translation>Chiudi</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="410"/>
+        <source>Ctrl+W</source>
+        <translation>Ctrl+W</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="415"/>
+        <source>C&amp;lose All</source>
+        <translation>Chiudi &amp;tutti</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="420"/>
+        <source>Close All BUT Current Document</source>
+        <translation>Chiudi tutti tranne il documento corrente</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="425"/>
+        <source>Load Session...</source>
+        <translation>Carica sessione...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="430"/>
+        <source>Save Session...</source>
+        <translation>Salva la sessione...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="435"/>
+        <source>Print...</source>
+        <translation>Stampa...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="438"/>
+        <source>Ctrl+P</source>
+        <translation>Ctrl+P</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="446"/>
+        <source>Print Now</source>
+        <translation>Stampa subito!</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="454"/>
+        <source>Open All Recent Files</source>
+        <translation>Apri tutti i file recenti</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="459"/>
+        <source>Empty Recent Files List</source>
+        <translation>Pulisci lista file recenti</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="464"/>
+        <source>E&amp;xit</source>
+        <translation>E&amp;sci</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="467"/>
+        <source>Alt+F4</source>
+        <translation>Alt+F4</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="472"/>
+        <source>&amp;Undo</source>
+        <translation>&amp;Annulla</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="475"/>
+        <source>Ctrl+Z</source>
+        <translation>Ctrl+Z</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="480"/>
+        <source>&amp;Redo</source>
+        <translation>&amp;Ripristina</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="483"/>
+        <source>Ctrl+Y</source>
+        <translation>Ctrl+Y</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="488"/>
+        <source>Cu&amp;t</source>
+        <translation>Ta&amp;glia</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="491"/>
+        <source>Ctrl+X</source>
+        <translation>Ctrl+X</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="496"/>
+        <source>&amp;Copy</source>
+        <translation>&amp;Copia</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="499"/>
+        <source>Ctrl+C</source>
+        <translation>Ctrl+C</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="504"/>
+        <source>&amp;Paste</source>
+        <translation>&amp;Incolla</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="507"/>
+        <source>Ctrl+V</source>
+        <translation>Ctrl+V</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="512"/>
+        <source>&amp;Delete</source>
+        <translation>&amp;Elimina</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="515"/>
+        <source>Del</source>
+        <translation>Canc</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="520"/>
+        <source>Select &amp;All</source>
+        <translation>&amp;Seleziona tutto</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="523"/>
+        <source>Ctrl+A</source>
+        <translation>Ctrl+A</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="528"/>
+        <source>About Notepadqq...</source>
+        <translation>Informazioni su Notepadqq...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="531"/>
+        <source>F1</source>
+        <translation>F1</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="536"/>
+        <source>About Qt...</source>
+        <translation>Altro su Qt...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="544"/>
+        <source>Windows Format</source>
+        <translation>Formato Windows</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="555"/>
+        <source>UNIX / OS X Format</source>
+        <translation>Formato UNIX / OS X</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="563"/>
+        <source>Old Mac Format</source>
+        <translation>Vecchio formato Mac</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="571"/>
+        <source>Show End of Line</source>
+        <translation>Mostra caratteri di fine riga</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="579"/>
+        <source>Show Tabs</source>
+        <translation>Mostra tabulazioni</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="587"/>
+        <source>Show All Characters</source>
+        <translation>Mostra tutti i caratteri</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="598"/>
+        <source>Show Indent Guide</source>
+        <translation>Mostra guide di indentazione</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="606"/>
+        <source>Show Wrap Symbol</source>
+        <translation>Mostra simbolo a capo automatico</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="614"/>
+        <source>Word wrap</source>
+        <translation>Attiva a copo automatico</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="622"/>
+        <source>Text Direction RTL</source>
+        <translation>Direzione testo RTL</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="627"/>
+        <source>Copy Full Path to Clipboard</source>
+        <translation>Percorso file corrente</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="632"/>
+        <source>Copy Filename to Clipboard</source>
+        <translation>Nome file corrente</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="637"/>
+        <source>Copy Directory to Clipboard</source>
+        <translation>Cartella corrente</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="642"/>
+        <source>Zoom &amp;In</source>
+        <translation>Aumenta &amp;zoom</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="645"/>
+        <source>Ctrl++</source>
+        <translation>Ctrl++</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="650"/>
+        <source>Zoom &amp;Out</source>
+        <translation>Diminuisci &amp;zoom</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="653"/>
+        <source>Ctrl+-</source>
+        <translation>Ctrl+-</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="658"/>
+        <source>Restore Default Zoom</source>
+        <translation>Ripristina lo zoom predefinito</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="661"/>
+        <source>Ctrl+0</source>
+        <translation>Ctrl+0</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="666"/>
+        <source>Move to Other View</source>
+        <translation>Sposta nell&apos;altra vista</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="671"/>
+        <source>Clone to Other View</source>
+        <translation>Copia nell&apos;altra vista</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="676"/>
+        <source>Move to a New Window</source>
+        <translation>Sposta in una nuova finestra</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="681"/>
+        <source>Open in a New Window</source>
+        <translation>Apri in una nuova finestra</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="686"/>
+        <source>&amp;Start Recording</source>
+        <translation>&amp;Inizia registrazione</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="697"/>
+        <source>&amp;Stop Recording</source>
+        <translation>&amp;Ferma registrazione</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="708"/>
+        <source>&amp;Playback</source>
+        <translation>&amp;Esegui la macro</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="719"/>
+        <source>Save Currently Recorded Macro</source>
+        <translation>Salva la macro registrata</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="727"/>
+        <source>Run a Macro Multiple Times...</source>
+        <translation>Esegui la macro più volte...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="735"/>
+        <source>Trim Trailing and save</source>
+        <translation>Rimuovere gli spazi di fine riga e salvare</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="740"/>
+        <source>Modify Shortcut/Delete Macro...</source>
+        <translation>Modificare scorciatoia/Eliminare macro...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="745"/>
+        <source>UPPERCASE</source>
+        <translation>MAIUSCOLE</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="748"/>
+        <source>Ctrl+Shift+U</source>
+        <translation>Ctrl+Shift+U</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="753"/>
+        <source>lowercase</source>
+        <translation>minuscule</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="756"/>
+        <source>Ctrl+U</source>
+        <translation>Ctrl+U</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="761"/>
+        <source>Convert to UTF-8</source>
+        <translation>Converti in UTF-8</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="766"/>
+        <source>Convert to UTF-16BE (UCS-2 Big Endian)</source>
+        <translation>Converti in UTF-16BE (UCS-2 Big Endian)</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="771"/>
+        <source>Convert to UTF-16LE (UCS-2 Little Endian)</source>
+        <translation>Converti in UTF-16LE (UCS-2 Little Endian)</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="776"/>
+        <source>Convert to UTF-8 without BOM</source>
+        <translation>Converti in UTF-8 (senza BOM)</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="781"/>
+        <source>&amp;Run...</source>
+        <translation>&amp;Esegui...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="786"/>
+        <source>Launch in Firefox</source>
+        <translation>Apri in Firefox</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="791"/>
+        <source>Launch in Chromium</source>
+        <translation>Apri in Chromium</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="796"/>
+        <source>Get PHP help</source>
+        <translation>Supporto PHP online</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="801"/>
+        <source>Google Search</source>
+        <translation>Cerca su Google</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="806"/>
+        <source>Wikipedia Search</source>
+        <translation>Cerca su Wikipédia</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="811"/>
+        <source>Open file(s)</source>
+        <translation>Apri file</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="816"/>
+        <source>Open file(s) in a new window</source>
+        <translation>Apri file in una nuova finestra</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="821"/>
+        <source>Modify Shortcut / Delete Command...</source>
+        <translation>Modificare scorciatoia / Elimina comando...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="826"/>
+        <source>Preferences...</source>
+        <translation>Preferenze...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="831"/>
+        <source>&amp;Find...</source>
+        <translation>&amp;Trova...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="834"/>
+        <source>Ctrl+F</source>
+        <translation>Ctrl+F</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="839"/>
+        <source>Find &amp;Next</source>
+        <translation>Trova &amp;successivo</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="842"/>
+        <source>F3</source>
+        <translation>F3</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="847"/>
+        <source>Find &amp;Previous</source>
+        <translation>Trova &amp;precedente</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="850"/>
+        <source>Shift+F3</source>
+        <translation>Shift+F3</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="855"/>
+        <source>Plain text</source>
+        <translation>Testo normale</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="860"/>
+        <source>Replace...</source>
+        <translation>Sostituisci...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="863"/>
+        <source>Ctrl+H</source>
+        <translation>Ctrl+H</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="868"/>
+        <source>Reload file interpreted as...</source>
+        <translation>Ricarica file interpretandolo come...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="873"/>
+        <source>Convert to...</source>
+        <translation>Converti in...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="878"/>
+        <source>Interpret as UTF-16BE (UCS-2 Big Endian)</source>
+        <translation>Interpreta come UTF-16BE (UCS-2 Big Endian)</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="883"/>
+        <source>Interpret as UTF-8 without BOM</source>
+        <translation>Interpreta come UTF-8 sans BOM</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="888"/>
+        <source>Interpret as UTF-8</source>
+        <translation>Interpreta come UTF-8</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="893"/>
+        <source>Interpret as UTF-16LE (UCS-2 Little Endian)</source>
+        <translation>Interpreta come UTF-16LE  (UCS-2 Little Endian)</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="904"/>
+        <source>Default settings</source>
+        <translation>Impostazioni predefinite</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="912"/>
+        <source>Custom...</source>
+        <translation>Personalizzata...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="917"/>
+        <source>Interpret as...</source>
+        <translation>Interpreta come...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="922"/>
+        <source>Launch in Chrome</source>
+        <translation>Apri in Chrome</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="927"/>
+        <source>Open a New Window</source>
+        <translation>Aprire una nuova finestra</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="932"/>
+        <source>Find in Files...</source>
+        <translation>Cerca nei file...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="935"/>
+        <source>Ctrl+Shift+F</source>
+        <translation>Ctrl+Shift+F</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="940"/>
+        <source>Delete Current Line</source>
+        <translation>Elimina riga corrente</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="943"/>
+        <source>Delete the current line</source>
+        <translation>Elimina la riga corrente</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="946"/>
+        <source>Ctrl+L</source>
+        <translation>Ctrl+L</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="951"/>
+        <source>Duplicate Current Line</source>
+        <translation>Duplica riga corrente</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="954"/>
+        <source>Duplicate the current line</source>
+        <translation>Duplica la riga corrente</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="957"/>
+        <source>Ctrl+D</source>
+        <translation>Ctrl+D</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="962"/>
+        <source>Move Line Up</source>
+        <translation>Sposta riga in su</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="965"/>
+        <source>Move the current line up</source>
+        <translation>Sposta in su la riga corrente</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="968"/>
+        <source>Ctrl+Shift+Up</source>
+        <translation>Ctrl+Shift+Up</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="973"/>
+        <source>Move Line Down</source>
+        <translation>Sposta riga in giù</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="976"/>
+        <source>Move the current line down</source>
+        <translation>Sposta in giù la riga corrente</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="979"/>
+        <source>Ctrl+Shift+Down</source>
+        <translation>Ctrl+Shift+Down</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="984"/>
+        <location filename="../ui/mainwindow.ui" line="987"/>
+        <source>Trim Trailing Space</source>
+        <translation>Elimina spazi a fine riga</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="992"/>
+        <location filename="../ui/mainwindow.ui" line="995"/>
+        <source>Trim Leading Space</source>
+        <translation>Elimina spazi iniziali</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="1000"/>
+        <source>Trim Leading and Trailing Space</source>
+        <translation>Elimina spazi iniziali e finali</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="1005"/>
+        <source>EOL to Space</source>
+        <translation>Converti EOL in Spazio</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="1010"/>
+        <source>TAB to Space</source>
+        <translation>Converti TAB in spazi</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="1015"/>
+        <source>Space to TAB (All)</source>
+        <translation>Converti spazi in tabulazioni (ovunque)</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="1020"/>
+        <source>Space to TAB (Leading)</source>
+        <translation>Converti spazi in tabulazioni (a inizio riga)</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="1025"/>
+        <source>Open Folder...</source>
+        <translation>Apri cartella...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="1030"/>
+        <source>Go to line...</source>
+        <translation>Vai alla riga...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="1033"/>
+        <source>Ctrl+G</source>
+        <translation>Ctrl+G</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="1038"/>
+        <source>Install Extension...</source>
+        <translation>Installare un&apos;estensione...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="1046"/>
+        <source>Full Screen</source>
+        <translation>Schermo intero</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="1049"/>
+        <source>F11</source>
+        <translation>F11</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="1057"/>
+        <location filename="../ui/mainwindow.ui" line="1060"/>
+        <source>Show Spaces</source>
+        <translation>Mostra spazi</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="1071"/>
+        <source>Enable Smart Indent</source>
+        <translation>Attiva indentazione intelligente</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="349"/>
+        <location filename="../ui/mainwindow.cpp" line="633"/>
+        <source>INS</source>
+        <translation>INS</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="377"/>
+        <source>Error while trying to save this session. Please ensure the following directory is accessible:
+
+</source>
+        <translation>Errore nel tentativo di salvare la sessione. Assicurarsi che la seguente directory sia accessibile:
+</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="631"/>
+        <source>OVR</source>
+        <translation>OVR</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="755"/>
+        <source>Your changes to «%1» will be discarded.</source>
+        <translation>Le modifiche di «%1» saranno annullate.</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="756"/>
+        <source>Reload</source>
+        <translation>Ricarica</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="794"/>
+        <source>Open</source>
+        <translation>Apri</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="796"/>
+        <source>All files (*)</source>
+        <translation>Tutti i file (*)</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="814"/>
+        <source>Open Folder</source>
+        <translation>Apri cartella</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="854"/>
+        <source>Do you want to save changes to «%1»?</source>
+        <translation>Vuoi salvare le modifiche a «%1»?</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="855"/>
+        <source>Don&apos;t Save</source>
+        <translation>Non salvare</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="858"/>
+        <source>Do you want to save changes to «%1» before closing?</source>
+        <translation>Vuoi salvare le modifiche a «%1» prima di uscire? </translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="862"/>
+        <source>If you don&apos;t save the changes you made, you&apos;ll lose them forever.</source>
+        <translation>Se non si salvano le modifiche, queste verrano perse in modo permanente.</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="962"/>
+        <source>The file on disk has changed since the last read.
+Do you want to save it anyway?</source>
+        <translation>Il file su disco, è stato modificato dopo l&apos;ultima lettura.
+Vuoi salvare comunque?</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="965"/>
+        <source>Saving the file might cause loss of external data.</source>
+        <translation>Salvare il file potrebbe causare la perdita di dati esterni.</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="984"/>
+        <source>Save as</source>
+        <translation>Salva come</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="986"/>
+        <source>Any file (*)</source>
+        <translation>Tutti i file (*)</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="1151"/>
+        <source>%1 chars, %2 lines</source>
+        <translation>%1 caratteri, %2 linee</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="1162"/>
+        <source>Ln %1, col %2</source>
+        <translation>Ln %1, col %2</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="1166"/>
+        <source>Sel %1 (%2)</source>
+        <translation>Sel %1 (%2)</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="1230"/>
+        <source>Windows</source>
+        <translation>Windows</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="1233"/>
+        <source>UNIX / OS X</source>
+        <translation>UNIX / OS X</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="1236"/>
+        <source>Old Mac</source>
+        <translation>Vecchio formato Mac</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="1243"/>
+        <source>%1 w/o BOM</source>
+        <translation>%1 senza BOM</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="1719"/>
+        <source>No recent files</source>
+        <translation>Nessun file recente</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="1883"/>
+        <source>Convert to:</source>
+        <translation>Convertire in:</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="1897"/>
+        <source>Reload as:</source>
+        <translation>Ricarica come:</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="1939"/>
+        <source>Interpret as:</source>
+        <translation>Interpretare come:</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="1954"/>
+        <source>Run...</source>
+        <translation>Esegui...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="1966"/>
+        <source>Modify Run Commands</source>
+        <translation>Gestisci comandi</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="2246"/>
+        <source>Extension</source>
+        <translation>Estensione</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="2291"/>
+        <source>Open Session...</source>
+        <translation>Apri sessione...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="2293"/>
+        <location filename="../ui/mainwindow.cpp" line="2313"/>
+        <source>Session file (*.xml);;Any file (*)</source>
+        <translation>File di sessione (*.xml);;Tutti i file (*)</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="2311"/>
+        <source>Save Session as...</source>
+        <translation>Salva sessione come...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="2337"/>
+        <source>Error while trying to save this session. Please try a different file name.</source>
+        <translation>Riscontrato errore cercando di salvare questa sessione. Provare un altro nome.</translation>
+    </message>
+</context>
+<context>
+    <name>NqqRun::RunDelegate</name>
+    <message>
+        <location filename="../ui/nqqrun.cpp" line="231"/>
+        <source>Open File</source>
+        <translation>Apri file</translation>
+    </message>
+</context>
+<context>
+    <name>NqqRun::RunDialog</name>
+    <message>
+        <location filename="../ui/nqqrun.cpp" line="263"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../ui/nqqrun.cpp" line="264"/>
+        <source>Cancel</source>
+        <translation>Annulla</translation>
+    </message>
+    <message>
+        <location filename="../ui/nqqrun.cpp" line="265"/>
+        <source>Save...</source>
+        <translation>Salva...</translation>
+    </message>
+    <message>
+        <location filename="../ui/nqqrun.cpp" line="267"/>
+        <source>    &lt;h3&gt;Special placeholders&lt;/h3&gt;&lt;ul&gt;    &lt;li&gt;&lt;em&gt;%fullpath%&lt;/em&gt; - Full path of the currently active file.&lt;/li&gt;    &lt;li&gt;&lt;em&gt;%directory%&lt;/em&gt; - Directory of the currently active file.&lt;/li&gt;    &lt;li&gt;&lt;em&gt;%filename%&lt;/em&gt; - Name of the currently active file.&lt;/li&gt;    &lt;li&gt;&lt;em&gt;%selection%&lt;/em&gt; - Currently selected text.&lt;/li&gt;    &lt;/ul&gt;</source>
+        <translation>    &lt;h3&gt;Segnaposti speciali&lt;/h3&gt;&lt;ul&gt;    &lt;li&gt;&lt;em&gt;%fullpath%&lt;/em&gt; - Percorso completo del file attivo.&lt;/li&gt;    &lt;li&gt;&lt;em&gt;%directory%&lt;/em&gt; - Directory del file attualmente attivo.&lt;/li&gt;    &lt;li&gt;&lt;em&gt;%filename%&lt;/em&gt; - Nome del file attualmente attivo.&lt;/li&gt;    &lt;li&gt;&lt;em&gt;%selection%&lt;/em&gt; - Testo attualmente selezionato.&lt;/li&gt;    &lt;/ul&gt;</translation>
+    </message>
+    <message>
+        <location filename="../ui/nqqrun.cpp" line="312"/>
+        <source>Choose the name to be displayed in the run menu.</source>
+        <translation>Scegliere il nome da visualizzare nel menù Esegui.</translation>
+    </message>
+    <message>
+        <location filename="../ui/nqqrun.cpp" line="313"/>
+        <source>Command Name:</source>
+        <translation>Nome comando:</translation>
+    </message>
+    <message>
+        <location filename="../ui/nqqrun.cpp" line="322"/>
+        <source>Command saved...</source>
+        <translation>Comando salvato...</translation>
+    </message>
+</context>
+<context>
+    <name>NqqRun::RunPreferences</name>
+    <message>
+        <location filename="../ui/nqqrun.cpp" line="26"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../ui/nqqrun.cpp" line="27"/>
+        <source>Cancel</source>
+        <translation>Annulla</translation>
+    </message>
+    <message>
+        <location filename="../ui/nqqrun.cpp" line="31"/>
+        <source>    &lt;h3&gt;Special placeholders&lt;/h3&gt;&lt;ul&gt;    &lt;li&gt;&lt;em&gt;%fullpath%&lt;/em&gt; - Full path of the currently active file.&lt;/li&gt;    &lt;li&gt;&lt;em&gt;%directory%&lt;/em&gt; - Directory of the currently active file.&lt;/li&gt;    &lt;li&gt;&lt;em&gt;%filename%&lt;/em&gt; - Name of the currently active file.&lt;/li&gt;    &lt;li&gt;&lt;em&gt;%selection%&lt;/em&gt; - Currently selected text.&lt;/li&gt;    &lt;/ul&gt;</source>
+        <translation>    &lt;h3&gt;Segnaposti speciali&lt;/h3&gt;&lt;ul&gt;    &lt;li&gt;&lt;em&gt;%fullpath%&lt;/em&gt; - Percorso completo del file attivo.&lt;/li&gt;    &lt;li&gt;&lt;em&gt;%directory%&lt;/em&gt; - Directory del file attualmente attivo.&lt;/li&gt;    &lt;li&gt;&lt;em&gt;%filename%&lt;/em&gt; - Nome del file attualmente attivo.&lt;/li&gt;    &lt;li&gt;&lt;em&gt;%selection%&lt;/em&gt; - Testo attualmente selezionato.&lt;/li&gt;    &lt;/ul&gt;</translation>
+    </message>
+    <message>
+        <location filename="../ui/nqqrun.cpp" line="67"/>
+        <source>Text</source>
+        <translation>Testo</translation>
+    </message>
+    <message>
+        <location filename="../ui/nqqrun.cpp" line="67"/>
+        <source>Command</source>
+        <translation>Comando</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../ui/notepadqq.cpp" line="17"/>
+        <source>Copyright © 2010-%1, Daniele Di Sarli</source>
+        <translation>Copyright © 2010-%1, Daniele Di Sarli</translation>
+    </message>
+    <message>
+        <location filename="../ui/notepadqq.cpp" line="81"/>
+        <source>Open a new window in an existing instance of %1.</source>
+        <translation>Aprire una nuova finestra in un&apos;istanza esistente di %1.</translation>
+    </message>
+    <message>
+        <location filename="../ui/notepadqq.cpp" line="86"/>
+        <source>Files to open.</source>
+        <translation>Il file da aprire.</translation>
+    </message>
+    <message>
+        <location filename="../ui/notepadqq.cpp" line="113"/>
+        <source>You are using an old version of Qt (%1)</source>
+        <translation>Stai utilizzando una vecchia versione di Qt (%1)</translation>
+    </message>
+    <message>
+        <location filename="../ui/notepadqq.cpp" line="115"/>
+        <source>Notepadqq will try to do its best, but &lt;b&gt;some things will not work properly&lt;/b&gt;.</source>
+        <translation>Notepadqq cercherà di fare del suo meglio, ma &lt;b&gt;alcune cose possono non funzionare correttamente&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../ui/notepadqq.cpp" line="116"/>
+        <source>Install a newer Qt version (&amp;ge; %1) from the official repositories of your distribution.&lt;br&gt;&lt;br&gt;If it&apos;s not available, download Qt (&amp;ge; %1) from %2 and install it to &quot;%3&quot; or to &quot;%4&quot;.</source>
+        <translation>Installare una nuova versione di Qt (&amp;ge; %1) dai repository ufficiali della propria distribuzione.&lt;br&gt;&lt;br&gt;Se non è disponibile, scaricare Qt (&amp;ge; %1) da %2 e installarlo in &quot;%3&quot; oppure in &quot;%4&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../ui/notepadqq.cpp" line="130"/>
+        <source>Don&apos;t show me this warning again</source>
+        <translation>Non mostrare più questo avviso</translation>
+    </message>
+    <message>
+        <location filename="../ui/Sessions/sessions.cpp" line="126"/>
+        <source>Error reading session file</source>
+        <translation>Errore lettura file di sessione</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.cpp" line="381"/>
+        <source>Restart required</source>
+        <translation>Riavvio necessario</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.cpp" line="382"/>
+        <source>You need to restart Notepadqq for the localization changes to take effect.</source>
+        <translation>È necessario riavviare Notepadqq affinché la modifica della lingua abbiano effetto.</translation>
+    </message>
+</context>
+<context>
+    <name>ReplaceInFilesWorker</name>
+    <message>
+        <location filename="../ui/Search/replaceinfilesworker.cpp" line="40"/>
+        <source>Error reading %1</source>
+        <translation>Errore di lettura %1</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/replaceinfilesworker.cpp" line="84"/>
+        <source>Error writing %1</source>
+        <translation>Errore di scrittura %1</translation>
+    </message>
+</context>
+<context>
+    <name>SearchInFilesWorker</name>
+    <message>
+        <location filename="../ui/Search/searchinfilesworker.cpp" line="66"/>
+        <source>Error reading %1</source>
+        <translation>Errore di lettura %1</translation>
+    </message>
+</context>
+<context>
+    <name>dlgSearching</name>
+    <message>
+        <location filename="../ui/Search/dlgsearching.ui" line="17"/>
+        <source>Dialog</source>
+        <translation>Dialogo</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/dlgsearching.ui" line="77"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Annulla</translation>
+    </message>
+</context>
+<context>
+    <name>frmAbout</name>
+    <message>
+        <location filename="../ui/frmabout.ui" line="17"/>
+        <source>Notepadqq</source>
+        <translation>Notepadqq</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmabout.ui" line="39"/>
+        <source>Close</source>
+        <translation>Chiudi</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmabout.ui" line="108"/>
+        <source>License</source>
+        <translation>Licenza</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmabout.cpp" line="23"/>
+        <source>Contributors:</source>
+        <translation>Riconoscimenti:</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmabout.cpp" line="23"/>
+        <source>GitHub Contributors</source>
+        <translation>Partecipazioni GitHub</translation>
+    </message>
+</context>
+<context>
+    <name>frmEncodingChooser</name>
+    <message>
+        <location filename="../ui/frmencodingchooser.ui" line="17"/>
+        <source>Encoding</source>
+        <translation>Codifica</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmencodingchooser.ui" line="30"/>
+        <source>Encoding:</source>
+        <translation>Codifica:</translation>
+    </message>
+</context>
+<context>
+    <name>frmIndentationMode</name>
+    <message>
+        <location filename="../ui/frmindentationmode.ui" line="14"/>
+        <source>Indentation</source>
+        <translation>Indentazione</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmindentationmode.ui" line="26"/>
+        <source>Tabs</source>
+        <translation>Tabulazioni</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmindentationmode.ui" line="36"/>
+        <source>Spaces</source>
+        <translation>Spazi</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmindentationmode.ui" line="60"/>
+        <source>Indentation width:</source>
+        <translation>Larghezza indentazione:</translation>
+    </message>
+</context>
+<context>
+    <name>frmLineNumberChooser</name>
+    <message>
+        <location filename="../ui/frmlinenumberchooser.ui" line="14"/>
+        <location filename="../ui/frmlinenumberchooser.ui" line="24"/>
+        <source>Go to line</source>
+        <translation>Vai alla riga</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmlinenumberchooser.ui" line="53"/>
+        <source>Line number:</source>
+        <translation>Numero di riga:</translation>
+    </message>
+</context>
+<context>
+    <name>frmPreferences</name>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="14"/>
+        <source>Preferences</source>
+        <translation>Preferenze</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="51"/>
+        <source>1</source>
+        <translation>1</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="56"/>
+        <source>General</source>
+        <translation>Generale</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="61"/>
+        <source>Appearance</source>
+        <translation>Aspetto</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="66"/>
+        <source>Languages</source>
+        <translation>Linguaggio</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="71"/>
+        <source>Search</source>
+        <translation>Cerca</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="76"/>
+        <source>Shortcuts</source>
+        <translation>Tasti di scelta rapida</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="81"/>
+        <source>Extensions</source>
+        <translation>Estensioni</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="105"/>
+        <source>Check Qt version at startup</source>
+        <translation>Controllare versione Qt all&apos;avvio</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="112"/>
+        <source>Warn when the indentation doesn&apos;t match the settings</source>
+        <translation>Avvisa quando l&apos;indentazione non corrisponde alle impostazioni</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="119"/>
+        <source>Remember open tabs when closing Notepadqq</source>
+        <translation>Ricordare le schede aperte quando si chiude Notepadqq</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="128"/>
+        <source>Localization:</source>
+        <translation>Lingua:</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="185"/>
+        <source>Color scheme:</source>
+        <translation>Seleziona tema:</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="217"/>
+        <source>Override Font Family</source>
+        <translation>Personalizza carattere</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="240"/>
+        <source>Override Font Size</source>
+        <translation>Personalizza dimensione</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="269"/>
+        <source>Override Line Height</source>
+        <translation>Personalizza altezza linea</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="285"/>
+        <source>em</source>
+        <translation>em</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="306"/>
+        <source>Preview</source>
+        <translation>Anteprima</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="389"/>
+        <source>Tab size:</source>
+        <translation>Dimensione Tab:</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="402"/>
+        <source>Use spaces instead of tabs</source>
+        <translation>Usa spazi anziché tabulazioni</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="426"/>
+        <source>Use default settings</source>
+        <translation>Utilizzare le impostazioni predefinite</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="462"/>
+        <source>Search as I type</source>
+        <translation>Ricerca mentre scrivo</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="517"/>
+        <source>Node.js runtime</source>
+        <translation>Ambiente di runtime Node.js</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="523"/>
+        <source>Supported Node versions: 0.10, 0.11, 0.12</source>
+        <translation>Versioni Node supportate: 0.10, 0.11, 0.12</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="530"/>
+        <source>Node.js path:</source>
+        <translation>Percorso Node.js:</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="542"/>
+        <location filename="../ui/frmpreferences.ui" line="563"/>
+        <source>Browse...</source>
+        <translation>Esplora...</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="551"/>
+        <source>NPM path:</source>
+        <translation>Percorso NPM:</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="572"/>
+        <source>WARNING: support for extensions is EXPERIMENTAL.</source>
+        <translation>ATTENZIONE: il supporto per le estensioni è SPERIMENTALE.</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.cpp" line="109"/>
+        <source>Keyboard shortcut conflict</source>
+        <translation>Una o più scorciatoie sono in conflitto</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.cpp" line="110"/>
+        <source>Two or more actions share the same shortcut. These conflicts must be resolved before your changes can be saved.</source>
+        <translation>Due o più azioni utilizzano gli stessi tasti di scelta rapida. Questi conflitti devono essere risolti prima che le modifiche possano essere salvate.</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.cpp" line="388"/>
+        <source>Browse</source>
+        <translation>Esplora</translation>
+    </message>
+</context>
+<context>
+    <name>frmSearchReplace</name>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="14"/>
+        <source>Search</source>
+        <translation>Cerca</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="50"/>
+        <source>Find</source>
+        <translation>Trova</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="63"/>
+        <source>Replace with</source>
+        <translation>Sostituisci con</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="76"/>
+        <location filename="../ui/Search/frmsearchreplace.cpp" line="572"/>
+        <source>Look in</source>
+        <translation>Cerca in</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="89"/>
+        <source>Filter</source>
+        <translation>Filtro</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="150"/>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="195"/>
+        <source>Include subdirectories</source>
+        <translation>Includi sottodirectory</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="202"/>
+        <source>Show advanced options</source>
+        <translation>Visualizza opzioni avanzate</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="209"/>
+        <source>Advanced</source>
+        <translation>Avanzate</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="215"/>
+        <source>Search plain text</source>
+        <translation>Cerca semplice testo</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="241"/>
+        <source>Match whole word only</source>
+        <translation>Solo parole intere</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="248"/>
+        <source>Match case</source>
+        <translation>Distingui tra maiuscole e minuscole</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="255"/>
+        <source>Search with special characters (\n, \r, \t, \0, \u..., \x...)</source>
+        <translation>Cerca con caratteri speciali (\n, \r, \t, \0, \u..., \x...)</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="262"/>
+        <source>Search with regular expressions</source>
+        <translation>Cerca con espressione regolare</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="290"/>
+        <source>Find ⇩</source>
+        <translation>Trova ⇩</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="300"/>
+        <location filename="../ui/Search/frmsearchreplace.cpp" line="432"/>
+        <source>Select all</source>
+        <translation>Seleziona tutto</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="310"/>
+        <source>Replace ⇧</source>
+        <translation>Sostituisci ⇧</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="320"/>
+        <source>Replace ⇩</source>
+        <translation>Sostituisci ⇩</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="330"/>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="383"/>
+        <location filename="../ui/Search/frmsearchreplace.cpp" line="420"/>
+        <source>Replace all</source>
+        <translation>Sostituisci tutti</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="347"/>
+        <source>Find all</source>
+        <translation>Trova tutti</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="357"/>
+        <source>Find ⇧</source>
+        <translation>Trova ⇧</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="396"/>
+        <source>Toolbar</source>
+        <translation>Barra degli strumenti</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="430"/>
+        <source>&amp;Replace</source>
+        <translation>&amp;Sostituisci</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="438"/>
+        <source>&amp;Find</source>
+        <translation>&amp;Trova</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="446"/>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="449"/>
+        <source>Find in files</source>
+        <translation>Cerca nei file</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.cpp" line="306"/>
+        <source>Searching...</source>
+        <translation>Ricerca...</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.cpp" line="214"/>
+        <location filename="../ui/Search/frmsearchreplace.cpp" line="244"/>
+        <source>Error</source>
+        <translation>Errore</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.cpp" line="232"/>
+        <location filename="../ui/Search/frmsearchreplace.cpp" line="236"/>
+        <location filename="../ui/Search/frmsearchreplace.cpp" line="285"/>
+        <source>Replace in files</source>
+        <translation>Sostituisci nei file</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.cpp" line="286"/>
+        <source>Are you sure you want to replace all occurrences in %1 for file types %2?</source>
+        <translation>Sei sicuro di sostituire tutte le occorrenze di %1 per i tipi di file %2?</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.cpp" line="266"/>
+        <source>Replacing...</source>
+        <translation>Sostituisci...</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.cpp" line="233"/>
+        <source>%1 occurrences replaced in %2 files.</source>
+        <translation>%1 occorrenze sostituite in %2 file.</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.cpp" line="237"/>
+        <source>%1 occurrences replaced in %2 files, but the replacement has been canceled before it could finish.</source>
+        <translation>%1 occorrenze sostituite in %2 file, ma la sostituzione è stata annullata prima della fine.</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.cpp" line="253"/>
+        <source>Replacing in </source>
+        <translation>Sostituzione in </translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.cpp" line="255"/>
+        <source>Searching in </source>
+        <translation>Ricerca in </translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.cpp" line="420"/>
+        <source>%1 occurrences have been replaced.</source>
+        <translation>%1 occorrenze sono state sostituite.</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.cpp" line="432"/>
+        <source>No results found</source>
+        <translation>Nessun risultato trovato</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
New resource file ( notepadqq_it.ts) for the support of the Italian language.
It is possible add this file in the official repository for add the Italian language support?

The addition of this file requires modification of:
     - ./notepadqq-master/src/ui/ui.pro  with the new line " ../translations/notepadqq_it.ts \ " 
and
    -  ./notepadqq-master/src/ui/resources.qrc with the new line " <file alias="notepadqq_it.qm">../translations/notepadqq_it.qm</file> "

please evaluate this change, to provide a more extensive support to this amazing program.

Thanks and best regards
Marco