### PR TITLE
Periodic Backups to prevent data loss. Fixes #266

### DIFF
--- a/src/editor/app.js
+++ b/src/editor/app.js
@@ -34,6 +34,10 @@ UiDriver.registerEventHandler("C_FUN_IS_CLEAN", function(msg, data, prevReturn) 
     return isCleanOrForced(changeGeneration);
 });
 
+UiDriver.registerEventHandler("C_FUN_GET_HISTORY_GENERATION", function(msg, data, prevReturn) {
+    return editor.getHistoryGeneration();
+});
+
 UiDriver.registerEventHandler("C_CMD_SET_LANGUAGE", function(msg, data, prevReturn) {
     Languages.setLanguage(editor, data);
 });

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -204,6 +204,11 @@ namespace EditorNS
         sendMessage("C_CMD_MARK_DIRTY");
     }
 
+    int Editor::getHistoryGeneration()
+    {
+        return sendMessageWithResult("C_FUN_GET_HISTORY_GENERATION", 0).toInt();
+    }
+
     QList<QMap<QString, QString>> Editor::languages()
     {
         QMap<QString, QVariant> languages =

--- a/src/ui/Sessions/autosave.cpp
+++ b/src/ui/Sessions/autosave.cpp
@@ -2,41 +2,126 @@
 #include "include/Sessions/persistentcache.h"
 #include "include/Sessions/sessions.h"
 
-#include <QTimer>
-
 #include "include/mainwindow.h"
 
-static QTimer g_autosaveTimer;
+QTimer Autosave::s_autosaveTimer;
+std::vector<Autosave::WindowData> Autosave::s_autosaveData;
 
-// Interval between autosaves, in milliseconds.
-static const int AUTOSAVE_INTERVAL = 5000;
+void Autosave::executeAutosave() {
+    // s_autosaveData contains pointers to all MainWindows (and their editors) that were saved during the last autosave. Since
+    // windows could have been opened or closed in the meantime the following steps are taken to update s_autosaveData:
+    // 1) Walk through all WindowData items in s_autosaveData and remove all that point to a MainWindow that isn't open anymore.
+    // 2) Walk through all MainWindows and add all to s_autosaveData that don't already have a corresponding WindowData item.
+    // 3) Walk through all WindowData items in s_autosaveData and see if the window needs to be saved.
 
-using namespace Sessions;
-
-namespace Autosave {
-
-static void executeAutosave() {
     const auto& autosavePath = PersistentCache::autosaveDirPath();
+    const auto& windows = MainWindow::instances();
 
-    QDir autosaveDir(autosavePath);
+    // Step 1: Remove window data of windows that don't exist anymore.
+    s_autosaveData.erase(std::remove_if(s_autosaveData.begin(), s_autosaveData.end(), [&](const WindowData& wndItem){
+        auto it = std::find(windows.begin(), windows.end(), wndItem.ptr);
 
-    // Since saveSession only clears the window_# subdirectories we'll manually delete
-    // the whole directory. saveSession will recreate the necessary subdirectories.
-    if (autosaveDir.exists())
-        autosaveDir.removeRecursively();
+        if (it != windows.end())
+            return false;
 
-    int i = 0;
-    for (const auto& window : MainWindow::instances()) {
-        const QString cachePath = autosavePath + QString("/window_%1").arg(i);
-        const QString sessPath = autosavePath + QString("/window_%1/window.xml").arg(i);
+        // Remove the folder that contains the saved session for this window.
+        // MainWindow's address is used to have a unique path name.
+        const auto ptrToInt = reinterpret_cast<uintptr_t>(wndItem.ptr);
+        const QString cachePath = autosavePath + QString("/window_%1").arg(ptrToInt);
+        QDir(cachePath).removeRecursively();
 
-        saveSession(window, sessPath, cachePath);
+        qDebug() << "Removing" << cachePath;
 
-        i++;
+        return true;
+    }), s_autosaveData.end());
+
+    qDebug() << "Num wndItems: " << s_autosaveData.size();
+
+    // Step 2: Add window data of all newly created windows
+    for (const auto& wnd : windows) {
+        auto it = std::find_if(s_autosaveData.begin(), s_autosaveData.end(), [wnd](const WindowData& w) { return w.ptr == wnd; });
+
+        if (it != s_autosaveData.end())
+            continue;
+
+        // Add a WindowData object with this window's pointer data.
+        // The editor vector is left empty to indicate that this MainWindow still needs to be autosaved.
+        WindowData w{ w.ptr, {} };
+        w.ptr = wnd;
+
+        qDebug() << "Adding window" << w.ptr;
+
+        s_autosaveData.push_back( std::move(w) );
     }
+
+    // Step 3: Walk through all window data and create a session if necessary.
+    for (auto& wndItem : s_autosaveData) {
+        MainWindow* wnd = wndItem.ptr;
+
+        // This lambda iterates through each Editor of a given TopEditorContainer* and searches through the
+        // std::vector<Editor*> in wndItem to see if the Editor is in that vector and whether its history generation
+        // matches. If yes to both, the Editor has already been saved in a previous autosave. If no to either, the Editor
+        // needs to be autosaved.
+        const auto needsSaving = [wndItem](TopEditorContainer* top){
+            bool success = true;
+
+            top->forEachEditor([wndItem, &ok](int,int,EditorTabWidget*,Editor* ed) {
+                const auto& editors = wndItem.editors;
+                auto eit = std::find_if(editors.begin(), editors.end(), [&](const std::pair<Editor*, int> p) {
+                    qDebug() << "Found" << p.first << p.second << ed->getHistoryGeneration();
+
+                    return p.first == ed && p.second == ed->getHistoryGeneration();
+                });
+
+                success = eit != editors.end();
+
+                // If success==false, an Editor has been found that needs saving. In this case we can stop iterating
+                // because this MainWindow definitely needs to be autosaved.
+                return success;
+            });
+
+            return !success;
+        };
+
+        // An autosave only needs to be done for this MainWindow if any Editors were added/removed or the user made changes
+        // to one of the editors.
+        if (wndItem.editors.size() != wnd->topEditorContainer()->getNumEditors() || needsSaving(wnd->topEditorContainer())) {
+
+            auto sz  =wndItem.editors.size() != wnd->topEditorContainer()->getNumEditors();
+            auto sa = sadf(wnd->topEditorContainer());
+            qDebug() << "Saving session" << wndItem.ptr << ". Reason:" << sz <<  sa;
+
+            // Save this MainWindow as a session inside the autosave path.
+            // MainWindow's address is used to have a unique path name.
+            const auto ptrToInt = reinterpret_cast<uintptr_t>(wnd);
+            const QString cachePath = autosavePath + QString("/window_%1").arg(ptrToInt);
+            const QString sessPath = autosavePath + QString("/window_%1/window.xml").arg(ptrToInt);
+
+            bool success = Sessions::saveSession(wnd->getDocEngine(), wnd->topEditorContainer(), sessPath, cachePath);
+
+            // The autosave dir is inside the Nqq config folder and should *always* be accessible. However, if for some reason
+            // it isn't, we don't want to continue as if the window has been saved properly. executeAutosave() will attempt another
+            // autosave after the autosave timer period has passed.
+            if(!success)
+                continue;
+
+            // Now that the MainWindow has been saved its data inside the wndItem needs to be updated.
+            // Specifically we save the list of all Editors and their history generation.
+            wndItem.editors.clear();
+
+            wnd->topEditorContainer()->forEachEditor([&wndItem](int,int,EditorTabWidget*,Editor* ed) {
+                wndItem.editors.push_back( std::make_pair(ed, ed->getHistoryGeneration()) );
+                return true;
+            });
+
+            qDebug() << "Updated window" << wndItem.ptr << "with" << wndItem.editors.size() << "editors";
+        }
+
+    }
+
 }
 
-void restoreFromAutosave()
+void Autosave::restoreFromAutosave()
 {
     const auto& autosavePath = PersistentCache::autosaveDirPath();
 
@@ -50,27 +135,39 @@ void restoreFromAutosave()
         const auto sessPath = dirInfo.filePath() + "/window.xml";
 
         MainWindow* wnd = new MainWindow(QStringList(), 0);
-        loadSession(wnd, sessPath);
+        Sessions::loadSession(wnd->getDocEngine(), wnd->topEditorContainer(), sessPath);
         wnd->show();
     }
 
 
 }
 
-void enableAutosave()
+void Autosave::enableAutosave()
 {
-    if (g_autosaveTimer.isActive())
+    if (s_autosaveTimer.isActive())
         return;
 
-    QObject::connect(&g_autosaveTimer, &QTimer::timeout, &executeAutosave);
+    // Last shutdown was either proper or all windows are already restored in case of a crash. Either way, the autosave directory needs to be cleared so Autosave can start anew.
+    const auto& autosavePath = PersistentCache::autosaveDirPath();
+    QDir autosaveDir(autosavePath);
 
-    g_autosaveTimer.setInterval(AUTOSAVE_INTERVAL);
-    g_autosaveTimer.start(AUTOSAVE_INTERVAL);
+    if (autosaveDir.exists())
+        autosaveDir.removeRecursively();
+
+    QObject::connect(&Autosave::s_autosaveTimer, &QTimer::timeout, &Autosave::executeAutosave);
+
+    s_autosaveTimer.setInterval(AUTOSAVE_INTERVAL);
+    s_autosaveTimer.start(AUTOSAVE_INTERVAL);
 }
 
-void disableAutosave()
+void Autosave::disableAutosave()
 {
-    g_autosaveTimer.stop();
-}
+    s_autosaveTimer.stop();
 
-} // namespace Autosave
+    // disableAutosave() is only called explicitely by the user if they want to disable the feature. In this case we'll clear the autosave dir to clear up disk space.
+    const auto& autosavePath = PersistentCache::autosaveDirPath();
+    QDir autosaveDir(autosavePath);
+
+    if (autosaveDir.exists())
+        autosaveDir.removeRecursively();
+}

--- a/src/ui/Sessions/autosave.cpp
+++ b/src/ui/Sessions/autosave.cpp
@@ -137,7 +137,6 @@ void Autosave::restoreFromAutosave()
         wnd->show();
     }
 
-
 }
 
 void Autosave::enableAutosave()

--- a/src/ui/Sessions/autosave.cpp
+++ b/src/ui/Sessions/autosave.cpp
@@ -30,12 +30,12 @@ void Autosave::executeAutosave() {
         const QString cachePath = autosavePath + QString("/window_%1").arg(ptrToInt);
         QDir(cachePath).removeRecursively();
 
-        qDebug() << "Removing" << cachePath;
+        //qDebug() << "Removing" << cachePath;
 
         return true;
     }), s_autosaveData.end());
 
-    qDebug() << "Num wndItems: " << s_autosaveData.size();
+    //qDebug() << "Num wndItems: " << s_autosaveData.size();
 
     // Step 2: Add window data of all newly created windows
     for (const auto& wnd : windows) {
@@ -49,7 +49,7 @@ void Autosave::executeAutosave() {
         WindowData w{ w.ptr, {} };
         w.ptr = wnd;
 
-        qDebug() << "Adding window" << w.ptr;
+        //qDebug() << "Adding window" << w.ptr;
 
         s_autosaveData.push_back( std::move(w) );
     }
@@ -65,11 +65,9 @@ void Autosave::executeAutosave() {
         const auto needsSaving = [wndItem](TopEditorContainer* top){
             bool success = true;
 
-            top->forEachEditor([wndItem, &ok](int,int,EditorTabWidget*,Editor* ed) {
+            top->forEachEditor([wndItem, &success](int,int,EditorTabWidget*,Editor* ed) {
                 const auto& editors = wndItem.editors;
                 auto eit = std::find_if(editors.begin(), editors.end(), [&](const std::pair<Editor*, int> p) {
-                    qDebug() << "Found" << p.first << p.second << ed->getHistoryGeneration();
-
                     return p.first == ed && p.second == ed->getHistoryGeneration();
                 });
 
@@ -87,9 +85,9 @@ void Autosave::executeAutosave() {
         // to one of the editors.
         if (wndItem.editors.size() != wnd->topEditorContainer()->getNumEditors() || needsSaving(wnd->topEditorContainer())) {
 
-            auto sz  =wndItem.editors.size() != wnd->topEditorContainer()->getNumEditors();
-            auto sa = sadf(wnd->topEditorContainer());
-            qDebug() << "Saving session" << wndItem.ptr << ". Reason:" << sz <<  sa;
+            //auto sz  =wndItem.editors.size() != wnd->topEditorContainer()->getNumEditors();
+            //auto sa = needsSaving(wnd->topEditorContainer());
+            //qDebug() << "Saving session" << wndItem.ptr << ". Reason:" << sz <<  sa;
 
             // Save this MainWindow as a session inside the autosave path.
             // MainWindow's address is used to have a unique path name.
@@ -114,7 +112,7 @@ void Autosave::executeAutosave() {
                 return true;
             });
 
-            qDebug() << "Updated window" << wndItem.ptr << "with" << wndItem.editors.size() << "editors";
+            //qDebug() << "Updated window" << wndItem.ptr << "with" << wndItem.editors.size() << "editors";
         }
 
     }

--- a/src/ui/Sessions/autosave.cpp
+++ b/src/ui/Sessions/autosave.cpp
@@ -1,0 +1,84 @@
+#include "include/Sessions/autosave.h"
+#include "include/Sessions/persistentcache.h"
+#include "include/Sessions/sessions.h"
+
+#include <QTimer>
+#include <QDebug>
+
+#include "include/mainwindow.h"
+
+static QTimer g_autosaveTimer;
+
+// Interval between autosaves, in milliseconds.
+static const int AUTOSAVE_INTERVAL = 5000;
+
+using namespace Sessions;
+
+namespace Autosave {
+
+static void executeAutosave() {
+    const auto& autosavePath = PersistentCache::autosaveDirPath();
+
+    QDir autosaveDir(autosavePath);
+
+    if (autosaveDir.exists())
+        autosaveDir.removeRecursively();
+
+    int i = 0;
+    for (const auto& window : MainWindow::instances()) {
+        qDebug() << "autosave window #" << i;
+
+        const QString cachePath = autosavePath + QString("/window_%1").arg(i);
+        const QString sessPath = autosavePath + QString("/window_%1/window.xml").arg(i);
+
+        saveSession(window, sessPath, cachePath);
+
+        i++;
+    }
+}
+
+void restoreFromAutosave()
+{
+    qDebug() << "restore from autosave";
+
+    const auto& autosavePath = PersistentCache::autosaveDirPath();
+
+    QDir autosaveDir(autosavePath);
+    autosaveDir.setFilter(QDir::Dirs | QDir::NoDotAndDotDot);
+    const auto& dirs = autosaveDir.entryInfoList();
+
+    for (const auto& dirInfo : dirs) {
+        qDebug() << "Dir: " << dirInfo.filePath();
+
+        const auto sessPath = dirInfo.filePath() + "/window.xml";
+
+        MainWindow *b = new MainWindow(QStringList(), 0);
+
+        loadSession(b, sessPath);
+
+        b->show();
+    }
+
+
+}
+
+void enableAutosave()
+{
+    if (g_autosaveTimer.isActive())
+        return;
+
+    qDebug() << "enable";
+
+    QObject::connect(&g_autosaveTimer, &QTimer::timeout, &executeAutosave);
+
+    g_autosaveTimer.setInterval(AUTOSAVE_INTERVAL);
+    g_autosaveTimer.start(AUTOSAVE_INTERVAL);
+}
+
+void disableAutosave()
+{
+    qDebug() << "disable";
+    g_autosaveTimer.stop();
+}
+
+} // namespace Autosave

--- a/src/ui/Sessions/persistentcache.cpp
+++ b/src/ui/Sessions/persistentcache.cpp
@@ -14,7 +14,8 @@ QString PersistentCache::cacheDirPath() {
 QString PersistentCache::autosaveDirPath() {
     static QString path = QFileInfo(QSettings().fileName()).dir().absolutePath().append("/autosaveCache");
     return path;
-{
+}
+
 QUrl PersistentCache::createValidCacheName(const QDir& parent, const QString &fileName)
 {
     QUrl cacheFile;

--- a/src/ui/Sessions/persistentcache.cpp
+++ b/src/ui/Sessions/persistentcache.cpp
@@ -11,6 +11,10 @@ QString PersistentCache::cacheDirPath() {
     return tabpath;
 }
 
+QString PersistentCache::autosaveDirPath() {
+    static QString path = QFileInfo(QSettings().fileName()).dir().absolutePath().append("/autosaveCache");
+    return path;
+{
 QUrl PersistentCache::createValidCacheName(const QDir& parent, const QString &fileName)
 {
     QUrl cacheFile;

--- a/src/ui/Sessions/sessions.cpp
+++ b/src/ui/Sessions/sessions.cpp
@@ -253,7 +253,10 @@ bool saveSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
 
         if(!success)
             return false;
+
+        qDebug() << "Writing to: " << cacheDir.absolutePath();
     }
+
 
     std::vector<ViewData> viewData;
 
@@ -349,6 +352,8 @@ void loadSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
         return;
     }
 
+    //m_dontUpdateRecentDocs = true;
+
     int viewCounter = 0;
     for (const auto& view : views) {
         // Each new view must be created if it does not yet exist.
@@ -429,6 +434,8 @@ void loadSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
             tabW->setCurrentIndex(activeIndex);
 
     } // end for
+
+    //m_dontUpdateRecentDocs = false;
 
     // Stop if we haven't added any views at all, otherwise we have to clean up after ourselves.
     if (viewCounter <= 0)

--- a/src/ui/Sessions/sessions.cpp
+++ b/src/ui/Sessions/sessions.cpp
@@ -253,10 +253,7 @@ bool saveSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
 
         if(!success)
             return false;
-
-        qDebug() << "Writing to: " << cacheDir.absolutePath();
     }
-
 
     std::vector<ViewData> viewData;
 
@@ -352,8 +349,6 @@ void loadSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
         return;
     }
 
-    //m_dontUpdateRecentDocs = true;
-
     int viewCounter = 0;
     for (const auto& view : views) {
         // Each new view must be created if it does not yet exist.
@@ -434,8 +429,6 @@ void loadSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
             tabW->setCurrentIndex(activeIndex);
 
     } // end for
-
-    //m_dontUpdateRecentDocs = false;
 
     // Stop if we haven't added any views at all, otherwise we have to clean up after ourselves.
     if (viewCounter <= 0)

--- a/src/ui/frmpreferences.cpp
+++ b/src/ui/frmpreferences.cpp
@@ -6,6 +6,7 @@
 #include "include/Extensions/extensionsloader.h"
 #include "include/notepadqq.h"
 #include "include/keygrabber.h"
+#include "include/Sessions/autosave.h"
 #include <QFileDialog>
 #include <QSortFilterProxyModel>
 #include <QInputDialog>
@@ -44,6 +45,7 @@ frmPreferences::frmPreferences(TopEditorContainer *topEditorContainer, QWidget *
     ui->chkCheckQtVersionAtStartup->setChecked(m_settings.General.getCheckVersionAtStartup());
     ui->chkWarnForDifferentIndentation->setChecked(m_settings.General.getWarnForDifferentIndentation());
     ui->chkRememberSession->setChecked(m_settings.General.getRememberTabsOnExit());
+    ui->chkEnableAutosave->setChecked(m_settings.General.getEnableAutosaving());
 
     loadLanguages();
     loadAppearanceTab();
@@ -116,6 +118,12 @@ void frmPreferences::on_buttonBox_accepted()
     m_settings.General.setCheckVersionAtStartup(ui->chkCheckQtVersionAtStartup->isChecked());
     m_settings.General.setWarnForDifferentIndentation(ui->chkWarnForDifferentIndentation->isChecked());
     m_settings.General.setRememberTabsOnExit(ui->chkRememberSession->isChecked());
+    m_settings.General.setEnableAutosaving(ui->chkEnableAutosave->isChecked());
+
+    if (m_settings.General.getEnableAutosaving())
+        Autosave::enableAutosave();
+    else
+        Autosave::disableAutosave();
 
     saveLanguages();
     saveAppearanceTab();

--- a/src/ui/frmpreferences.ui
+++ b/src/ui/frmpreferences.ui
@@ -121,6 +121,13 @@
           </widget>
          </item>
          <item>
+          <widget class="QCheckBox" name="chkEnableAutosave">
+           <property name="text">
+            <string>Enable Autosaving</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <layout class="QFormLayout" name="formLayout">
            <item row="0" column="0">
             <widget class="QLabel" name="localizationLabel">

--- a/src/ui/frmpreferences.ui
+++ b/src/ui/frmpreferences.ui
@@ -513,8 +513,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>356</width>
-              <height>205</height>
+              <width>338</width>
+              <height>200</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_3">

--- a/src/ui/include/EditorNS/editor.h
+++ b/src/ui/include/EditorNS/editor.h
@@ -181,6 +181,7 @@ namespace EditorNS
         Q_INVOKABLE bool isClean();
         Q_INVOKABLE void markClean();
         Q_INVOKABLE void markDirty();
+        Q_INVOKABLE int getHistoryGeneration();
         QList<QMap<QString, QString> > languages();
 
         /**

--- a/src/ui/include/Sessions/autosave.h
+++ b/src/ui/include/Sessions/autosave.h
@@ -3,9 +3,20 @@
 
 namespace Autosave {
 
+/**
+ * @brief restoreFromAutosave Reads the autosave sessions and recreates
+ *        all windows and their tabs.
+ */
 void restoreFromAutosave();
 
+/**
+ * @brief enableAutosave Starts periodic autosaving.
+ */
 void enableAutosave();
+
+/**
+ * @brief disableAutosave Stops periodic autosaving.
+ */
 void disableAutosave();
 
 } // namespace Autosave

--- a/src/ui/include/Sessions/autosave.h
+++ b/src/ui/include/Sessions/autosave.h
@@ -1,0 +1,14 @@
+#ifndef AUTOSAVE_H
+#define AUTOSAVE_H
+
+namespace Autosave {
+
+void restoreFromAutosave();
+
+void enableAutosave();
+void disableAutosave();
+
+} // namespace Autosave
+
+
+#endif // AUTOSAVE_H

--- a/src/ui/include/Sessions/autosave.h
+++ b/src/ui/include/Sessions/autosave.h
@@ -1,25 +1,49 @@
 #ifndef AUTOSAVE_H
 #define AUTOSAVE_H
 
-namespace Autosave {
+#include <QTimer>
+#include <QString>
+#include <tuple>
+#include <vector>
 
-/**
- * @brief restoreFromAutosave Reads the autosave sessions and recreates
- *        all windows and their tabs.
- */
-void restoreFromAutosave();
+namespace EditorNS{
+class Editor;
+}
+class MainWindow;
 
-/**
- * @brief enableAutosave Starts periodic autosaving.
- */
-void enableAutosave();
+class Autosave {
+public:
 
-/**
- * @brief disableAutosave Stops periodic autosaving.
- */
-void disableAutosave();
+    /**
+     * @brief restoreFromAutosave Reads the autosave sessions and recreates
+     *        all windows and their tabs.
+     */
+    static void restoreFromAutosave();
 
-} // namespace Autosave
+    /**
+     * @brief enableAutosave Starts periodic autosaving.
+     */
+    static void enableAutosave();
 
+    /**
+     * @brief disableAutosave Stops periodic autosaving.
+     */
+    static void disableAutosave();
+
+private:
+    // Interval between autosaves, in milliseconds.
+    static const int AUTOSAVE_INTERVAL = 5000;
+
+    static QTimer s_autosaveTimer;
+
+    struct WindowData {
+        MainWindow* ptr;
+        std::vector<std::pair<EditorNS::Editor*, int>> editors;
+    };
+
+    static std::vector<WindowData> s_autosaveData;
+
+    static void executeAutosave();
+};
 
 #endif // AUTOSAVE_H

--- a/src/ui/include/Sessions/autosave.h
+++ b/src/ui/include/Sessions/autosave.h
@@ -36,6 +36,12 @@ private:
 
     static QTimer s_autosaveTimer;
 
+    /**
+     * @brief The WindowData struct contains a list Editor*'s and the history generation
+     *        at the time of the last autosave. With every new autosave this data will be
+     *        compared to the MainWindow's current list of Editor*'s and their history gens
+     *        to determine whether the MainWindow has changed since the last save.
+     */
     struct WindowData {
         MainWindow* ptr;
         std::vector<std::pair<EditorNS::Editor*, int>> editors;
@@ -43,6 +49,10 @@ private:
 
     static std::vector<WindowData> s_autosaveData;
 
+    /**
+     * @brief executeAutosave Updates the data inside s_autosaveData and executes saveSession
+     *        for every open MainWindow that needs it.
+     */
     static void executeAutosave();
 };
 

--- a/src/ui/include/Sessions/persistentcache.h
+++ b/src/ui/include/Sessions/persistentcache.h
@@ -18,6 +18,11 @@ public:
     static QString cacheDirPath();
 
     /**
+     * @brief Returns the path to the directory that contains the autosave cache.
+     */
+    static QString autosaveDirPath();
+
+    /**
      * @brief Generates a QUrl to a file within the a directory.
      * @param parent The parent directory for the file.
      * @param fileName The file name for the file.

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -62,7 +62,9 @@ public:
     QList<const QMenu*> getMenus() const ;
 
     DocEngine*  getDocEngine() const;
+
     void generateRunMenu();
+
 public slots:
     void refreshEditorUiInfo(Editor *editor);
 

--- a/src/ui/include/nqqsettings.h
+++ b/src/ui/include/nqqsettings.h
@@ -76,6 +76,8 @@ public:
         NQQ_SETTING(ShowEOL,                        bool,       false)
 
         NQQ_SETTING(RememberTabsOnExit,             bool,       true)
+        NQQ_SETTING(EnableAutosaving,               bool,       false) // True if Nqq was closed normally, false otherwise.
+        NQQ_SETTING(ProperShutdown,                 bool,       true)
         NQQ_SETTING(LastSelectedDir,                QString,    ".")
         NQQ_SETTING(LastSelectedSessionDir,         QString,    QString())
         NQQ_SETTING(RecentDocuments,                QList<QVariant>, QList<QVariant>())

--- a/src/ui/include/nqqsettings.h
+++ b/src/ui/include/nqqsettings.h
@@ -76,8 +76,8 @@ public:
         NQQ_SETTING(ShowEOL,                        bool,       false)
 
         NQQ_SETTING(RememberTabsOnExit,             bool,       true)
-        NQQ_SETTING(EnableAutosaving,               bool,       false) // True if Nqq was closed normally, false otherwise.
-        NQQ_SETTING(ProperShutdown,                 bool,       true)
+        NQQ_SETTING(EnableAutosaving,               bool,       false)
+        NQQ_SETTING(ProperShutdown,                 bool,       true) // True if Nqq was closed normally, false otherwise.
         NQQ_SETTING(LastSelectedDir,                QString,    ".")
         NQQ_SETTING(LastSelectedSessionDir,         QString,    QString())
         NQQ_SETTING(RecentDocuments,                QList<QVariant>, QList<QVariant>())

--- a/src/ui/include/topeditorcontainer.h
+++ b/src/ui/include/topeditorcontainer.h
@@ -46,6 +46,11 @@ public:
     void forEachEditor(bool backwardIndexes, std::function<bool (const int, const int, EditorTabWidget *, Editor *)> callback);
     void forEachEditor(std::function<bool (const int, const int, EditorTabWidget *, Editor *)> callback);
 
+    /**
+     * @brief Returns the number of editors in all of the TopEditorWidget's children.
+     */
+    int getNumEditors();
+
 private:
     EditorTabWidget *m_currentTabWidget;
 

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -124,18 +124,19 @@ int main(int argc, char *argv[])
 #endif
     }
 
-    MainWindow *w;
     if(settings.General.getEnableAutosaving() && !settings.General.getProperShutdown()) {
         Autosave::restoreFromAutosave();
     }
 
     // If no autosave session was restored, or if the session was completely empty, we new up
     // a new Window, otherwise there is at least one window open already.
+    MainWindow* wnd = nullptr;
+
     if (MainWindow::instances().isEmpty()) {
-        w = new MainWindow(QApplication::arguments(), 0);
-        w->show();
+        wnd = new MainWindow(QApplication::arguments(), 0);
+        wnd->show();
     } else {
-        w = MainWindow::instances().back();
+        wnd = MainWindow::instances().back();
     }
 
     if (settings.General.getEnableAutosaving())
@@ -147,9 +148,11 @@ int main(int argc, char *argv[])
 #endif
 
     if (Notepadqq::oldQt() && settings.General.getCheckVersionAtStartup()) {
-        Notepadqq::showQtVersionWarning(true, w);
+        Notepadqq::showQtVersionWarning(true, wnd);
     }
 
+    // The ProperShutdown variable indicates whether Nqq was closed normally or crashed/etc.
+    // If it is 'false' then a.exec() never returned.
     settings.General.setProperShutdown(false);
     const auto retVal = a.exec();
     settings.General.setProperShutdown(true);

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -19,6 +19,7 @@
 #include "include/Sessions/persistentcache.h"
 #include "include/Sessions/sessions.h"
 #include "include/nqqrun.h"
+#include "include/Sessions/autosave.h"
 #include <QFileDialog>
 #include <QLineEdit>
 #include <QInputDialog>
@@ -133,7 +134,8 @@ MainWindow::MainWindow(const QString &workingDirectory, const QStringList &argum
 
     // We want to restore tabs only if...
     if (    m_instances.size()==1 && // this window is the first one to be opened,
-            m_settings.General.getRememberTabsOnExit() // and the Remember-tabs option is enabled
+            m_settings.General.getRememberTabsOnExit() && // the Remember-tabs option is enabled
+            (m_settings.General.getProperShutdown() || !m_settings.General.getEnableAutosaving()) // and no restoration from the autosave feature is going on
     ) {
         Sessions::loadSession(m_docEngine, m_topEditorContainer, PersistentCache::cacheSessionPath());
     }

--- a/src/ui/topeditorcontainer.cpp
+++ b/src/ui/topeditorcontainer.cpp
@@ -148,6 +148,16 @@ void TopEditorContainer::forEachEditor(std::function<bool (const int, const int,
     forEachEditor(false, callback);
 }
 
+int TopEditorContainer::getNumEditors()
+{
+    int total = 0;
+
+    for(int i = 0; i < count(); ++i)
+        total += tabWidget(i)->count();
+
+    return total;
+}
+
 void TopEditorContainer::forEachEditor(bool backwardIndexes,
                                        std::function<bool (const int tabWidgetId, const int editorId, EditorTabWidget *tabWidget, Editor *editor)> callback)
 {

--- a/src/ui/ui.pro
+++ b/src/ui/ui.pro
@@ -92,7 +92,8 @@ SOURCES += main.cpp\
     Sessions/sessions.cpp \
     Sessions/persistentcache.cpp \
     nqqsettings.cpp \  
-    nqqrun.cpp
+    nqqrun.cpp \
+    Sessions/autosave.cpp
 
 HEADERS  += include/mainwindow.h \
     include/topeditorcontainer.h \
@@ -138,7 +139,8 @@ HEADERS  += include/mainwindow.h \
     include/Sessions/sessions.h \
     include/Sessions/persistentcache.h \
     include/nqqsettings.h \
-    include/nqqrun.h
+    include/nqqrun.h \
+    include/Sessions/autosave.h
 
 FORMS    += mainwindow.ui \
     frmabout.ui \


### PR DESCRIPTION
So this was a long time in the pipe.

The autosave functionality periodically inspects all open MainWindows and saves their current session into an autosave directory inside Nqq's .config folder. Right now the autosave interval is set to 5 seconds. Autosave is clever enough not to re-save a window if nothing has changed since the last time it was saved.

This process is completely transparent to the user. It's only use is that, if Nqq wasn't properly shut down, all windows, tabs, and their content will be restored from the autosave directory. This is useful since unsaved changes would otherwise be lost (the "Remember tabs on exit" feature won't work if Nqq or the system crashed).

Right now the feature is referred to as "Autosaving" pretty much everywhere in the code but it's probably not a good name for it since it doesn't actually *do* autosaving. I couldn't think of a good, short, descriptive text for Nqq's settings menu so I left it at "Enable Autosaving" for the time being. I'm open to good ideas.

A few commented debug statements/etc are still in the code; I'll remove them if/when the code is about to be merged. Right now they're pretty useful for me.