### PR TITLE
Clear banner-related signal prior to moving tabs.

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1096,7 +1096,7 @@ void MainWindow::on_editorAdded(EditorTabWidget *tabWidget, int tab)
     Editor *editor = tabWidget->editor(tab);
     
     // If the tab is not newly opened but only transferred (e.g. with "Move to other View") it may
-    // have a banner attached to it. We need to connect previous signals to prevent
+    // have a banner attached to it. We need to disconnect previous signals to prevent
     // on_bannerRemoved() to be called twice (once for the current connection and once for the connection
     // created a few lines below).
     disconnect(editor, &Editor::bannerRemoved, 0, 0);

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1094,6 +1094,13 @@ void MainWindow::on_currentEditorChanged(EditorTabWidget *tabWidget, int tab)
 void MainWindow::on_editorAdded(EditorTabWidget *tabWidget, int tab)
 {
     Editor *editor = tabWidget->editor(tab);
+    
+    // If the tab is not newly opened but only transferred (e.g. with "Move to other View") it may
+    // have a banner attached to it. We need to connect previous signals to prevent
+    // on_bannerRemoved() to be called twice (once for the current connection and once for the connection
+    // created a few lines below).
+    disconnect(editor, &Editor::bannerRemoved, 0, 0);
+    
     connect(editor, &Editor::cursorActivity, this, &MainWindow::on_cursorActivity);
     connect(editor, &Editor::currentLanguageChanged, this, &MainWindow::on_currentLanguageChanged);
     connect(editor, &Editor::bannerRemoved, this, &MainWindow::on_bannerRemoved);


### PR DESCRIPTION
If a tab shows a banner and is then moved, `on_editorAdded()` is called for that tab. It creates a connection to delete the banner when the user clicks it away. Since this is not a newly created tab it already had such a connection from the first time it was added. Thus, `banner` is deleted twice.

The banner code is kind of a mess and probably deserves some cleaning up. But until then this is a simple fix.

Fixes #344, see this issue for reproduction.