### PR TITLE
Minor cleanup of Banner messages

### DIFF
--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -414,7 +414,7 @@ namespace EditorNS
     {
         if (banner != m_webView && m_layout->indexOf(banner) >= 0) {
             m_layout->removeWidget(banner);
-            emit bannerRemoved(banner);
+            banner->deleteLater();
         }
     }
 

--- a/src/ui/include/EditorNS/editor.h
+++ b/src/ui/include/EditorNS/editor.h
@@ -321,7 +321,6 @@ namespace EditorNS
         void gotFocus();
         void mouseWheel(QWheelEvent *ev);
         void urlsDropped(QList<QUrl> urls);
-        void bannerRemoved(QWidget *banner);
 
         // Pre-interpreted messages:
         void contentChanged();

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -119,7 +119,6 @@ private slots:
     void on_actionLowercase_triggered();
     void on_actionClose_All_BUT_Current_Document_triggered();
     void on_actionSave_All_triggered();
-    void on_bannerRemoved(QWidget *banner);
     void on_documentSaved(EditorTabWidget *tabWidget, int tab);
     void on_documentReloaded(EditorTabWidget *tabWidget, int tab);
     void on_documentLoaded(EditorTabWidget *tabWidget, int tab, bool wasAlreadyOpened, bool updateRecentDocs);

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1099,16 +1099,9 @@ void MainWindow::on_currentEditorChanged(EditorTabWidget *tabWidget, int tab)
 void MainWindow::on_editorAdded(EditorTabWidget *tabWidget, int tab)
 {
     Editor *editor = tabWidget->editor(tab);
-    
-    // If the tab is not newly opened but only transferred (e.g. with "Move to other View") it may
-    // have a banner attached to it. We need to disconnect previous signals to prevent
-    // on_bannerRemoved() to be called twice (once for the current connection and once for the connection
-    // created a few lines below).
-    disconnect(editor, &Editor::bannerRemoved, 0, 0);
-    
+
     connect(editor, &Editor::cursorActivity, this, &MainWindow::on_cursorActivity);
     connect(editor, &Editor::currentLanguageChanged, this, &MainWindow::on_currentLanguageChanged);
-    connect(editor, &Editor::bannerRemoved, this, &MainWindow::on_bannerRemoved);
     connect(editor, &Editor::cleanChanged, this, [=]() {
         if (currentEditor() == editor)
             refreshEditorUiInfo(editor);
@@ -1602,11 +1595,6 @@ void MainWindow::on_actionSave_All_triggered()
             return (result != DocEngine::saveFileResult_Canceled);
         }
     });
-}
-
-void MainWindow::on_bannerRemoved(QWidget *banner)
-{
-    delete banner;
 }
 
 void MainWindow::on_documentSaved(EditorTabWidget *tabWidget, int tab)


### PR DESCRIPTION
I took a closer look at the way banners are handled after that last PR. 

A banner's deletion even is propagated through a few signals and ultimately ends up in a function inside `MainWindow`. These signals aren't used for anything else, and a good chunk of the call chain can be removed with no consequences by moving the deletion to the `removeBanner` function.

That also removes the need for that last band-aid fix.