### PR TITLE
Minor visual changes to Banners.

### DIFF
--- a/src/ui/EditorNS/bannerbasicmessage.cpp
+++ b/src/ui/EditorNS/bannerbasicmessage.cpp
@@ -25,11 +25,14 @@ namespace EditorNS
         m_message = new QLabel(this);
 
         m_message->setStyleSheet(".QLabel { margin-left: 5px; margin-right: 10px; color: white } ");
-        m_message->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::MinimumExpanding);
-        m_message->setMaximumHeight(50);
-        m_message->setMinimumWidth(200);
+        m_message->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+        m_message->setMinimumWidth(150);
+        m_message->setMaximumHeight( fontMetrics().height() * 6 );
+
         m_message->setWordWrap(true);
-        m_layout->addWidget(m_message, 1);
+        m_message->setScaledContents(true);
+
+        m_layout->addWidget(m_message,1);
 
         m_layout->addStretch(0);
 
@@ -40,6 +43,7 @@ namespace EditorNS
     void BannerBasicMessage::setMessage(QString text)
     {
         m_message->setText(text);
+        m_message->setMaximumWidth( fontMetrics().width(text)+30 );
     }
 
     void BannerBasicMessage::setImportance(Importance importance)
@@ -60,7 +64,7 @@ namespace EditorNS
         QPushButton *button = new QPushButton(this);
         button->setText(text);
         button->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-        m_layout->insertWidget(m_layout->count(), button);
+        m_layout->insertWidget(m_layout->count()-1, button);
 
         button->setStyleSheet("QPushButton { border: 1px solid white; background: transparent; padding: 5px; color: white }"
                               "QPushButton:hover { background: rgba(0, 0, 0, 60); }"

--- a/src/ui/EditorNS/bannerbasicmessage.cpp
+++ b/src/ui/EditorNS/bannerbasicmessage.cpp
@@ -25,10 +25,13 @@ namespace EditorNS
         m_message = new QLabel(this);
 
         m_message->setStyleSheet(".QLabel { margin-left: 5px; margin-right: 10px; color: white } ");
-        m_message->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Preferred);
-        m_layout->addWidget(m_message);
+        m_message->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::MinimumExpanding);
+        m_message->setMaximumHeight(50);
+        m_message->setMinimumWidth(200);
+        m_message->setWordWrap(true);
+        m_layout->addWidget(m_message, 1);
 
-        m_layout->addStretch(1);
+        m_layout->addStretch(0);
 
         m_topWidget->setLayout(m_layout);
         setLayout(topLayout);
@@ -57,7 +60,7 @@ namespace EditorNS
         QPushButton *button = new QPushButton(this);
         button->setText(text);
         button->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-        m_layout->insertWidget(m_layout->count() - 1, button);
+        m_layout->insertWidget(m_layout->count(), button);
 
         button->setStyleSheet("QPushButton { border: 1px solid white; background: transparent; padding: 5px; color: white }"
                               "QPushButton:hover { background: rgba(0, 0, 0, 60); }"

--- a/src/ui/EditorNS/bannerbasicmessage.cpp
+++ b/src/ui/EditorNS/bannerbasicmessage.cpp
@@ -30,10 +30,8 @@ namespace EditorNS
         m_message->setMaximumHeight( fontMetrics().height() * 6 );
 
         m_message->setWordWrap(true);
-        m_message->setScaledContents(true);
 
         m_layout->addWidget(m_message,1);
-
         m_layout->addStretch(0);
 
         m_topWidget->setLayout(m_layout);


### PR DESCRIPTION
Right now a banner has a relatively high minimum width which sometimes messes with tab widths, especially when using several views.

Here's a patch that makes the banner message flexible by allowing it to word-wrap (and moves banner buttons to the right side).

I kept this separate from the #348 since one is internal and this one is an arguable visual change.

![Preview Image](http://i.imgur.com/QNsPtHY.png)