### PR TITLE
Misc. improvements for Preferences menu

### DIFF
--- a/src/ui/frmpreferences.cpp
+++ b/src/ui/frmpreferences.cpp
@@ -75,8 +75,6 @@ void frmPreferences::resetAllShortcuts() {
     m_keyGrabber->checkForConflicts();
 }
 
-#include <QDebug>
-
 void frmPreferences::resetSelectedShortcuts()
 {
     auto& bindings = m_keyGrabber->getAllBindings();

--- a/src/ui/frmpreferences.cpp
+++ b/src/ui/frmpreferences.cpp
@@ -82,7 +82,7 @@ void frmPreferences::resetSelectedShortcut()
 
     // Search for the selected item and set its key sequence to the default one.
     for (auto& item : bindings) {
-        if( currItem != item.getTreeItem() ) continue;
+        if (currItem != item.getTreeItem()) continue;
 
         const QString& objName = item.getAction()->objectName();
         const QKeySequence seq = m_settings.Shortcuts.getDefaultShortcut(objName);
@@ -121,7 +121,7 @@ void frmPreferences::on_buttonBox_clicked(QAbstractButton *button)
 {
     // Accept and Reject buttons are handled separately. Other buttons need to use this generic clicked() event.
 
-    if( button == ui->buttonBox->button(QDialogButtonBox::Apply) )
+    if (button == ui->buttonBox->button(QDialogButtonBox::Apply))
         applySettings();
 }
 

--- a/src/ui/frmpreferences.cpp
+++ b/src/ui/frmpreferences.cpp
@@ -127,7 +127,7 @@ void frmPreferences::on_buttonBox_clicked(QAbstractButton *button)
 
 void frmPreferences::on_buttonBox_accepted()
 {
-    if(applySettings())
+    if (applySettings())
         accept();
 }
 
@@ -137,13 +137,13 @@ void frmPreferences::loadLanguages()
 
     std::sort(langs.begin(), langs.end(), Editor::LanguageGreater());
 
-    //Add "Default" language into the list.
+    // Add "Default" language into the list.
     QMap<QString,QString> defaultMap;
     defaultMap.insert("id", "default");
     defaultMap.insert("name", "Default");
     langs.push_front(defaultMap);
 
-    //Add all languages to the comboBox and write their current settings to a temp list
+    // Add all languages to the comboBox and write their current settings to a temp list
     for (int i = 0; i < langs.length(); i++) {
         const QMap<QString, QString> &map = langs.at(i);
         const QString langId = map.value("id", "");
@@ -166,7 +166,7 @@ void frmPreferences::loadLanguages()
 
 void frmPreferences::saveLanguages()
 {
-    //Write all temporary language settings back into the settings file.
+    // Write all temporary language settings back into the settings file.
     for (auto&& lang : m_tempLangSettings) {
         m_settings.Languages.setTabSize(lang.langId, lang.tabSize);
         m_settings.Languages.setIndentWithSpaces(lang.langId, lang.indentWithSpaces);
@@ -313,7 +313,7 @@ void frmPreferences::saveShortcuts()
 
 bool frmPreferences::applySettings()
 {
-    if(m_keyGrabber->hasConflicts()){
+    if (m_keyGrabber->hasConflicts()) {
         //Try our best to show the error to the user immediately.
         ui->treeWidget->setCurrentItem(ui->treeWidget->topLevelItem(ui->stackedWidget->indexOf(ui->pageShortcuts)));
         m_keyGrabber->scrollToConflict();

--- a/src/ui/frmpreferences.cpp
+++ b/src/ui/frmpreferences.cpp
@@ -75,7 +75,7 @@ void frmPreferences::resetAllShortcuts() {
     m_keyGrabber->checkForConflicts();
 }
 
-void frmPreferences::resetSelectedShortcuts()
+void frmPreferences::resetSelectedShortcut()
 {
     auto& bindings = m_keyGrabber->getAllBindings();
     auto currItem = m_keyGrabber->currentItem();
@@ -119,10 +119,10 @@ void frmPreferences::on_treeWidget_currentItemChanged(QTreeWidgetItem *current, 
 
 void frmPreferences::on_buttonBox_clicked(QAbstractButton *button)
 {
-    if( button != ui->buttonBox->button(QDialogButtonBox::Apply) )
-        return;
+    // Accept and Reject buttons are handled separately. Other buttons need to use this generic clicked() event.
 
-    applySettings();
+    if( button == ui->buttonBox->button(QDialogButtonBox::Apply) )
+        applySettings();
 }
 
 void frmPreferences::on_buttonBox_accepted()
@@ -282,7 +282,7 @@ void frmPreferences::loadShortcuts()
     QPushButton *resetSelected = new QPushButton("Reset Seleted");
     QPushButton *resetAll = new QPushButton("Reset All");
 
-    QObject::connect(resetSelected, &QPushButton::clicked, this, &frmPreferences::resetSelectedShortcuts);
+    QObject::connect(resetSelected, &QPushButton::clicked, this, &frmPreferences::resetSelectedShortcut);
     QObject::connect(resetAll, &QPushButton::clicked, this, &frmPreferences::resetAllShortcuts);
 
     resetSelected->setFixedWidth(144);

--- a/src/ui/frmpreferences.ui
+++ b/src/ui/frmpreferences.ui
@@ -86,9 +86,9 @@
      <item>
       <widget class="QStackedWidget" name="stackedWidget">
        <property name="currentIndex">
-        <number>0</number>
+        <number>4</number>
        </property>
-       <widget class="QWidget" name="page">
+       <widget class="QWidget" name="pageGeneral">
         <layout class="QVBoxLayout" name="verticalLayout_6">
          <property name="topMargin">
           <number>9</number>
@@ -149,7 +149,7 @@
          </item>
         </layout>
        </widget>
-       <widget class="QWidget" name="page_3">
+       <widget class="QWidget" name="pageAppearance">
         <layout class="QVBoxLayout" name="verticalLayout_8" stretch="0,0,0,1">
          <property name="leftMargin">
           <number>9</number>
@@ -336,7 +336,7 @@
          </item>
         </layout>
        </widget>
-       <widget class="QWidget" name="page_2">
+       <widget class="QWidget" name="pageLanguages">
         <layout class="QVBoxLayout" name="verticalLayout_9">
          <property name="leftMargin">
           <number>9</number>
@@ -445,7 +445,7 @@
          </item>
         </layout>
        </widget>
-       <widget class="QWidget" name="page_4">
+       <widget class="QWidget" name="pageSearch">
         <layout class="QVBoxLayout" name="verticalLayout_5">
          <property name="topMargin">
           <number>9</number>
@@ -479,7 +479,7 @@
         </layout>
        </widget>
        <widget class="QWidget" name="pageShortcuts"/>
-       <widget class="QWidget" name="page_6">
+       <widget class="QWidget" name="pageExtensions">
         <layout class="QVBoxLayout" name="verticalLayout_7">
          <property name="leftMargin">
           <number>9</number>
@@ -506,8 +506,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>356</width>
-              <height>205</height>
+              <width>565</width>
+              <height>389</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -618,7 +618,10 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+     <property name="centerButtons">
+      <bool>false</bool>
      </property>
     </widget>
    </item>

--- a/src/ui/frmpreferences.ui
+++ b/src/ui/frmpreferences.ui
@@ -86,7 +86,7 @@
      <item>
       <widget class="QStackedWidget" name="stackedWidget">
        <property name="currentIndex">
-        <number>4</number>
+        <number>0</number>
        </property>
        <widget class="QWidget" name="pageGeneral">
         <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -506,8 +506,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>565</width>
-              <height>389</height>
+              <width>356</width>
+              <height>205</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_3">

--- a/src/ui/include/frmpreferences.h
+++ b/src/ui/include/frmpreferences.h
@@ -12,6 +12,8 @@ namespace Ui {
 class frmPreferences;
 }
 
+class QAbstractButton;
+
 class frmPreferences : public QDialog
 {
     Q_OBJECT
@@ -34,7 +36,8 @@ private slots:
     void on_btnNpmBrowse_clicked();
     void on_txtNodejs_textChanged(const QString &);
     void on_txtNpm_textChanged(const QString &);
-    void resetShortcuts();
+    void resetSelectedShortcuts();
+    void resetAllShortcuts();
     void on_chkOverrideFontFamily_toggled(bool checked);
     void on_chkOverrideFontSize_toggled(bool checked);
     void on_spnFontSize_valueChanged(int arg1);
@@ -42,7 +45,10 @@ private slots:
     void on_chkOverrideLineHeight_toggled(bool checked);
     void on_spnLineHeight_valueChanged(double arg1);
 
+    void on_buttonBox_clicked(QAbstractButton *button);
+
 private:
+    static int s_lastSelectedTab;
 
     struct LanguageSettings {
         QString langId;
@@ -67,6 +73,12 @@ private:
     void saveTranslation();
     void loadShortcuts();
     void saveShortcuts();
+
+    /**
+     * @brief applySettings Applies all user-set settings.
+     * @return True if settings were successfully changed
+     */
+    bool applySettings();
 
     bool extensionBrowseRuntime(QLineEdit *lineEdit);
     void checkExecutableExists(QLineEdit *path);

--- a/src/ui/include/frmpreferences.h
+++ b/src/ui/include/frmpreferences.h
@@ -36,7 +36,7 @@ private slots:
     void on_btnNpmBrowse_clicked();
     void on_txtNodejs_textChanged(const QString &);
     void on_txtNpm_textChanged(const QString &);
-    void resetSelectedShortcuts();
+    void resetSelectedShortcut();
     void resetAllShortcuts();
     void on_chkOverrideFontFamily_toggled(bool checked);
     void on_chkOverrideFontSize_toggled(bool checked);
@@ -48,6 +48,9 @@ private slots:
     void on_buttonBox_clicked(QAbstractButton *button);
 
 private:
+    /**
+     * @brief s_lastSelectedTab Contains the index of the last selected preferences tab. Default is 0.
+     */
     static int s_lastSelectedTab;
 
     struct LanguageSettings {

--- a/src/ui/include/keygrabber.h
+++ b/src/ui/include/keygrabber.h
@@ -46,6 +46,7 @@ public:
 
     public:
         QAction* getAction() { return action; }
+        QTreeWidgetItem* getTreeItem() { return treeItem; }
 
         void setText(QString seq) { treeItem->setText(1,seq); }
         QString text() const { return treeItem->text(1); }


### PR DESCRIPTION
Here's a small batch of changes:

* Preferences menu now has an "Apply" button in addition to "Ok" and "Cancel". That way users can immediately see visual changes (like themes) without having to exit the menu all the time.
* The Shortcuts tab now has a "Reset Selected Shortcut" in addition to the "Reset All Shortcut" button.
* The Preferences menu remembers the last selected settings tab and will automatically switch to it when re-opened (this is not a saved setting. Only implemented as a static variable).
* Renamed the object names for the tabs from something like "page_2" to more sensible names.

PS: This PR's diff looks a bit misleading because I moved around a function or two. The changes made are pretty self-contained.

![Sample](http://i.imgur.com/K1T9wmF.png)