### PR TITLE
During session load, show BannerFileRemoved when the file is missing.

### DIFF
--- a/src/ui/Sessions/sessions.cpp
+++ b/src/ui/Sessions/sessions.cpp
@@ -406,9 +406,17 @@ void loadSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
             if (fileExists && cacheFileExists && tab.lastModified != 0) {
                 auto lastModified = fileInfo.lastModified().toMSecsSinceEpoch();
 
-                if(lastModified > tab.lastModified)
+                if (lastModified > tab.lastModified) {
                     editor->setFileOnDiskChanged(true);
+                }
             }
+
+            // If the orig. file does not exist but *should* exist, we inform the user of its removal.
+            if (!fileExists && !fileUrl.isEmpty()) {
+                editor->setFileOnDiskChanged(true);
+                emit docEngine->fileOnDiskChanged(tabW, idx, true);
+            }
+
 
             if(tab.active) activeIndex = idx;
 


### PR DESCRIPTION
If a document is loaded through loadSession and its original file doesn't exist while its cache file exists, a banner message informing the user should be shown.

Here steps to reproduce what I mean, because the sentence above is awful:
* The "Remember open tabs when closing" setting must be enabled in Nqq.
* Create new text file
* Open it in Nqq and write some text to it. Close Nqq without explicitely saving the file (so it gets cached).
* Now delete the text file.
* Open Nqq again. The cached file is restored and marked as dirty as should be, but the user isn't informed about the original file's removal.