### PR TITLE
Fix handling "Reload" actions if no file to reload exists.

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1234,6 +1234,10 @@ void MainWindow::refreshEditorUiInfo(Editor *editor)
     ui->actionMove_to_New_Window->setEnabled(isClean);
     ui->actionOpen_in_New_Window->setEnabled(isClean);
 
+    bool allowReloading = !editor->fileName().isEmpty();
+    ui->actionReload_file_interpreted_as->setEnabled(allowReloading);
+    ui->actionReload_from_Disk->setEnabled(allowReloading);
+
     // EOL
     QString eol = editor->endOfLineSequence();
     if (eol == "\r\n") {
@@ -1903,11 +1907,6 @@ void MainWindow::on_actionConvert_to_triggered()
 void MainWindow::on_actionReload_file_interpreted_as_triggered()
 {
     Editor *editor = currentEditor();
-
-    // Don't do anything if there is no file to reload from.
-    if (editor->fileName().isEmpty())
-        return;
-
     frmEncodingChooser *dialog = new frmEncodingChooser(this);
     dialog->setEncoding(editor->codec());
     dialog->setInfoText(tr("Reload as:"));

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -745,6 +745,10 @@ void MainWindow::on_actionShow_All_Characters_toggled(bool on)
 
 bool MainWindow::reloadWithWarning(EditorTabWidget *tabWidget, int tab, QTextCodec *codec, bool bom)
 {
+    // Don't do anything if there is no file to reload from.
+    if (tabWidget->editor(tab)->fileName().isEmpty())
+        return false;
+
     if (!tabWidget->editor(tab)->isClean()) {
         QMessageBox msgBox(this);
         QString name = tabWidget->tabText(tab).toHtmlEscaped();
@@ -1899,6 +1903,11 @@ void MainWindow::on_actionConvert_to_triggered()
 void MainWindow::on_actionReload_file_interpreted_as_triggered()
 {
     Editor *editor = currentEditor();
+
+    // Don't do anything if there is no file to reload from.
+    if (editor->fileName().isEmpty())
+        return;
+
     frmEncodingChooser *dialog = new frmEncodingChooser(this);
     dialog->setEncoding(editor->codec());
     dialog->setInfoText(tr("Reload as:"));


### PR DESCRIPTION
When clicking 'Reload from disk' or 'Reload file interpreted as' if no file exists, nothing should be done since there is no file to reload from.