### PR TITLE
Add "moc" to C++ file extensions

### DIFF
--- a/src/editor/classes/Languages.js
+++ b/src/editor/classes/Languages.js
@@ -57,7 +57,7 @@ var Languages = new function() {
             name: "C++",
             mode: "clike",
             mime: "text/x-c++src",
-            fileExtensions: ["cc", "cp", "cpp", "c++", "cxx", "hh", "hpp", "hxx", "h++", "ii", "ino"]
+            fileExtensions: ["cc", "cp", "cpp", "c++", "cxx", "hh", "hpp", "hxx", "h++", "ii", "ino", "moc"]
         },
 
         "cobol": {


### PR DESCRIPTION
moc is sometimes used as extension for C++ files generated from the Qt Meta Object Compiler
http://doc.qt.io/qt-5/qttestlib-tutorial1-example.html
http://doc.qt.io/qt-4.8/moc.html#writing-make-rules-for-invoking-moc