### PR TITLE
QtWebEngine: Fix crash-on-exit.

### DIFF
--- a/src/ui/include/topeditorcontainer.h
+++ b/src/ui/include/topeditorcontainer.h
@@ -17,6 +17,8 @@ class TopEditorContainer : public QSplitter
     Q_OBJECT
 public:
     explicit TopEditorContainer(QWidget *parent = 0);
+    ~TopEditorContainer();
+
     EditorTabWidget *addTabWidget();
     EditorTabWidget *tabWidget(int index);
     EditorTabWidget *currentTabWidget();
@@ -49,6 +51,7 @@ public:
 private:
     EditorTabWidget *m_currentTabWidget;
     int m_currentTabIndex = -1;
+    bool m_shuttingDown = false;
 
 signals:
     /**

--- a/src/ui/include/topeditorcontainer.h
+++ b/src/ui/include/topeditorcontainer.h
@@ -51,6 +51,14 @@ public:
 private:
     EditorTabWidget *m_currentTabWidget;
     int m_currentTabIndex = -1;
+    /**
+     * @brief Is set to true when destructor is called. Required workaround to prevent a crash:
+              When TopEditorContainer is destroyed, it first destructs its members, then calls its parent destructor. 
+              That one makes sure all children get destroyed as well, that includes all EditorTabWidet. 
+              During that process, a number of signals are emitted that are being caught by the now half-destructed TopEditorContainer. 
+              That kills the program.
+              More info: https://github.com/notepadqq/notepadqq/pull/394
+     */
     bool m_shuttingDown = false;
 
 signals:

--- a/src/ui/topeditorcontainer.cpp
+++ b/src/ui/topeditorcontainer.cpp
@@ -11,6 +11,11 @@ TopEditorContainer::TopEditorContainer(QWidget *parent) :
     m_currentTabWidget = addTabWidget();
 }
 
+TopEditorContainer::~TopEditorContainer()
+{
+    m_shuttingDown = true;
+}
+
 EditorTabWidget *TopEditorContainer::addTabWidget()
 {
     EditorTabWidget *tabWidget = new EditorTabWidget(this);
@@ -82,7 +87,7 @@ EditorTabWidget *TopEditorContainer::tabWidgetFromEditor(Editor *editor)
 
 void TopEditorContainer::on_currentTabChanged(int index)
 {
-    if (index == -1)
+    if (index == -1 || m_shuttingDown)
         return;
 
     EditorTabWidget *tabWidget = dynamic_cast<EditorTabWidget *>(sender());


### PR DESCRIPTION
There was a SIGSEV that popped up in the experimental branch. I fixed it and broke editor signaling with it. When I fixed editor signaling I made the SIGSEV come back.

So here's the fix for the fix for the fix for the SIGSEV.

I should go into gardening, not programming.

------

Technical details:

I'm not quite sure why this happens but here's what I believe: When `TopEditorContainer` is destroyed, it first destructs its members and then calls its parent `QObject` destructor. That one makes sure all children get destroyed as well, that includes all `EditorTabWidgets` and the tabs therein. During that process, a number of signals are emitted that are being caught and acted upon by the now half-destructed `TopEditorContainer`. That kills the program.

Manually disconnecting the affected signals at destruction leads to a SIGPIPE instead (first time I ever managed that error!), probably because of some meta-type magic done by Qt. So instead, I added a switch to stop handling the problematic signal when the `TopEditorContainer` is being destructed.

I think it'll suffice for now, the whole tab stuff is due for an overhaul anyways.