### PR TITLE
Add parsing of %directory% in Run command

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2027,10 +2027,13 @@ void MainWindow::runCommand()
     Editor *editor = currentEditor();
 
     QUrl url = currentEditor()->fileName();
-    QStringList selection = editor->selectedTexts();
+    QString path = url.path(QUrl::FullyEncoded);
+    QFileInfo fi(path);
+    QStringList selection = editor->getSelectedTexts();
     if (!url.isEmpty()) {
         cmd.replace("\%fullpath\%", url.toString(QUrl::None));
-        cmd.replace("\%path\%", url.path(QUrl::FullyEncoded));
+        cmd.replace("\%path\%", path);
+        cmd.replace("\%directory\%", fi.absolutePath());
         cmd.replace("\%filename\%", url.fileName(QUrl::FullyEncoded));
     }
     if(!selection.first().isEmpty()) {

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2029,7 +2029,7 @@ void MainWindow::runCommand()
     QUrl url = currentEditor()->fileName();
     QString path = url.path(QUrl::FullyEncoded);
     QFileInfo fi(path);
-    QStringList selection = editor->getSelectedTexts();
+    QStringList selection = editor->SelectedTexts();
     if (!url.isEmpty()) {
         cmd.replace("\%fullpath\%", url.toString(QUrl::None));
         cmd.replace("\%path\%", path);

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2029,7 +2029,7 @@ void MainWindow::runCommand()
     QUrl url = currentEditor()->fileName();
     QString path = url.path(QUrl::FullyEncoded);
     QFileInfo fi(path);
-    QStringList selection = editor->SelectedTexts();
+    QStringList selection = editor->selectedTexts();
     if (!url.isEmpty()) {
         cmd.replace("\%fullpath\%", url.toString(QUrl::None));
         cmd.replace("\%path\%", path);


### PR DESCRIPTION
The parsing of `%directory%` placeholders is advertised in the run menu, but the code wasn't actually there.
![image](https://cloud.githubusercontent.com/assets/5351348/23968331/96789e02-09c2-11e7-9b3f-6bc1150dce6b.png)

The current directory is retrieved using `QFileInfo` since `QUrl `does not provide clean directory path without "file://" scheme. Also to avoid the use of hard-coded regex.

P.S. `%path%` parsing is there but it's not advertised, I leave it to the maintainer to decide if it's should be removed.