### PR TITLE
Add show whole lines option to search results

### DIFF
--- a/src/ui/frmpreferences.cpp
+++ b/src/ui/frmpreferences.cpp
@@ -53,6 +53,7 @@ frmPreferences::frmPreferences(TopEditorContainer *topEditorContainer, QWidget *
     loadShortcuts();
 
     ui->chkSearch_SearchAsIType->setChecked(m_settings.Search.getSearchAsIType());
+    ui->chkSearch_ShowWholeLines->setChecked(m_settings.Search.getShowWholeLines());
 
     ui->txtNodejs->setText(m_settings.Extensions.getRuntimeNodeJS());
     ui->txtNpm->setText(m_settings.Extensions.getRuntimeNpm());
@@ -338,6 +339,7 @@ bool frmPreferences::applySettings()
     saveShortcuts();
 
     m_settings.Search.setSearchAsIType(ui->chkSearch_SearchAsIType->isChecked());
+    m_settings.Search.setShowWholeLines(ui->chkSearch_ShowWholeLines->isChecked());
     m_settings.Extensions.setRuntimeNodeJS(ui->txtNodejs->text());
     m_settings.Extensions.setRuntimeNpm(ui->txtNpm->text());
 

--- a/src/ui/frmpreferences.ui
+++ b/src/ui/frmpreferences.ui
@@ -86,7 +86,7 @@
      <item>
       <widget class="QStackedWidget" name="stackedWidget">
        <property name="currentIndex">
-        <number>0</number>
+        <number>3</number>
        </property>
        <widget class="QWidget" name="pageGeneral">
         <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -464,6 +464,13 @@
           </widget>
          </item>
          <item>
+          <widget class="QCheckBox" name="chkSearch_ShowWholeLines">
+           <property name="text">
+            <string>Show whole lines in search results</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <spacer name="verticalSpacer_2">
            <property name="orientation">
             <enum>Qt::Vertical</enum>
@@ -506,8 +513,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>356</width>
-              <height>205</height>
+              <width>401</width>
+              <height>200</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_3">

--- a/src/ui/include/Search/searchinfilesworker.h
+++ b/src/ui/include/Search/searchinfilesworker.h
@@ -79,11 +79,12 @@ private:
      * @param `matchLen`
      * @return `FileSearchResult::Result` object to be used for final search results.
      */
-    FileSearchResult::Result buildResult(const int &line, 
-            const int &column, 
+    FileSearchResult::Result buildResult(const int &line,
+            const QVector<int> &linePosition,
             const int &absoluteColumn, 
             const QString &lineContent, 
-            const int &matchLen);
+            const int &matchLen,
+            const bool showWholeLines);
 
     /**
      * @brief Perform a search using regular expression matching

--- a/src/ui/include/nqqsettings.h
+++ b/src/ui/include/nqqsettings.h
@@ -92,6 +92,7 @@ public:
 
     BEGIN_CATEGORY(Search)
         NQQ_SETTING(SearchAsIType,  bool,           true)
+        NQQ_SETTING(ShowWholeLines, bool,           false)
         NQQ_SETTING(SearchHistory,  QStringList,    QStringList())
         NQQ_SETTING(ReplaceHistory, QStringList,    QStringList())
         NQQ_SETTING(FileHistory,    QStringList,    QStringList())


### PR DESCRIPTION
I have recently switched from notepad++ to notepadqq. The only thing that disturbs me in notepadqq is that results of Find in Files option display just 50 characters before and 50 characters after match.

This makes searching through files which have long lines quite difficult. 
Especially in case of log files, lines may be mostly similar to each other, with just part of the line containing some specific information.  It is likely that this information might be cut out from search preview. As a result one have to click in each found line to see it in main window:
![screenshot from 2017-03-17 23-45-40](https://cloud.githubusercontent.com/assets/26494112/24073789/7965b272-0bfd-11e7-9dbb-c08e60020d15.png)
This seems unnecessary as find results could show whole lines:
![screenshot from 2017-03-17 23-44-34](https://cloud.githubusercontent.com/assets/26494112/24073793/84ca3dc2-0bfd-11e7-8e7a-e59597016c92.png)
However, as I understand some users may still prefer to have in preview only part of line which is close to match.
Therefore I propose to make enabling of this feature configurable in Preferences.
![screenshot from 2017-03-17 23-43-03](https://cloud.githubusercontent.com/assets/26494112/24073802/b87f5da0-0bfd-11e7-93fd-8de3308ffe22.png)

Also, refactored buildResult function so that it uses linePosition to determine start and end of line. This should improve performance of that function.

The only issue left which could be fixed in next iteration is lack of horizontal scroll bar in search results. This could be helpful if lines are longer then Find result window width.


