### PR TITLE
Webengine async

### DIFF
--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -306,13 +306,10 @@ namespace EditorNS
         return langs;
     }
 
-    QString Editor::getLanguage(const QString& val)
+    QString Editor::getLanguage()
     {
         QVariantMap data = m_jsProxy->getRawValue("language").toMap();
-        if ( val == "id" ) {
-            return data.value("id").toString();
-        }
-        return data.value("lang").toMap().value(val).toString();
+        return data.value("id").toString();
     }
 
     void Editor::setLanguage(const QString &language)

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -703,7 +703,7 @@ namespace EditorNS
         sendMessage("C_CMD_DISPLAY_NORMAL_STYLE");
     }
 
-    void Editor::getSelections(std::function<void(QList<Editor::Selection>)> callback)
+    void Editor::getSelections(std::function<void(const QList<Editor::Selection>&)> callback)
     {
         sendMessageWithCallback("C_FUN_GET_SELECTIONS",
         [&, callback](const QVariant& v) {
@@ -726,7 +726,7 @@ namespace EditorNS
         });
     }
     
-    void Editor::getSelectedTexts(std::function<void(QStringList)> callback)
+    void Editor::getSelectedTexts(std::function<void(const QStringList&)> callback)
     {
         sendMessageWithCallback("C_FUN_GET_SELECTIONS_TEXT",
         [callback](const QVariant& v) mutable {
@@ -734,7 +734,7 @@ namespace EditorNS
         });
     }
 
-    void Editor::getLanguage(std::function<void(QString)> callback) {
+    void Editor::getLanguage(std::function<void(const QString&)> callback) {
         sendMessageWithCallback("C_FUN_GET_CURRENT_LANGUAGE",
         [callback](const QVariant &v) {
             QString langId = v.toMap().value("id").toString();
@@ -742,7 +742,7 @@ namespace EditorNS
         });
     }
 
-    void Editor::getCurrentWordOrSelections(std::function<void(QStringList)> callback) {
+    void Editor::getCurrentWordOrSelections(std::function<void(const QStringList&)> callback) {
         sendMessageWithCallback("C_FUN_GET_SELECTIONS_TEXT",
         [&, callback](const QVariant& v) mutable {
             if(v.isNull()) {

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -724,4 +724,29 @@ namespace EditorNS
         //m_webView->print(printer); // FIXME
         sendMessage("C_CMD_DISPLAY_NORMAL_STYLE");
     }
+
+    void Editor::getSelections(std::function<void(QList<Editor::Selection>)> callback)
+    {
+        sendMessageWithCallback("C_FUN_GET_SELECTIONS",
+                [&, callback](const QVariant& v) {
+            callback(convertToSelections(v));
+        });
+    }
+    
+    void Editor::getSelectedTexts(std::function<void(QStringList)> callback)
+    {
+        sendMessageWithCallback("C_FUN_GET_SELECTIONS_TEXT",
+                [callback](const QVariant& v) mutable {
+            callback(v.toStringList());
+        });
+    }
+
+    void Editor::getLanguage(std::function<void(QString)> callback) {
+        sendMessageWithCallback("C_FUN_GET_CURRENT_LANGUAGE",
+        [callback](const QVariant &v) {
+            QString langId = v.toMap().value("id").toString();
+            callback(langId);
+        });
+    }
+
 }

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -728,10 +728,4 @@ namespace EditorNS
         //m_webView->print(printer); // FIXME
         sendMessage("C_CMD_DISPLAY_NORMAL_STYLE");
     }
-
-    QString Editor::getCurrentWord()
-    {
-        return sendMessageWithResult("C_FUN_GET_CURRENT_WORD").toString();
-    }
-
 }

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -668,28 +668,6 @@ namespace EditorNS
         sendMessage("C_CMD_SET_THEME", tmap);
     }
 
-    QList<Editor::Selection> Editor::convertToSelections(const QVariant& data)
-    {
-        QList<Selection> out;
-
-        QList<QVariant> sels = data.toList();
-        for (int i = 0; i < sels.length(); i++) {
-            QVariantMap selMap = sels[i].toMap();
-            QVariantMap from = selMap.value("anchor").toMap();
-            QVariantMap to = selMap.value("head").toMap();
-
-            Selection sel;
-            sel.from.line = from.value("line").toInt();
-            sel.from.column = from.value("ch").toInt();
-            sel.to.line = to.value("line").toInt();
-            sel.to.column = to.value("ch").toInt();
-
-            out.append(sel);
-        }
-
-        return out;
-    }
-
     void Editor::setOverwrite(bool overwrite)
     {
         sendMessage("C_CMD_SET_OVERWRITE", overwrite);
@@ -728,15 +706,30 @@ namespace EditorNS
     void Editor::getSelections(std::function<void(QList<Editor::Selection>)> callback)
     {
         sendMessageWithCallback("C_FUN_GET_SELECTIONS",
-                [&, callback](const QVariant& v) {
-            callback(convertToSelections(v));
+        [&, callback](const QVariant& v) {
+            QList<Selection> out;
+            QList<QVariant> sels = v.toList();
+            for (int i = 0; i < sels.length(); i++) {
+                QVariantMap selMap = sels[i].toMap();
+                QVariantMap from = selMap.value("anchor").toMap();
+                QVariantMap to = selMap.value("head").toMap();
+
+                Selection sel;
+                sel.from.line = from.value("line").toInt();
+                sel.from.column = from.value("ch").toInt();
+                sel.to.line = to.value("line").toInt();
+                sel.to.column = to.value("ch").toInt();
+
+                out.append(sel);
+            }
+            callback(out);
         });
     }
     
     void Editor::getSelectedTexts(std::function<void(QStringList)> callback)
     {
         sendMessageWithCallback("C_FUN_GET_SELECTIONS_TEXT",
-                [callback](const QVariant& v) mutable {
+        [callback](const QVariant& v) mutable {
             callback(v.toStringList());
         });
     }

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -749,4 +749,19 @@ namespace EditorNS
         });
     }
 
+    void Editor::getCurrentWordOrSelections(std::function<void(QStringList)> callback) {
+        sendMessageWithCallback("C_FUN_GET_SELECTIONS_TEXT",
+        [&, callback](const QVariant& v) mutable {
+            if(v.isNull()) {
+                sendMessageWithCallback("C_FUN_GET_CURRENT_WORD",
+                [callback](const QVariant& v) mutable {
+                    callback(v.toStringList());
+                });
+            }else {
+                callback(v.toStringList());
+            }
+        });
+    }
+
+
 }

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -537,6 +537,7 @@ namespace EditorNS
     void Editor::setCursorPosition(const int line, const int column)
     {
         QList<QVariant> arg = QList<QVariant>({line, column});
+//        sendMessageWithCallback("C_CMD_SET_CURSOR", QVariant(arg), [](const QVariant& v) {});
         sendMessage("C_CMD_SET_CURSOR", QVariant(arg));
     }
 
@@ -674,11 +675,11 @@ namespace EditorNS
         sendMessage("C_CMD_SET_THEME", tmap);
     }
 
-    QList<Editor::Selection> Editor::getSelections()
+    QList<Editor::Selection> Editor::convertToSelections(const QVariant& data)
     {
         QList<Selection> out;
 
-        QList<QVariant> sels = m_jsProxy->getRawValue("selections").toList();
+        QList<QVariant> sels = data.toList();
         for (int i = 0; i < sels.length(); i++) {
             QVariantMap selMap = sels[i].toMap();
             QVariantMap from = selMap.value("anchor").toMap();
@@ -694,13 +695,6 @@ namespace EditorNS
         }
 
         return out;
-    }
-
-    QStringList Editor::getSelectedTexts()
-    {
-        QStringList selectedTexts;
-        m_jsProxy->getValue("selectionsText", selectedTexts);
-        return selectedTexts;
     }
 
     void Editor::setOverwrite(bool overwrite)

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -706,7 +706,7 @@ namespace EditorNS
     void Editor::getSelections(std::function<void(const QList<Editor::Selection>&)> callback)
     {
         sendMessageWithCallback("C_FUN_GET_SELECTIONS",
-        [&, callback](const QVariant& v) {
+        [callback](const QVariant& v) {
             QList<Selection> out;
             QList<QVariant> sels = v.toList();
             for (int i = 0; i < sels.length(); i++) {

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -418,14 +418,11 @@ namespace EditorNS
 
     void Editor::sendMessage(const QString &msg, const QVariant &data)
     {
-//        waitAsyncLoad();
         m_jsProxy->sendMsg(jsStringEscape(msg), data);
     }
 
     QVariant Editor::sendMessageWithResult(const QString &msg, const QVariant &data)
     {
-        qDebug() << "Getting result for: " << msg;
-//        waitAsyncLoad();
         if (m_processLoop.isRunning())
             throw std::runtime_error("m_processLoop must never be running at this point. Did this function get called from another thread?");
 
@@ -534,7 +531,6 @@ namespace EditorNS
     void Editor::setCursorPosition(const int line, const int column)
     {
         QList<QVariant> arg = QList<QVariant>({line, column});
-//        sendMessageWithCallback("C_CMD_SET_CURSOR", QVariant(arg), [](const QVariant& v) {});
         sendMessage("C_CMD_SET_CURSOR", QVariant(arg));
     }
 

--- a/src/ui/Search/frmsearchreplace.cpp
+++ b/src/ui/Search/frmsearchreplace.cpp
@@ -528,22 +528,23 @@ void frmSearchReplace::on_radSearchWithSpecialChars_toggled(bool checked)
         manualSizeAdjust();
     }
 }
-
+#include <QDebug>
 void frmSearchReplace::on_searchStringEdited(const QString &/*text*/)
 {
     NqqSettings& s = NqqSettings::getInstance();
 
     if (s.Search.getSearchAsIType()) {
         if (ui->actionFind->isChecked()) {
-            Editor *editor = currentEditor();
+            currentEditor()->getSelections([&](const QList<Editor::Selection> selections) {
+                Editor *editor = currentEditor();
+                if (selections.length() > 0) {
+                    qDebug() << "Test" << selections[0].to.line;
+                    editor->setCursorPosition(
+                        std::min(selections[0].from, selections[0].to));
+                }
+                findFromUI(true);
 
-            QList<Editor::Selection> selections = editor->getSelections();
-            if (selections.length() > 0) {
-                editor->setCursorPosition(
-                            std::min(selections[0].from, selections[0].to));
-            }
-
-            findFromUI(true);
+            });
         }
     }
 }

--- a/src/ui/Search/frmsearchreplace.cpp
+++ b/src/ui/Search/frmsearchreplace.cpp
@@ -528,7 +528,7 @@ void frmSearchReplace::on_radSearchWithSpecialChars_toggled(bool checked)
         manualSizeAdjust();
     }
 }
-#include <QDebug>
+
 void frmSearchReplace::on_searchStringEdited(const QString &/*text*/)
 {
     NqqSettings& s = NqqSettings::getInstance();

--- a/src/ui/Search/frmsearchreplace.cpp
+++ b/src/ui/Search/frmsearchreplace.cpp
@@ -535,10 +535,9 @@ void frmSearchReplace::on_searchStringEdited(const QString &/*text*/)
 
     if (s.Search.getSearchAsIType()) {
         if (ui->actionFind->isChecked()) {
-            currentEditor()->getSelections([&](const QList<Editor::Selection> selections) {
-                Editor *editor = currentEditor();
+            Editor *editor = currentEditor();
+            editor->getSelections([&, editor](const QList<Editor::Selection> selections) {
                 if (selections.length() > 0) {
-                    qDebug() << "Test" << selections[0].to.line;
                     editor->setCursorPosition(
                         std::min(selections[0].from, selections[0].to));
                 }

--- a/src/ui/frmpreferences.cpp
+++ b/src/ui/frmpreferences.cpp
@@ -102,7 +102,9 @@ void frmPreferences::updatePreviewEditorFont()
 
     // Re-setting language also updates the position of text selection. If not done, selected text
     // would often glitch out when changing the font causes the position of text characters to change.
-    m_previewEditor->setLanguage(m_previewEditor->getLanguage());
+    m_previewEditor->getLanguage([&](const QString& langId) {
+        m_previewEditor->setLanguage(langId);
+    });
 }
 
 void frmPreferences::on_treeWidget_currentItemChanged(QTreeWidgetItem *current, QTreeWidgetItem * /*previous*/)
@@ -355,7 +357,9 @@ bool frmPreferences::applySettings()
             editor->setFont(fontFamily, fontSize, lineHeight);
 
             // Reset language-dependent settings (e.g. tab settings)
-            editor->setLanguage(editor->getLanguage());
+            editor->getLanguage([&, editor](const QString& langId) {
+                editor->setLanguage(langId);
+            });
 
             return true;
         });

--- a/src/ui/include/EditorNS/editor.h
+++ b/src/ui/include/EditorNS/editor.h
@@ -278,13 +278,7 @@ namespace EditorNS
 
         void setSelectionsText(const QStringList &texts, selectMode mode);
         void setSelectionsText(const QStringList &texts);
-        void setSelection(int fromLine, int fromCol, int toLine, int toCol);
-
-        /**
-         * @brief Returns the currently selected texts.
-         * @return
-         */
-        QList<Selection> convertToSelections(const QVariant& sels);
+        void setSelection(int fromLine, int fromCol, int toLine, int toCol); 
 
         void setOverwrite(bool overwrite);
         void setTabsVisible(bool visible);
@@ -435,6 +429,7 @@ namespace EditorNS
             sendMessageWithCallback(msg, QVariant(0), callback);
         }
 
+        QList<Selection> convertToSelections(const QVariant& sels);
     private slots:
         void on_javaScriptWindowObjectCleared();
         /**

--- a/src/ui/include/EditorNS/editor.h
+++ b/src/ui/include/EditorNS/editor.h
@@ -11,10 +11,9 @@
 #include <QVBoxLayout>
 #include <QTextCodec>
 #include <QPrinter>
-#include <QMutex>
-#include <QMutexLocker>
 #include <QEventLoop>
 #include <QJsonDocument>
+#include <functional>
 namespace EditorNS
 {
 
@@ -308,42 +307,21 @@ namespace EditorNS
          * @param callback  Lambda or functor.
          *                  Must accept QList<Editor::Selection> type as parameter.
          */
-        template<typename T>
-        void getSelections(T callback)
-        {
-            sendMessageWithCallback("C_FUN_GET_SELECTIONS", 
-                    [&, callback](const QVariant& v) {
-                callback(convertToSelections(v));
-            }); 
-        }
+        void getSelections(std::function<void(QList<Selection>)> callback);
 
         /**
          * @brief Get the currently selected texts.
          * @param callback  Lambda or functor.
          *                  Must accept QStringList type as parameter.
          */
-        template<typename T>
-        void getSelectedTexts(T callback)
-        {
-            sendMessageWithCallback("C_FUN_GET_SELECTIONS_TEXT", 
-                    [callback](const QVariant& v) mutable {
-                callback(v.toStringList());
-            });
-        }
+        void getSelectedTexts(std::function<void(QStringList)> callback);
 
         /**
          * @brief Get the current editor language.
          * @param callback Lambda or functor.
          *                 Must accept QString type as parameter.
          */
-        template<typename T>
-        void getLanguage(T callback) {
-            sendMessageWithCallback("C_FUN_GET_CURRENT_LANGUAGE",
-            [callback](const QVariant &v) {
-                QString langId = v.toMap().value("id").toString();
-                callback(langId);
-            });
-        }
+        void getLanguage(std::function<void(QString)> callback); 
 
 
     private:

--- a/src/ui/include/EditorNS/editor.h
+++ b/src/ui/include/EditorNS/editor.h
@@ -177,15 +177,7 @@ namespace EditorNS
         static QList<QMap<QString, QString> > languages();
 
 
-        /**
-         * @brief Get the currently active language used
-         *        in the editor.
-         * @param val The value to pull from the language data,
-         *        or ID by default.
-         * @return The value associated with the key "val".
-         */
-
-        QString getLanguage(const QString& val = "id");
+        QString getLanguage();
         /**
          * @brief Set the language to use for the editor.
          *        It automatically adjusts tab settings from
@@ -337,6 +329,15 @@ namespace EditorNS
                 }else {
                     callback(v.toStringList());
                 }
+            });
+        }
+
+        template<typename T>
+        void getLanguage(T callback) {
+            sendMessageWithCallback("C_FUN_GET_CURRENT_LANGUAGE",
+            [callback](const QVariant &v) {
+                QString langId = v.toMap().value("id").toString();
+                callback(langId);
             });
         }
 

--- a/src/ui/include/EditorNS/editor.h
+++ b/src/ui/include/EditorNS/editor.h
@@ -408,7 +408,6 @@ namespace EditorNS
             sendMessageWithCallback(msg, QVariant(0), callback);
         }
 
-        QList<Selection> convertToSelections(const QVariant& sels);
     private slots:
         void on_javaScriptWindowObjectCleared();
         /**

--- a/src/ui/include/EditorNS/editor.h
+++ b/src/ui/include/EditorNS/editor.h
@@ -285,7 +285,6 @@ namespace EditorNS
         Editor::IndentationMode detectDocumentIndentation(bool *found = nullptr);
         Editor::IndentationMode indentationMode();
 
-        QString getCurrentWord(); 
         int getLineCount();
         int getCharCount();
 
@@ -314,21 +313,6 @@ namespace EditorNS
             sendMessageWithCallback("C_FUN_GET_SELECTIONS_TEXT", 
                     [callback](const QVariant& v) mutable {
                 callback(v.toStringList());
-            });
-        }
-
-        template<typename T>
-        void getCurrentWordOrSelections(T callback) {
-            sendMessageWithCallback("C_FUN_GET_SELECTIONS_TEXT",
-            [&, callback](const QVariant& v) mutable {
-                if(v.isNull()) {
-                    sendMessageWithCallback("C_FUN_GET_CURRENT_WORD",
-                    [callback](const QVariant& v) mutable {
-                        callback(v.toStringList());
-                    });
-                }else {
-                    callback(v.toStringList());
-                }
             });
         }
 

--- a/src/ui/include/EditorNS/editor.h
+++ b/src/ui/include/EditorNS/editor.h
@@ -323,6 +323,7 @@ namespace EditorNS
          */
         void getLanguage(std::function<void(QString)> callback); 
 
+        void getCurrentWordOrSelections(std::function<void(QStringList)> callback); 
 
     private:
         static QQueue<Editor*> m_editorBuffer;

--- a/src/ui/include/EditorNS/editor.h
+++ b/src/ui/include/EditorNS/editor.h
@@ -307,23 +307,28 @@ namespace EditorNS
          * @param callback  Lambda or functor.
          *                  Must accept QList<Editor::Selection> type as parameter.
          */
-        void getSelections(std::function<void(QList<Selection>)> callback);
+        void getSelections(std::function<void(const QList<Selection>&)> callback);
 
         /**
          * @brief Get the currently selected texts.
          * @param callback  Lambda or functor.
          *                  Must accept QStringList type as parameter.
          */
-        void getSelectedTexts(std::function<void(QStringList)> callback);
+        void getSelectedTexts(std::function<void(const QStringList&)> callback);
 
         /**
          * @brief Get the current editor language.
          * @param callback Lambda or functor.
          *                 Must accept QString type as parameter.
          */
-        void getLanguage(std::function<void(QString)> callback); 
-
-        void getCurrentWordOrSelections(std::function<void(QStringList)> callback); 
+        void getLanguage(std::function<void(const QString&)> callback); 
+        /**
+         * @brief Get the currently selected text, or the word under the cursor
+         *        if no text is selected.
+         * @param callback Lambda or functor.
+         *                 Must accept QStringList type as parameter.
+         */
+        void getCurrentWordOrSelections(std::function<void(const QStringList&)> callback); 
 
     private:
         static QQueue<Editor*> m_editorBuffer;

--- a/src/ui/include/EditorNS/editor.h
+++ b/src/ui/include/EditorNS/editor.h
@@ -176,8 +176,12 @@ namespace EditorNS
         void markDirty();
         static QList<QMap<QString, QString> > languages();
 
-
+        /**
+         * @brief Get the id of the language currently being used by the editor.
+         * @return language_id
+         */
         QString getLanguage();
+
         /**
          * @brief Set the language to use for the editor.
          *        It automatically adjusts tab settings from
@@ -188,8 +192,15 @@ namespace EditorNS
         void setLanguageFromFileName(QString fileName);
         void setLanguageFromFileName();
         
-        
+        /**
+         * @brief Get the content of the editor.
+         * @return QString content text.
+         */
         QString value();
+        /**
+         * @brief Set the content of the editor, overwriting previous content.
+         * @param value New content to set.
+         */
         void setValue(const QString &value);
 
         /**
@@ -298,6 +309,11 @@ namespace EditorNS
          */
         void requestCursorInfo();
 
+        /**
+         * @brief Get the current selection boundaries.
+         * @param callback  Lambda or functor.
+         *                  Must accept QList<Editor::Selection> type as parameter.
+         */
         template<typename T>
         void getSelections(T callback)
         {
@@ -307,6 +323,11 @@ namespace EditorNS
             }); 
         }
 
+        /**
+         * @brief Get the currently selected texts.
+         * @param callback  Lambda or functor.
+         *                  Must accept QStringList type as parameter.
+         */
         template<typename T>
         void getSelectedTexts(T callback)
         {
@@ -316,6 +337,11 @@ namespace EditorNS
             });
         }
 
+        /**
+         * @brief Get the current editor language.
+         * @param callback Lambda or functor.
+         *                 Must accept QString type as parameter.
+         */
         template<typename T>
         void getLanguage(T callback) {
             sendMessageWithCallback("C_FUN_GET_CURRENT_LANGUAGE",
@@ -379,18 +405,36 @@ namespace EditorNS
         LanguageInfo buildLanguageChangedEventData(const QVariant& data,
                 bool cache = true);
 
+        /**
+         * @brief Sends a javascript message, including data, to the editor.
+         *        Invoking the specified "callback" when execution has 
+         *        completed.
+         * @param msg Initial message, which maps to a javascript function.
+         * @param data QVariant filled with data to send to javascript.
+         * @param callback Functor or lambda.
+         */
         template<typename T>
         void sendMessageWithCallback(const QString& msg, const QVariant &data, T callback) {
             QString jsonData = QJsonDocument::fromVariant(data).toJson();
+            if (jsonData.isEmpty()) 
+                jsonData.append("0");
             QString jsMsg = QString("UiDriver.messageReceived('%1',%2)").arg(msg).arg(jsonData);
             m_webView->page()->runJavaScript(jsMsg, callback);
         }
 
+        /**
+         * @brief This is an overloaded function.
+         *        Sends a javascript message to the editor, invoking the 
+         *        specified "callback" when execution has completed.
+         * @param msg Initial message, which maps to a javascript function.
+         * @param data QVariant filled with data to send to javascript.
+         * @param callback Functor or lambda.
+         */
         template<typename T>
         void sendMessageWithCallback(const QString& msg, T callback) {
-            QString jsMsg = QString("UiDriver.messageReceived('%1',%2)").arg(msg).arg(0);
-            m_webView->page()->runJavaScript(jsMsg, callback);
+            sendMessageWithCallback(msg, QVariant(0), callback);
         }
+
     private slots:
         void on_javaScriptWindowObjectCleared();
         /**

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -158,8 +158,6 @@ private slots:
     void on_actionOpen_a_New_Window_triggered();
     void on_actionOpen_in_New_Window_triggered();
     void on_actionMove_to_New_Window_triggered();
-    void on_actionOpen_file_triggered();
-    void on_actionOpen_in_another_window_triggered();
     void on_tabBarDoubleClicked(EditorTabWidget *tabWidget, int tab);
     void on_actionFind_in_Files_triggered();
     void on_actionDelete_Line_triggered();
@@ -263,9 +261,6 @@ private:
     void                convertEditorEncoding(Editor *editor, QTextCodec *codec, bool bom);
     void                toggleOverwrite();
     bool                reloadWithWarning(EditorTabWidget *tabWidget, int tab, QTextCodec *codec, bool bom);
-    QStringList         currentWordOrSelections();
-    QString             currentWordOrSelection();
-    void                currentWordOnlineSearch(const QString &searchUrl);
 
     /**
      * @brief Workaround for this bug: https://bugs.launchpad.net/ubuntu/+source/appmenu-qt5/+bug/1313248

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -254,7 +254,7 @@ private:
     int                 saveAs(EditorTabWidget *tabWidget, int tab, bool copy);
     QUrl                getSaveDialogDefaultFileName(EditorTabWidget *tabWidget, int tab);
     void                setupLanguagesMenu();
-    void                transformSelectedText(std::function<QString (const QString &)> func);
+    void                transformSelectedText(QString (*func)(const QString&));
     void                restoreWindowSettings();
     void                loadIcons();
     void                updateRecentDocsInMenu();

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2005,7 +2005,7 @@ void MainWindow::runCommand()
         QStringList args = NqqRun::RunDialog::parseCommandString(cmd);
         if (!args.isEmpty()) {
             cmd = args.takeFirst();
-            if(!QProcess::startDetached(cmd, args)) {
+            if (!QProcess::startDetached(cmd, args)) {
             }
         }
     };
@@ -2018,14 +2018,14 @@ void MainWindow::runCommand()
     }
 
     // Check for selection before performing asynchronous call.
-    if(cmd.contains("\%selection\%")) {
+    if (cmd.contains("\%selection\%")) {
         editor->getSelectedTexts([cmd, doRun](const QStringList& selection) mutable {
-            if(!selection.isEmpty() && !selection.first().isEmpty()) {
+            if (!selection.isEmpty() && !selection.first().isEmpty()) {
                 cmd.replace("\%selection\%",selection.first());
             }
             doRun(cmd);
         });
-    }else {
+    } else {
         doRun(cmd);
     }
 }

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1067,7 +1067,7 @@ void MainWindow::on_actionSave_a_Copy_As_triggered()
 
 void MainWindow::on_action_Copy_triggered()
 {
-    currentEditor()->getSelectedTexts([&](const QStringList& sel) {
+    currentEditor()->getSelectedTexts([](const QStringList& sel) {
         QApplication::clipboard()->setText(sel.join("\n"));
     });
 }
@@ -1332,9 +1332,9 @@ void MainWindow::on_actionSearch_triggered()
         instantiateFrmSearchReplace();
     }
 
-    currentEditor()->getSelectedTexts([&](const QStringList& sel) {
+    currentEditor()->getSelectedTexts([this](const QStringList& sel) {
         if (sel.length() > 0 && sel[0].length() > 0) {
-            m_frmSearchReplace->setSearchText(sel[0]);
+            this->m_frmSearchReplace->setSearchText(sel[0]);
         } 
     });
    
@@ -1470,7 +1470,7 @@ void MainWindow::on_actionReplace_triggered()
         instantiateFrmSearchReplace();
     }
 
-    currentEditor()->getSelectedTexts([&](const QStringList& sel) {
+    currentEditor()->getSelectedTexts([this](const QStringList& sel) {
         if (sel.length() > 0 && sel[0].length() > 0) {
             m_frmSearchReplace->setSearchText(sel[0]);
         }     
@@ -1521,10 +1521,11 @@ void MainWindow::on_editorMouseWheel(EditorTabWidget *tabWidget, int tab, QWheel
     }
 }
 
-void MainWindow::transformSelectedText(std::function<QString (const QString &)> func)
+void MainWindow::transformSelectedText(QString (*func)(const QString&))
 {
     Editor* editor = currentEditor();
-    editor->getSelectedTexts([&, editor](QStringList sel) {
+    editor->getSelectedTexts([func, editor](QStringList sel) {
+        qDebug() << sizeof(func);
         for (int i = 0; i < sel.length(); i++) {
             sel.replace(i, func(sel.at(i)));
         }
@@ -1535,14 +1536,14 @@ void MainWindow::transformSelectedText(std::function<QString (const QString &)> 
 
 void MainWindow::on_actionUPPERCASE_triggered()
 {
-    transformSelectedText([](const QString &str) {
+    transformSelectedText(+[](const QString&str) {
         return str.toUpper();
     });
 }
 
 void MainWindow::on_actionLowercase_triggered()
 {
-    transformSelectedText([](const QString &str) {
+    transformSelectedText(+[](const QString &str) {
         return str.toLower();
     });
 }

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1523,11 +1523,12 @@ void MainWindow::on_editorMouseWheel(EditorTabWidget *tabWidget, int tab, QWheel
 
 void MainWindow::transformSelectedText(std::function<QString (const QString &)> func)
 {
-    currentEditor()->getSelectedTexts([&](QStringList sel) {
+    Editor* editor = currentEditor();
+    editor->getSelectedTexts([&, editor](QStringList sel) {
         for (int i = 0; i < sel.length(); i++) {
             sel.replace(i, func(sel.at(i)));
         }
-        currentEditor()->setSelectionsText(sel, Editor::selectMode_selected);          
+        editor->setSelectionsText(sel, Editor::selectMode_selected);          
     });
 
 }

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1067,8 +1067,9 @@ void MainWindow::on_actionSave_a_Copy_As_triggered()
 
 void MainWindow::on_action_Copy_triggered()
 {
-    QStringList sel = currentEditor()->getSelectedTexts();
-    QApplication::clipboard()->setText(sel.join("\n"));
+    currentEditor()->getSelectedTexts([&](const QStringList& sel) {
+        QApplication::clipboard()->setText(sel.join("\n"));
+    });
 }
 
 void MainWindow::on_action_Paste_triggered()
@@ -1331,11 +1332,12 @@ void MainWindow::on_actionSearch_triggered()
         instantiateFrmSearchReplace();
     }
 
-    QStringList sel = currentEditor()->getSelectedTexts();
-    if (sel.length() > 0 && sel[0].length() > 0) {
-        m_frmSearchReplace->setSearchText(sel[0]);
-    }
-
+    currentEditor()->getSelectedTexts([&](const QStringList& sel) {
+        if (sel.length() > 0 && sel[0].length() > 0) {
+            m_frmSearchReplace->setSearchText(sel[0]);
+        } 
+    });
+   
     m_frmSearchReplace->show(frmSearchReplace::TabSearch);
     m_frmSearchReplace->activateWindow();
 }
@@ -1468,10 +1470,11 @@ void MainWindow::on_actionReplace_triggered()
         instantiateFrmSearchReplace();
     }
 
-    QStringList sel = currentEditor()->getSelectedTexts();
-    if (sel.length() > 0 && sel[0].length() > 0) {
-        m_frmSearchReplace->setSearchText(sel[0]);
-    }
+    currentEditor()->getSelectedTexts([&](const QStringList& sel) {
+        if (sel.length() > 0 && sel[0].length() > 0) {
+            m_frmSearchReplace->setSearchText(sel[0]);
+        }     
+    });
 
     m_frmSearchReplace->show(frmSearchReplace::TabReplace);
     m_frmSearchReplace->activateWindow();
@@ -1520,14 +1523,13 @@ void MainWindow::on_editorMouseWheel(EditorTabWidget *tabWidget, int tab, QWheel
 
 void MainWindow::transformSelectedText(std::function<QString (const QString &)> func)
 {
-    Editor *editor = currentEditor();
-    QStringList sel = editor->getSelectedTexts();
+    currentEditor()->getSelectedTexts([&](QStringList sel) {
+        for (int i = 0; i < sel.length(); i++) {
+            sel.replace(i, func(sel.at(i)));
+        }
+        currentEditor()->setSelectionsText(sel, Editor::selectMode_selected);          
+    });
 
-    for (int i = 0; i < sel.length(); i++) {
-        sel.replace(i, func(sel.at(i)));
-    }
-
-    editor->setSelectionsText(sel, Editor::selectMode_selected);
 }
 
 void MainWindow::on_actionUPPERCASE_triggered()
@@ -1979,7 +1981,7 @@ void MainWindow::runCommand()
     QAction *a = qobject_cast<QAction*>(sender());
     QString cmd;
 
-    if (a->data().toString().size()) {
+    if (!a->data().isNull()) {
         cmd = a->data().toString();
     } else {
         NqqRun::RunDialog rd;
@@ -1999,22 +2001,24 @@ void MainWindow::runCommand()
     Editor *editor = currentEditor();
 
     QUrl url = currentEditor()->fileName();
-    QStringList selection = editor->getSelectedTexts();
     if (!url.isEmpty()) {
         cmd.replace("\%fullpath\%", url.toString(QUrl::None));
         cmd.replace("\%path\%", url.path(QUrl::FullyEncoded));
         cmd.replace("\%filename\%", url.fileName(QUrl::FullyEncoded));
     }
-    if(!selection.first().isEmpty()) {
-        cmd.replace("\%selection\%",selection.first());
-    }
-    QStringList args = NqqRun::RunDialog::parseCommandString(cmd);
-    if (!args.isEmpty()) {
-        cmd = args.takeFirst();
-        if(!QProcess::startDetached(cmd, args)) {
-        
+    editor->getSelectedTexts([cmd](const QStringList& selection) mutable {
+        if(!selection.isEmpty() && !selection.first().isEmpty()) {
+            cmd.replace("\%selection\%",selection.first());
         }
-    }
+        QStringList args = NqqRun::RunDialog::parseCommandString(cmd);
+        if (!args.isEmpty()) {
+            cmd = args.takeFirst();
+            if(!QProcess::startDetached(cmd, args)) {
+            }
+        }
+
+    });
+
 }
 
 void MainWindow::on_actionPrint_triggered()
@@ -2029,48 +2033,6 @@ void MainWindow::on_actionPrint_Now_triggered()
 {
     QPrinter printer(QPrinter::HighResolution);
     currentEditor()->print(&printer);
-}
-/*
-void MainWindow::on_actionLaunch_in_Chrome_triggered()
-{
-    QUrl fileName = currentEditor()->fileName();
-    if (!fileName.isEmpty()) {
-        QStringList args;
-        args << fileName.toString(QUrl::None);
-        QProcess::startDetached("google-chrome", args);
-    }
-}
-*/
-QStringList MainWindow::currentWordOrSelections()
-{
-    Editor *editor = currentEditor();
-    QStringList selection = editor->getSelectedTexts();
-
-    if (selection.isEmpty() || selection.first().isEmpty()) {
-        return QStringList(editor->getCurrentWord());
-    } else {
-        return selection;
-    }
-}
-
-QString MainWindow::currentWordOrSelection()
-{
-    QStringList terms = currentWordOrSelections();
-    if (terms.isEmpty()) {
-        return QString();
-    } else {
-        return terms.first();
-    }
-}
-
-void MainWindow::currentWordOnlineSearch(const QString &searchUrl)
-{
-    QString term = currentWordOrSelection();
-
-    if (!term.isNull() && !term.isEmpty()) {
-        QUrl phpHelp = QUrl(searchUrl.arg(QString(QUrl::toPercentEncoding(term))));
-        QDesktopServices::openUrl(phpHelp);
-    }
 }
 
 void MainWindow::on_actionOpen_a_New_Window_triggered()
@@ -2107,31 +2069,6 @@ void MainWindow::on_actionMove_to_New_Window_triggered()
     }
 }
 
-void MainWindow::on_actionOpen_file_triggered()
-{
-    QStringList terms = currentWordOrSelections();
-    if (!terms.isEmpty()) {
-        QList<QUrl> urls;
-        for (QString term : terms) {
-            urls.append(QUrl::fromLocalFile(term));
-        }
-
-        m_docEngine->loadDocuments(urls,
-                                   m_topEditorContainer->currentTabWidget());
-    }
-}
-
-void MainWindow::on_actionOpen_in_another_window_triggered()
-{
-    QStringList terms = currentWordOrSelections();
-    if (!terms.isEmpty()) {
-        terms.prepend(QApplication::arguments().first());
-
-        MainWindow *b = new MainWindow(terms, 0);
-        b->show();
-    }
-}
-
 void MainWindow::on_tabBarDoubleClicked(EditorTabWidget *tabWidget, int tab)
 {
     if (tab == -1) {
@@ -2145,10 +2082,11 @@ void MainWindow::on_actionFind_in_Files_triggered()
         instantiateFrmSearchReplace();
     }
 
-    QStringList sel = currentEditor()->getSelectedTexts();
-    if (sel.length() > 0 && sel[0].length() > 0) {
-        m_frmSearchReplace->setSearchText(sel[0]);
-    }
+    currentEditor()->getSelectedTexts([&](const QStringList& sel) {
+        if (sel.length() > 0 && sel[0].length() > 0) {
+            m_frmSearchReplace->setSearchText(sel[0]);
+        }
+    });
 
     m_frmSearchReplace->show(frmSearchReplace::TabSearchInFiles);
     m_frmSearchReplace->activateWindow();

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1525,7 +1525,6 @@ void MainWindow::transformSelectedText(QString (*func)(const QString&))
 {
     Editor* editor = currentEditor();
     editor->getSelectedTexts([func, editor](QStringList sel) {
-        qDebug() << sizeof(func);
         for (int i = 0; i < sel.length(); i++) {
             sel.replace(i, func(sel.at(i)));
         }

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -784,46 +784,6 @@
     <string>&amp;Run...</string>
    </property>
   </action>
-  <action name="actionLaunch_in_Firefox">
-   <property name="text">
-    <string>Launch in Firefox</string>
-   </property>
-  </action>
-  <action name="actionLaunch_in_Chromium">
-   <property name="text">
-    <string>Launch in Chromium</string>
-   </property>
-  </action>
-  <action name="actionGet_php_help">
-   <property name="text">
-    <string>Get PHP help</string>
-   </property>
-  </action>
-  <action name="actionGoogle_Search">
-   <property name="text">
-    <string>Google Search</string>
-   </property>
-  </action>
-  <action name="actionWikipedia_Search">
-   <property name="text">
-    <string>Wikipedia Search</string>
-   </property>
-  </action>
-  <action name="actionOpen_file">
-   <property name="text">
-    <string>Open file(s)</string>
-   </property>
-  </action>
-  <action name="actionOpen_in_another_window">
-   <property name="text">
-    <string>Open file(s) in a new window</string>
-   </property>
-  </action>
-  <action name="actionModify_Shortcut_Delete_Command">
-   <property name="text">
-    <string>Modify Shortcut / Delete Command...</string>
-   </property>
-  </action>
   <action name="actionPreferences">
    <property name="text">
     <string>&amp;Preferences...</string>


### PR DESCRIPTION
Putting this here so progress on the async implementation can be tracked.  The goal is to make calls asynchronous where we can... and supply a blocking fallback where we can't.

Currently, sessions uses the fallback getLanguage... mainly because I'm not familiar enough with that part of Notepadqq to make it asynchronous. (And it might be pretty messy to do so.)

I'm going to try and keep asynchronous to what's necessary for the moment just to be safe.... Most of the data is transported through JsProxy on the fly anyways, which alleviates a lot of the issues.

The current commits fix #389, I believe, which is a big plus since it's been a little evasive.