### PR TITLE
Webengine misc cleanup.

### DIFF
--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -1,7 +1,6 @@
 #include <QDir>
 #include <QMessageBox>
 #include <QRegularExpression>
-#include <QStringBuilder>
 #include <QUrlQuery>
 #include <QVBoxLayout>
 #include <QWebEngineSettings>
@@ -58,7 +57,7 @@ namespace EditorNS
         query.addQueryItem("themePath", theme.path);
         query.addQueryItem("themeName", theme.name);
 
-        QUrl url = QUrl("file://" % Notepadqq::editorPath());
+        QUrl url = QUrl("file://" + Notepadqq::editorPath());
         url.setQuery(query);
         m_webView->setEnabled(false);
         m_webView->page()->load(url);
@@ -646,8 +645,8 @@ namespace EditorNS
             return theme;
 
         auto editorPath = QFileInfo(Notepadqq::editorPath());
-        auto bundledThemesDir = QDir(editorPath.absolutePath() % "/libs/codemirror/theme/");
-        auto themeFile = bundledThemesDir.filePath(name % ".css");
+        auto bundledThemesDir = QDir(editorPath.absolutePath() + "/libs/codemirror/theme/");
+        auto themeFile = bundledThemesDir.filePath(name + ".css");
         if (QFile(themeFile).exists()) {
             theme.name = name;
             theme.path = themeFile;
@@ -659,7 +658,7 @@ namespace EditorNS
     {
         auto editorPath = QFileInfo(Notepadqq::editorPath());
         auto bundledThemesDir = 
-            QDir(editorPath.absolutePath() % "/libs/codemirror/theme/");
+            QDir(editorPath.absolutePath() + "/libs/codemirror/theme/");
         auto filters = QStringList("*.css");
         bundledThemesDir.setNameFilters(filters);
 

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -1,20 +1,15 @@
+#include <QDir>
+#include <QMessageBox>
+#include <QRegularExpression>
+#include <QStringBuilder>
+#include <QUrlQuery>
+#include <QVBoxLayout>
+#include <QWebEngineSettings>
+
 #include "include/EditorNS/editor.h"
 #include "include/notepadqq.h"
 #include "include/nqqsettings.h"
-#include <QVBoxLayout>
-#include <QMessageBox>
-#include <QDir>
-#include <QEventLoop>
-#include <QUrlQuery>
-#include <QRegularExpression>
-#include <QJsonDocument>
-#include <QJsonObject>
-#include <QJsonArray>
 
-#include <QWebEngineSettings>
-#include <QtWebChannel/QWebChannel>
-#include <QJsonDocument>
-#include <memory>
 namespace EditorNS
 {
     QQueue<Editor*> Editor::m_editorBuffer = QQueue<Editor*>();
@@ -39,30 +34,31 @@ namespace EditorNS
         vbox->addWidget(m_webView, 1);
         setLayout(vbox);
 
-        connect(m_webView->page(),
-                &QWebEnginePage::loadStarted,
-                this,
-                &Editor::on_javaScriptWindowObjectCleared);
-        connect(m_webView, &CustomQWebView::mouseWheel, this, &Editor::mouseWheel);
-        connect(m_webView, &CustomQWebView::urlsDropped, this, &Editor::urlsDropped);
     }
 
     void Editor::initWebView()
     {
         // Get the currently active color scheme/theme
         auto themeName = NqqSettings::getInstance().Appearance.getColorScheme();
-        if (themeName == "") {
+        if (themeName.isEmpty()) {
             themeName = "default";
         }
         const auto theme = themeFromName(themeName);
 
         m_webView = new CustomQWebView(this);
+        //m_webView->page()->setBackgroundColor(Qt::transparent);
+        connect(m_webView->page(),
+                &QWebEnginePage::loadStarted,
+                this,
+                &Editor::on_javaScriptWindowObjectCleared);
+        connect(m_webView, &CustomQWebView::mouseWheel, this, &Editor::mouseWheel);
+        connect(m_webView, &CustomQWebView::urlsDropped, this, &Editor::urlsDropped);
 
         QUrlQuery query;
         query.addQueryItem("themePath", theme.path);
         query.addQueryItem("themeName", theme.name);
 
-        QUrl url = QUrl("file://" + Notepadqq::editorPath());
+        QUrl url = QUrl("file://" % Notepadqq::editorPath());
         url.setQuery(query);
         m_webView->setEnabled(false);
         m_webView->page()->load(url);
@@ -157,33 +153,33 @@ namespace EditorNS
 
     void Editor::on_proxyMessageReceived(QString msg, QVariant data)
     {
-        if (msg == "J_EVT_READY") {
+        if (msg == QLatin1String("J_EVT_READY")) {
             m_loaded = true;
             emit editorReady();
-        } else if (msg == "J_EVT_CONTENT_CHANGED") {
+        } else if (msg == QLatin1String("J_EVT_CONTENT_CHANGED")) {
             emit contentChanged(buildContentChangedEventData(data));
-        } else if (msg == "J_EVT_CLEAN_CHANGED") {
+        } else if (msg == QLatin1String("J_EVT_CLEAN_CHANGED")) {
             m_info.content.clean = data.toBool();
             emit cleanChanged(m_info.content.clean);
-        } else if (msg == "J_EVT_CURSOR_ACTIVITY") {
+        } else if (msg == QLatin1String("J_EVT_CURSOR_ACTIVITY")) {
             emit cursorActivity(buildCursorEventData(data));
-        } else if (msg == "J_EVT_GOT_FOCUS") {
+        } else if (msg == QLatin1String("J_EVT_GOT_FOCUS")) {
             emit gotFocus();
-        } else if (msg == "J_EVT_DOCUMENT_LOADED") {
+        } else if (msg == QLatin1String("J_EVT_DOCUMENT_LOADED")) {
             emit documentLoaded(m_alreadyLoaded, buildDocumentLoadedEventData(data));
             m_alreadyLoaded = true;
-        } else if (msg == "J_EVT_SCROLL_CHANGED") {
+        } else if (msg == QLatin1String("J_EVT_SCROLL_CHANGED")) {
             QPair<int, int> scrollPos;
             scrollPos.first = data.toList().at(0).toInt();
             scrollPos.second = data.toList().at(1).toInt();
-        } else if (msg == "J_EVT_OPTION_CHANGED") {
+        } else if (msg == QLatin1String("J_EVT_OPTION_CHANGED")) {
             // This may need its own function later
-            QVariantMap v = data.toMap();
-            QString key = v.value("key").toString();
-            if (key == "language") {
+            auto v = data.toMap();
+            auto key = v.value("key").toString();
+            if (key == QLatin1String("language")) {
                 auto& cache = LanguageCache::getInstance();
                 emit languageChanged(cache[cache.lookupById(v.value("value").toString())]);
-            }else if (key == "theme") {
+            }else if (key == QLatin1String("theme")) {
                 updateBackground(v.value("value").toString());
             }
         }
@@ -196,9 +192,10 @@ namespace EditorNS
         if (!data.canConvert<QVariantList>()) {
             return m_info.content.indentMode;
         }
-        Editor::IndentationMode indentMode;
-        indentMode.useTabs = data.toList().at(0).toBool();
-        indentMode.size = data.toList().at(1).toInt();
+        auto v = data.toList();
+        IndentationMode indentMode;
+        indentMode.useTabs = v.at(0).toBool();
+        indentMode.size = v.at(1).toInt();
         return indentMode;
     }
 
@@ -221,11 +218,13 @@ namespace EditorNS
             bool cache)
     {
         auto v = data.toMap();
-        CursorInfo  temp;
-        temp.line = v["cursorLine"].toInt();
-        temp.column = v["cursorColumn"].toInt();
-        temp.selectionCharCount = v["selectionCharCount"].toInt();
-        temp.selectionLineCount = v["selectionLineCount"].toInt();
+        CursorInfo temp = {
+            .line = v["cursorLine"].toInt(),
+            .column = v["cursorLine"].toInt(),
+            .selectionCharCount = v["selectionCharCount"].toInt(),
+            .selectionLineCount = v["selectionLineCount"].toInt(),
+            .selections = QList<Selection>()
+        };
         for (auto selection : v["selections"].toList()) {
             QVariantMap anchor = selection.toMap().value("anchor").toMap();
             QVariantMap head = selection.toMap().value("head").toMap();
@@ -305,19 +304,14 @@ namespace EditorNS
     void Editor::setLanguage(const Language& language)
     {
         auto& cache = LanguageCache::getInstance();
-
         if (!m_info.content.indentMode.custom) {
             setIndentationMode(language.id);
         }
-
-        auto& currentLang = cache[m_info.language];
-        QVariantMap data;
-        if (currentLang.mime.isEmpty()) {
-            data["mode"] = currentLang.mode;
-        } else {
-            data["mode"] = currentLang.mime;
-        }
-        data["id"] = currentLang.id;
+        auto& cLang = cache[m_info.language];
+        QVariantMap data {
+            {"id", cLang.id},
+            {"mode", cLang.mime.isEmpty() ? cLang.mode : cLang.mime}
+        };
         sendMessage("C_CMD_SET_LANGUAGE", data);
 
     }
@@ -371,25 +365,26 @@ namespace EditorNS
 
     void Editor::setIndentationMode(QString language)
     {
-        NqqSettings& s = NqqSettings::getInstance();
+        auto& ls = NqqSettings::getInstance().Languages;
 
-        if (s.Languages.getUseDefaultSettings(language))
+        if (ls.getUseDefaultSettings(language))
             language = "default";
 
-        setIndentationMode(!s.Languages.getIndentWithSpaces(language),
-                            s.Languages.getTabSize(language),
+        setIndentationMode(!ls.getIndentWithSpaces(language),
+                            ls.getTabSize(language),
                             false);
     }
 
     void Editor::setIndentationMode(const bool useTabs, const int size, 
             const bool custom)
     {
-        QVariantMap data;
-        data.insert("useTabs", useTabs);
-        data.insert("size", size);
         m_info.content.indentMode.useTabs = useTabs;
         m_info.content.indentMode.size = size;
         m_info.content.indentMode.custom = custom;
+        QVariantMap data {
+            {"useTabs", useTabs}, 
+            {"size", size}
+        };
         sendMessage("C_CMD_SET_INDENTATION_MODE", data);
     }
 
@@ -426,7 +421,6 @@ namespace EditorNS
 
     void Editor::setValue(const QString &value)
     {
-        // Go ahead and detect the language from content if we can up front.
         detectLanguageFromContent(value);
         sendMessage("C_CMD_SET_VALUE", value);
     }
@@ -497,22 +491,18 @@ namespace EditorNS
 
     void Editor::setSelectionsText(const QStringList &texts, SelectMode mode)
     {
-        QString modeStr = "";
+        QVariantMap data {{"text", texts}};
         switch (mode) {
             case SelectMode::CursorAfter:
-                modeStr = "after";
+                data.insert("select", "after");
                 break;
             case SelectMode::CursorBefore:
-                modeStr = "before";
+                data.insert("select", "before");
                 break;
             default:
-                modeStr = "selected";
+                data.insert("select", "selected");
                 break;
         }
-        QVariantMap data;
-        data.insert("text", texts);
-        data.insert("select", modeStr);
-
         sendMessage("C_CMD_SET_SELECTIONS_TEXT", data);
     }
 
@@ -656,8 +646,8 @@ namespace EditorNS
             return theme;
 
         auto editorPath = QFileInfo(Notepadqq::editorPath());
-        auto bundledThemesDir = QDir(editorPath.absolutePath() + "/libs/codemirror/theme/");
-        auto themeFile = bundledThemesDir.filePath(name + ".css");
+        auto bundledThemesDir = QDir(editorPath.absolutePath() % "/libs/codemirror/theme/");
+        auto themeFile = bundledThemesDir.filePath(name % ".css");
         if (QFile(themeFile).exists()) {
             theme.name = name;
             theme.path = themeFile;
@@ -668,7 +658,8 @@ namespace EditorNS
     QList<Editor::Theme> Editor::themes()
     {
         auto editorPath = QFileInfo(Notepadqq::editorPath());
-        auto bundledThemesDir = QDir(editorPath.absolutePath() + "/libs/codemirror/theme/");
+        auto bundledThemesDir = 
+            QDir(editorPath.absolutePath() % "/libs/codemirror/theme/");
         auto filters = QStringList("*.css");
         bundledThemesDir.setNameFilters(filters);
 

--- a/src/ui/EditorNS/jsproxy.cpp
+++ b/src/ui/EditorNS/jsproxy.cpp
@@ -1,5 +1,4 @@
 #include "include/EditorNS/jsproxy.h"
-#include <QDebug>
 
 namespace EditorNS {
 

--- a/src/ui/EditorNS/languagecache.cpp
+++ b/src/ui/EditorNS/languagecache.cpp
@@ -20,11 +20,6 @@
 
 namespace EditorNS {
 
-Language::Language()
-{
-
-}
-
 Language::Language(const Language& o) :
     id(o.id),
     name(o.name),

--- a/src/ui/Sessions/sessions.cpp
+++ b/src/ui/Sessions/sessions.cpp
@@ -379,7 +379,6 @@ void loadSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
             QString tmpTxt;
             if(tmpEditor) {
                 if (tmpEditor->fileName().isEmpty()) {
-                    qDebug() << "HERE";
                     tmpTxt = tabW->tabText(0);
                     tmpEditor->setFileName(QUrl("tmp"));
                 }else {
@@ -388,7 +387,6 @@ void loadSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
             }
             const bool success = docEngine->loadDocumentSilent(loadUrl, tabW);
             if (tmpEditor) {
-                qDebug() << "HERE 2";
                 tmpEditor->setFileName(QUrl());
                 tabW->setTabText(0, tmpTxt);
             }

--- a/src/ui/Sessions/sessions.cpp
+++ b/src/ui/Sessions/sessions.cpp
@@ -378,11 +378,17 @@ void loadSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
             Editor* tmpEditor = tabW->editor(0);
             QString tmpTxt;
             if(tmpEditor) {
-                tmpTxt = tabW->tabText(0);
-                tmpEditor->setFileName(QUrl("tmp"));
+                if (tmpEditor->fileName().isEmpty()) {
+                    qDebug() << "HERE";
+                    tmpTxt = tabW->tabText(0);
+                    tmpEditor->setFileName(QUrl("tmp"));
+                }else {
+                    tmpEditor = nullptr;
+                }
             }
             const bool success = docEngine->loadDocumentSilent(loadUrl, tabW);
             if (tmpEditor) {
+                qDebug() << "HERE 2";
                 tmpEditor->setFileName(QUrl());
                 tabW->setTabText(0, tmpTxt);
             }

--- a/src/ui/include/EditorNS/editor.h
+++ b/src/ui/include/EditorNS/editor.h
@@ -1,17 +1,13 @@
 #ifndef EDITOR_H
 #define EDITOR_H
 
-#include <QObject>
-#include <QVariant>
-#include <QJsonValue>
-#include <QQueue>
-#include <QWheelEvent>
-#include <QVBoxLayout>
-#include <QTextCodec>
-#include <QPrinter>
+#include <functional>
 #include <QEventLoop>
 #include <QJsonDocument>
-#include <functional>
+#include <QObject>
+#include <QPrinter>
+#include <QQueue>
+#include <QTextCodec>
 
 #include "include/EditorNS/customqwebview.h"
 #include "include/EditorNS/jsproxy.h"

--- a/src/ui/include/EditorNS/jsproxy.h
+++ b/src/ui/include/EditorNS/jsproxy.h
@@ -2,9 +2,9 @@
 #define _JSPROXY_H_
 
 #include <QObject>
-#include <QVariant>
 #include <QPair>
 #include <QQueue>
+#include <QVariant>
 
 namespace EditorNS {
     /**

--- a/src/ui/include/EditorNS/languagecache.h
+++ b/src/ui/include/EditorNS/languagecache.h
@@ -20,7 +20,7 @@ struct Language {
     QStringList fileNames;
     QStringList fileExtensions;
     QStringList firstNonBlankLine;
-    Language();
+    Language() {};
     Language(const Language& o);
     Language(Language&& o) noexcept;
     Language& operator=(const Language& o);

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -101,7 +101,6 @@ int main(int argc, char *argv[])
 
     // There are no other instances: start a new server.
     a.startServer();
-    //Editor::addEditorToBuffer();
 
     QFile file(Notepadqq::editorPath());
     if (!file.open(QIODevice::ReadOnly)) {

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -101,7 +101,7 @@ int main(int argc, char *argv[])
 
     // There are no other instances: start a new server.
     a.startServer();
-    Editor::addEditorToBuffer();
+    //Editor::addEditorToBuffer();
 
     QFile file(Notepadqq::editorPath());
     if (!file.open(QIODevice::ReadOnly)) {


### PR DESCRIPTION
Just some minor cleanup, removing unused headers... mild tweaks to code to use a few more C++11 constructs.  And a small bug fixes where I forgot to include "real" files in the DocEngine work-around.


On a side note, we probably need to find a better way to do on_proxyMessageReceived... its starting to look pretty ugly.  Might write a "function map", which would route the message to the appropriate function.  This would be similar to how we do it on the JS side.

Another side note: I also came up with a way to delay resizing of the QWebEngineView until the resize is finished (buttery smooth resize)... but its a little hacky so I'm going to try a few different things to see what works best there.  

Mainly getting the ACTUAL state of the mouse after a resize event has completed is darn near impossible using your typical QT functions.  QApplication::mouseButtons() returns the state when the event started, unfortunately.

We could use QAbstractEventDispatcher, but we'd need to write separate bits of code for each individual OS(Windows/Mac/Linux).

Setting up an app-wide eventFilter and keeping track of "is_resizing" would probably be a good way to go, though I'm not 100% on that.