### PR TITLE
https://github.com/notepadqq/notepadqq/issues/421 - fixed

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -136,6 +136,7 @@ MainWindow::MainWindow(const QString &workingDirectory, const QStringList &argum
             m_settings.General.getRememberTabsOnExit() // and the Remember-tabs option is enabled
     ) {
         Sessions::loadSession(m_docEngine, m_topEditorContainer, PersistentCache::cacheSessionPath());
+        refreshEditorUiInfo(m_topEditorContainer->currentTabWidget()->currentEditor());
     }
 
     // Inserts at least an editor


### PR DESCRIPTION
https://github.com/notepadqq/notepadqq/issues/421 fixed.

The title bar is showing the wrong title when Notepadqq
is restarted.

Signed-off-by: Quinton Erasmus <qcerasmus@gmail.com>