### PR TITLE
Open folder contents if a folder is dropped onto Nqq. 

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -593,7 +593,6 @@ void MainWindow::on_editorUrlsDropped(QList<QUrl> urls)
             QFileInfo fileInfo(path);
             if(fileInfo.isDir()) {
                 urls.clear();
-                qDebug() << "WQ";
                 for(QFileInfo fi : QDir(path).entryInfoList(QDir::Files)) {
                     urls.push_back(QUrl::fromLocalFile(fi.filePath()));
                 }

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -586,6 +586,20 @@ void MainWindow::on_editorUrlsDropped(QList<QUrl> urls)
     }
 
     if (!urls.empty()) {
+
+        // If only one URL is dropped and it's a directory, we query the dir's entry list and open that one instead.
+        if(urls.size() == 1) {
+            const QString path = urls.front().toLocalFile();
+            QFileInfo fileInfo(path);
+            if(fileInfo.isDir()) {
+                urls.clear();
+                qDebug() << "WQ";
+                for(QFileInfo fi : QDir(path).entryInfoList(QDir::Files)) {
+                    urls.push_back(QUrl::fromLocalFile(fi.filePath()));
+                }
+            }
+        }
+
         m_docEngine->loadDocuments(urls,
                                    tabWidget);
     }


### PR DESCRIPTION
I've limited it to opening one folder at a time, non-recursively. I think that's the best compromise between sanity and functionality.

Fixes #448 