### PR TITLE
Don't load tabs from session that don't exist and aren't cached.

### DIFF
--- a/src/ui/Sessions/sessions.cpp
+++ b/src/ui/Sessions/sessions.cpp
@@ -371,6 +371,9 @@ void loadSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
             // This is the file to load the document from
             const QUrl& loadUrl = cacheFileExists ? cacheFileUrl : fileUrl;
 
+            if (!fileExists && !cacheFileExists)
+                continue;
+
             const bool success = docEngine->loadDocumentSilent(loadUrl, tabW);
 
             if (!success)


### PR DESCRIPTION
This mirrors the functionality of Notepad++.