### PR TITLE
Prompt user when opening a file from recent history that does not exist anymore

### DIFF
--- a/src/ui/docengine.cpp
+++ b/src/ui/docengine.cpp
@@ -215,6 +215,7 @@ bool DocEngine::loadDocuments(const QList<QUrl> &fileNames, EditorTabWidget *tab
                     // creates that file from outside of notepadqq,
                     // when the user tries to save over it he gets a warning.
                     editor->setFileOnDiskChanged(true);
+                    editor->markDirty();
                 }
 
                 // If there was only a new empty tab opened, remove it

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -263,6 +263,13 @@ private:
     void                currentWordOnlineSearch(const QString &searchUrl);
 
     /**
+     * @brief Attempts to open a file from the recent history. Prompts the user if the file does not exist and
+     *        removes it from the recent history if applicable.
+     * @param url Url of file to open.
+     */
+    void                openRecentFileEntry(QUrl url);
+
+    /**
      * @brief Workaround for this bug: https://bugs.launchpad.net/ubuntu/+source/appmenu-qt5/+bug/1313248
      */
     void                fixKeyboardShortcuts();

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1753,8 +1753,8 @@ void MainWindow::updateRecentDocsInMenu()
     for (QVariant recentDoc : recentDocs) {
         QUrl url = recentDoc.toUrl();
         QAction *action = new QAction(Notepadqq::fileNameFromUrl(url), this);
-        connect(action, &QAction::triggered, this, [=]() {
-            m_docEngine->loadDocument(url, m_topEditorContainer->currentTabWidget());
+        connect(action, &QAction::triggered, this, [this, url]() {
+            openRecentFileEntry(url);
         });
 
         actions.append(action);
@@ -1841,14 +1841,8 @@ void MainWindow::on_actionEmpty_Recent_Files_List_triggered()
 
 void MainWindow::on_actionOpen_All_Recent_Files_triggered()
 {
-    QList<QVariant> recentDocs = m_settings.General.getRecentDocuments();
-
-    QList<QUrl> convertedList;
-    for (QVariant doc : recentDocs) {
-        convertedList.append(doc.toUrl());
-    }
-
-    m_docEngine->loadDocuments(convertedList, m_topEditorContainer->currentTabWidget());
+    for (const auto& doc : m_settings.General.getRecentDocuments())
+        openRecentFileEntry(doc.toUrl());
 }
 
 void MainWindow::on_actionUNIX_Format_triggered()
@@ -2124,6 +2118,29 @@ void MainWindow::currentWordOnlineSearch(const QString &searchUrl)
         QUrl phpHelp = QUrl(searchUrl.arg(QString(QUrl::toPercentEncoding(term))));
         QDesktopServices::openUrl(phpHelp);
     }
+}
+
+void MainWindow::openRecentFileEntry(QUrl url)
+{
+    const QString filePath = url.toLocalFile();
+
+    if (!QFileInfo::exists(filePath)) {
+        QMessageBox msg;
+        msg.setIcon(QMessageBox::Question);
+        msg.setText(tr("The file \"%1\" does not exist. Do you want to re-create it?").arg(filePath));
+        msg.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+
+        if (msg.exec() == QMessageBox::No) {
+            // Remove this entry from the history if the user does not want to recreate the file.
+            QList<QVariant> recentDocs = m_settings.General.getRecentDocuments();
+            recentDocs.removeOne( QVariant::fromValue(url) );
+            m_settings.General.setRecentDocuments(recentDocs);
+            updateRecentDocsInMenu();
+            return;
+        }
+    }
+
+    m_docEngine->loadDocument(url, m_topEditorContainer->currentTabWidget());
 }
 
 void MainWindow::on_actionOpen_a_New_Window_triggered()

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1855,7 +1855,7 @@ void MainWindow::on_actionOpen_All_Recent_Files_triggered()
     }
 
     if (!urlsOfMissingFiles.empty()) {
-        QString text = tr("These files do not exist anymore. Do you want to open them anyway?\n");
+        QString text = tr("The following files do not exist anymore. Do you want to open them anyway?\n");
 
         for(const auto& url : urlsOfMissingFiles)
             text += '\n' + url.toLocalFile();


### PR DESCRIPTION
We talked about that looong ago in #248.

This implements it like in N++:

* When clicking on an entry in recent history, the file existence is checked.
* * If it exists, it'll be loaded as usual.
* * If it does not exist, the user is asked whether he wants to re-create it.
* * * If user answers yes, the file is tentatively opened (this is what always happens at the moment).
* * * If user answers no, the file entry is removed from recent history.

The "Open all recent files" action works with this as well.