### PR TITLE
Fixed always true condition

### DIFF
--- a/src/ui/Search/searchinfilesworker.cpp
+++ b/src/ui/Search/searchinfilesworker.cpp
@@ -116,9 +116,7 @@ FileSearchResult::FileResult SearchInFilesWorker::searchPlainText(const QString 
             for (int i = line; i < totalLines; i++) {
                 if (linePosition[i] > column) {
                     line = i-1;
-                    if (hasResult) {
-                        fileResult.results.append(buildResult(line, column - linePosition[line], column, content, matchLength));
-                    }
+                    fileResult.results.append(buildResult(line, column - linePosition[line], column, content, matchLength));
                     break;
                 }
             }


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. Warnings, found using PVS-Studio:
notepadqq/src/ui/Search/searchinfilesworker.cpp     119     warn    V547 Expression 'hasResult' is always true.