### PR TITLE
Rename Editor::fileName() and change EditorTabWidget::setTabText() to deal with KDE

### DIFF
--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -174,24 +174,34 @@ namespace EditorNS
     /**
      * Automatically converts local relative file names to absolute ones.
      */
-    void Editor::setFileName(const QUrl &filename)
+    void Editor::setFilePath(const QUrl &filename)
     {
-        QUrl old = m_fileName;
+        QUrl old = m_filePath;
         QUrl newUrl = filename;
 
         if (newUrl.isLocalFile())
             newUrl = QUrl::fromLocalFile(QFileInfo(filename.toLocalFile()).absoluteFilePath());
 
-        m_fileName = newUrl;
+        m_filePath = newUrl;
         emit fileNameChanged(old, newUrl);
     }
 
     /**
      * Always returns an absolute url.
      */
-    QUrl Editor::fileName() const
+    QUrl Editor::filePath() const
     {
-        return m_fileName;
+        return m_filePath;
+    }
+
+    QString Editor::tabName() const
+    {
+        return m_tabName;
+    }
+
+    void Editor::setTabName(const QString& name)
+    {
+        m_tabName = name;
     }
 
     bool Editor::isClean()
@@ -258,7 +268,7 @@ namespace EditorNS
 
     QString Editor::setLanguageFromFileName()
     {
-        return setLanguageFromFileName(fileName().toString());
+        return setLanguageFromFileName(filePath().toString());
     }
 
     void Editor::setIndentationMode(QString language)

--- a/src/ui/Sessions/sessions.cpp
+++ b/src/ui/Sessions/sessions.cpp
@@ -269,7 +269,7 @@ bool saveSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
         for (int j = 0; j < tabCount; j++) {
             Editor* editor = tabWidget->editor(j);
             bool isClean = editor->isClean();
-            bool isOrphan = editor->fileName().isEmpty();
+            bool isOrphan = editor->filePath().isEmpty();
 
             if (isOrphan && !cacheModifiedFiles)
                 continue; // Don't save temporary files if we're not caching tabs
@@ -291,7 +291,7 @@ bool saveSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
             }
             // Else tab is an openened unmodified file, we don't have to do anything special.
 
-            td.filePath = !isOrphan ? editor->fileName().toLocalFile() : "";
+            td.filePath = !isOrphan ? editor->filePath().toLocalFile() : "";
 
             // Finally save other misc information about the tab.
             const auto& scrollPos = editor->scrollPosition();
@@ -396,10 +396,10 @@ void loadSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
             }
 
             if (tab.filePath.isEmpty()) {
-                editor->setFileName(QUrl());
+                editor->setFilePath(QUrl());
                 tabW->setTabText(idx, docEngine->getNewDocumentName());
             } else {
-                editor->setFileName(fileUrl);
+                editor->setFilePath(fileUrl);
                 if(fileExists)
                     docEngine->monitorDocument(editor);
             }

--- a/src/ui/docengine.cpp
+++ b/src/ui/docengine.cpp
@@ -122,7 +122,7 @@ bool DocEngine::reloadDocument(EditorTabWidget *tabWidget, int tab, QTextCodec *
 {
     Editor *editor = tabWidget->editor(tab);
     QList<QUrl> files;
-    files.append(editor->fileName());
+    files.append(editor->filePath());
     return loadDocuments(files, tabWidget, true, codec, bom);
 }
 
@@ -221,7 +221,7 @@ bool DocEngine::loadDocuments(const QList<QUrl> &fileNames, EditorTabWidget *tab
                 // If there was only a new empty tab opened, remove it
                 if (tabWidget->count() == 2) {
                     Editor *victim = tabWidget->editor(0);
-                    if (victim->fileName().isEmpty() && victim->isClean()) {
+                    if (victim->filePath().isEmpty() && victim->isClean()) {
                         tabWidget->removeTab(0);
                         tabIndex--;
                     }
@@ -229,7 +229,7 @@ bool DocEngine::loadDocuments(const QList<QUrl> &fileNames, EditorTabWidget *tab
 
                 file.close();
                 if (!reload) {
-                    editor->setFileName(fileNames[i]);
+                    editor->setFilePath(fileNames[i]);
                     //sci->setEolMode(sci->guessEolMode());
                     tabWidget->setTabToolTip(tabIndex, fi.absoluteFilePath());
                     editor->setLanguageFromFileName();
@@ -453,7 +453,7 @@ int DocEngine::saveDocument(EditorTabWidget *tabWidget, int tab, QUrl outFileNam
         unmonitorDocument(editor);
 
     if (outFileName.isEmpty())
-        outFileName = editor->fileName();
+        outFileName = editor->filePath();
 
     if (outFileName.isLocalFile()) {
         QFile file(outFileName.toLocalFile());
@@ -496,8 +496,8 @@ int DocEngine::saveDocument(EditorTabWidget *tabWidget, int tab, QUrl outFileNam
 
         // Update the file name if necessary.
         if (!copy) {
-            if (editor->fileName() != outFileName) {
-                editor->setFileName(outFileName);
+            if (editor->filePath() != outFileName) {
+                editor->setFilePath(outFileName);
                 editor->setLanguageFromFileName();
             }
             editor->markClean();
@@ -550,17 +550,17 @@ void DocEngine::closeDocument(EditorTabWidget *tabWidget, int tab)
 
 void DocEngine::monitorDocument(Editor *editor)
 {
-    monitorDocument(editor->fileName().toLocalFile());
+    monitorDocument(editor->filePath().toLocalFile());
 }
 
 void DocEngine::unmonitorDocument(Editor *editor)
 {
-    unmonitorDocument(editor->fileName().toLocalFile());
+    unmonitorDocument(editor->filePath().toLocalFile());
 }
 
 bool DocEngine::isMonitored(Editor *editor)
 {
-    return m_fsWatcher->files().contains(editor->fileName().toLocalFile());
+    return m_fsWatcher->files().contains(editor->filePath().toLocalFile());
 }
 
 DocEngine::DecodedText DocEngine::decodeText(const QByteArray &contents)

--- a/src/ui/editortabwidget.cpp
+++ b/src/ui/editortabwidget.cpp
@@ -68,6 +68,34 @@ void EditorTabWidget::disconnectEditorSignals(Editor *editor)
                this, &EditorTabWidget::on_fileNameChanged);
 }
 
+
+QString EditorTabWidget::tabText(Editor* editor) const
+{
+    return editor->tabName();
+}
+
+QString EditorTabWidget::tabText(int index) const
+{
+    return editor(index)->tabName();
+}
+
+void EditorTabWidget::setTabText(int index, const QString& text)
+{
+    QTabWidget::setTabText(index, text);
+    editor(index)->setTabName(text);
+}
+
+
+void EditorTabWidget::setTabText(Editor* editor, const QString& text)
+{
+    int idx = indexOf(editor);
+
+    if(idx >= 0) {
+        QTabWidget::setTabText(idx, text);
+        editor->setTabName(text);
+    }
+}
+
 int EditorTabWidget::transferEditorTab(bool setFocus, EditorTabWidget *source, int tabIndex)
 {
     return this->rawAddEditorTab(setFocus, QString(), source, tabIndex);
@@ -107,7 +135,8 @@ int EditorTabWidget::rawAddEditorTab(const bool setFocus, const QString &title, 
     }
 
     m_editorPointers.insert(editor.data(), editor);
-    int index = addTab(editor.data(), create ? title : oldText);
+    int index = addTab(editor.data(), QString());
+    setTabText(index, create ? title : oldText); // this also stores the tab's title in the Editor object
 
     if (!create) {
         source->disconnectEditorSignals(editor.data());
@@ -149,14 +178,14 @@ int EditorTabWidget::findOpenEditorByUrl(const QUrl &filename)
 
     for (int i = 0; i < count(); i++) {
         Editor *editor = this->editor(i);
-        if (editor->fileName() == filename)
+        if (editor->filePath() == filename)
             return i;
     }
 
     return -1;
 }
 
-Editor *EditorTabWidget::editor(int index)
+Editor *EditorTabWidget::editor(int index) const
 {
     return dynamic_cast<Editor *>(this->widget(index));
 }

--- a/src/ui/include/EditorNS/editor.h
+++ b/src/ui/include/EditorNS/editor.h
@@ -9,6 +9,8 @@
 #include <QVBoxLayout>
 #include <QTextCodec>
 
+class EditorTabWidget;
+
 namespace EditorNS
 {
 
@@ -156,13 +158,13 @@ namespace EditorNS
              * @brief Set the file name associated with this editor
              * @param filename full path of the file
              */
-        Q_INVOKABLE void setFileName(const QUrl &filename);
+        Q_INVOKABLE void setFilePath(const QUrl &filename);
 
         /**
              * @brief Get the file name associated with this editor
              * @return
              */
-        Q_INVOKABLE QUrl fileName() const;
+        Q_INVOKABLE QUrl filePath() const;
 
         Q_INVOKABLE bool fileOnDiskChanged() const;
         Q_INVOKABLE void setFileOnDiskChanged(bool fileOnDiskChanged);
@@ -190,7 +192,7 @@ namespace EditorNS
          * @param language Language id
          */
         Q_INVOKABLE void setLanguage(const QString &language);
-        Q_INVOKABLE QString setLanguageFromFileName(QString fileName);
+        Q_INVOKABLE QString setLanguageFromFileName(QString filePath);
         Q_INVOKABLE QString setLanguageFromFileName();
         Q_INVOKABLE void setValue(const QString &value);
         Q_INVOKABLE QString value();
@@ -292,11 +294,19 @@ namespace EditorNS
         int lineCount();
 
     private:
+        friend class ::EditorTabWidget;
+
+        // These functions should only be used by EditorTabWidget to manage the tab's title. This works around
+        // KDE's habit to automatically modify QTabWidget's tab titles to insert shortcut sequences (like &1).
+        QString tabName() const;
+        void setTabName(const QString& name);
+
         static QQueue<Editor*> m_editorBuffer;
         QVBoxLayout *m_layout;
         CustomQWebView *m_webView;
         JsToCppProxy *m_jsToCppProxy;
-        QUrl m_fileName = QUrl();
+        QUrl m_filePath = QUrl();
+        QString m_tabName;
         bool m_fileOnDiskChanged = false;
         bool m_loaded = false;
         QString m_endOfLineSequence = "\n";

--- a/src/ui/include/editortabwidget.h
+++ b/src/ui/include/editortabwidget.h
@@ -28,7 +28,7 @@ public:
      */
     int transferEditorTab(bool setFocus, EditorTabWidget *source, int tabIndex);
     int findOpenEditorByUrl(const QUrl &filename);
-    Editor *editor(int index);
+    Editor *editor(int index) const;
     QSharedPointer<Editor> editorSharedPtr(int index);
     QSharedPointer<Editor> editorSharedPtr(Editor *editor);
     Editor *currentEditor();
@@ -53,7 +53,20 @@ public:
      */
     static void deleteIfEmpty(EditorTabWidget *tabWidget);
 
+    /**
+     * @brief tabText Returns the title of the given Editor or tab index
+     */
+    QString tabText(Editor* editor) const;
+    QString tabText(int index) const;
+
+    /**
+     * @brief tabText Sets the title of the given Editor or tab index
+     */
+    void setTabText(Editor* editor, const QString& text);
+    void setTabText(int index, const QString& text);
+
 private:
+
     // Smart pointers to the editors within this TabWidget
     QHash<Editor*, QSharedPointer<Editor>> m_editorPointers;
 

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -816,7 +816,7 @@ void MainWindow::on_actionShow_All_Characters_toggled(bool on)
 bool MainWindow::reloadWithWarning(EditorTabWidget *tabWidget, int tab, QTextCodec *codec, bool bom)
 {
     // Don't do anything if there is no file to reload from.
-    if (tabWidget->editor(tab)->fileName().isEmpty())
+    if (tabWidget->editor(tab)->filePath().isEmpty())
         return false;
 
     if (!tabWidget->editor(tab)->isClean()) {
@@ -859,7 +859,7 @@ void MainWindow::removeTabWidgetIfEmpty(EditorTabWidget *tabWidget) {
 
 void MainWindow::on_action_Open_triggered()
 {
-    QUrl defaultUrl = currentEditor()->fileName();
+    QUrl defaultUrl = currentEditor()->filePath();
     if (defaultUrl.isEmpty())
         defaultUrl = QUrl::fromLocalFile(m_settings.General.getLastSelectedDir());
 
@@ -880,7 +880,7 @@ void MainWindow::on_action_Open_triggered()
 
 void MainWindow::on_actionOpen_Folder_triggered()
 {
-    QUrl defaultUrl = currentEditor()->fileName();
+    QUrl defaultUrl = currentEditor()->filePath();
     if (defaultUrl.isEmpty())
         defaultUrl = QUrl::fromLocalFile(m_settings.General.getLastSelectedDir());
 
@@ -953,7 +953,7 @@ int MainWindow::closeTab(EditorTabWidget *tabWidget, int tab, bool remove, bool 
     // Don't remove the tab if it's the last tab, it's empty, in an unmodified state and it's not associated with a file name.
     // Else, continue.
     if (! (m_topEditorContainer->count() == 1 && tabWidget->count() == 1
-           && editor->fileName().isEmpty() && editor->isClean())) {
+           && editor->filePath().isEmpty() && editor->isClean())) {
 
         if(!force && !editor->isClean()) {
             tabWidget->setCurrentIndex(tab);
@@ -1023,7 +1023,7 @@ int MainWindow::save(EditorTabWidget *tabWidget, int tab)
 {
     Editor *editor = tabWidget->editor(tab);
 
-    if (editor->fileName().isEmpty())
+    if (editor->filePath().isEmpty())
     {
         // Call "save as"
         return saveAs(tabWidget, tab, false);
@@ -1032,8 +1032,8 @@ int MainWindow::save(EditorTabWidget *tabWidget, int tab)
         // If the file has changed outside the editor, ask
         // the user if he want to save it.
         bool fileOverwrite = false;
-        if (editor->fileName().isLocalFile())
-            fileOverwrite = QFile(editor->fileName().toLocalFile()).exists();
+        if (editor->filePath().isLocalFile())
+            fileOverwrite = QFile(editor->filePath().toLocalFile()).exists();
 
         if (editor->fileOnDiskChanged() && fileOverwrite) {
             QMessageBox msgBox(this);
@@ -1053,7 +1053,7 @@ int MainWindow::save(EditorTabWidget *tabWidget, int tab)
                 return DocEngine::saveFileResult_Canceled;
         }
 
-        return m_docEngine->saveDocument(tabWidget, tab, editor->fileName());
+        return m_docEngine->saveDocument(tabWidget, tab, editor->filePath());
     }
 }
 
@@ -1078,7 +1078,7 @@ int MainWindow::saveAs(EditorTabWidget *tabWidget, int tab, bool copy)
 
 QUrl MainWindow::getSaveDialogDefaultFileName(EditorTabWidget *tabWidget, int tab)
 {
-    QUrl docFileName = tabWidget->editor(tab)->fileName();
+    QUrl docFileName = tabWidget->editor(tab)->filePath();
 
     if (docFileName.isEmpty()) {
         return QUrl::fromLocalFile(m_settings.General.getLastSelectedDir()
@@ -1299,7 +1299,7 @@ void MainWindow::refreshEditorUiInfo(Editor *editor)
 
     // Update MainWindow title
     QString newTitle;
-    if (editor->fileName().isEmpty()) {
+    if (editor->filePath().isEmpty()) {
 
         EditorTabWidget *tabWidget = m_topEditorContainer->tabWidgetFromEditor(editor);
         if (tabWidget != 0) {
@@ -1312,7 +1312,7 @@ void MainWindow::refreshEditorUiInfo(Editor *editor)
         }
 
     } else {
-        QUrl url = editor->fileName();
+        QUrl url = editor->filePath();
 
         QString path = url.toDisplayString(QUrl::RemovePassword |
                                            QUrl::RemoveUserInfo |
@@ -1327,7 +1327,7 @@ void MainWindow::refreshEditorUiInfo(Editor *editor)
                                            );
 
         newTitle = QString("%1 (%2) - %3")
-                   .arg(Notepadqq::fileNameFromUrl(editor->fileName()))
+                   .arg(Notepadqq::fileNameFromUrl(editor->filePath()))
                    .arg(path)
                    .arg(QApplication::applicationName());
 
@@ -1340,12 +1340,12 @@ void MainWindow::refreshEditorUiInfo(Editor *editor)
 
     // Enable / disable menus
     bool isClean = editor->isClean();
-    QUrl fileName = editor->fileName();
+    QUrl fileName = editor->filePath();
     ui->actionRename->setEnabled(!fileName.isEmpty());
     ui->actionMove_to_New_Window->setEnabled(isClean);
     ui->actionOpen_in_New_Window->setEnabled(isClean);
 
-    bool allowReloading = !editor->fileName().isEmpty();
+    bool allowReloading = !editor->filePath().isEmpty();
     ui->actionReload_file_interpreted_as->setEnabled(allowReloading);
     ui->actionReload_from_Disk->setEnabled(allowReloading);
 
@@ -1474,13 +1474,13 @@ void MainWindow::on_actionSearch_triggered()
 void MainWindow::on_actionCurrent_Full_File_path_to_Clipboard_triggered()
 {
     Editor *editor = currentEditor();
-    if (currentEditor()->fileName().isEmpty())
+    if (currentEditor()->filePath().isEmpty())
     {
         EditorTabWidget *tabWidget = m_topEditorContainer->currentTabWidget();
         QApplication::clipboard()->setText(tabWidget->tabText(tabWidget->indexOf(editor)));
     } else {
         QApplication::clipboard()->setText(
-                    editor->fileName().toDisplayString(QUrl::PreferLocalFile |
+                    editor->filePath().toDisplayString(QUrl::PreferLocalFile |
                                                        QUrl::RemovePassword));
     }
 }
@@ -1488,24 +1488,24 @@ void MainWindow::on_actionCurrent_Full_File_path_to_Clipboard_triggered()
 void MainWindow::on_actionCurrent_Filename_to_Clipboard_triggered()
 {
     Editor *editor = currentEditor();
-    if (currentEditor()->fileName().isEmpty())
+    if (currentEditor()->filePath().isEmpty())
     {
         EditorTabWidget *tabWidget = m_topEditorContainer->currentTabWidget();
         QApplication::clipboard()->setText(tabWidget->tabText(tabWidget->indexOf(editor)));
     } else {
-        QApplication::clipboard()->setText(Notepadqq::fileNameFromUrl(editor->fileName()));
+        QApplication::clipboard()->setText(Notepadqq::fileNameFromUrl(editor->filePath()));
     }
 }
 
 void MainWindow::on_actionCurrent_Directory_Path_to_Clipboard_triggered()
 {
     Editor *editor = currentEditor();
-    if(currentEditor()->fileName().isEmpty())
+    if(currentEditor()->filePath().isEmpty())
     {
         QApplication::clipboard()->setText("");
     } else {
         QApplication::clipboard()->setText(
-                    editor->fileName().toDisplayString(QUrl::RemovePassword |
+                    editor->filePath().toDisplayString(QUrl::RemovePassword |
                                                        QUrl::RemoveUserInfo |
                                                        QUrl::RemovePort |
                                                        QUrl::RemoveAuthority |
@@ -1755,7 +1755,7 @@ void MainWindow::on_documentLoaded(EditorTabWidget *tabWidget, int tab, bool was
     const int MAX_RECENT_ENTRIES = 10;
 
     if(updateRecentDocs){
-        QUrl newUrl = editor->fileName();
+        QUrl newUrl = editor->filePath();
         QList<QVariant> recentDocs = m_settings.General.getRecentDocuments();
         recentDocs.insert(0, QVariant(newUrl));
 
@@ -1879,12 +1879,12 @@ void MainWindow::on_actionFind_Previous_triggered()
 void MainWindow::on_actionRename_triggered()
 {
     EditorTabWidget *tabW = m_topEditorContainer->currentTabWidget();
-    QUrl oldFilename = tabW->currentEditor()->fileName();
+    QUrl oldFilename = tabW->currentEditor()->filePath();
     int result = saveAs(tabW, tabW->currentIndex(), false);
 
     if (result == DocEngine::saveFileResult_Saved && !oldFilename.isEmpty()) {
 
-        if (QFileInfo(oldFilename.toLocalFile()) != QFileInfo(tabW->currentEditor()->fileName().toLocalFile())) {
+        if (QFileInfo(oldFilename.toLocalFile()) != QFileInfo(tabW->currentEditor()->filePath().toLocalFile())) {
 
             // Remove the old file
             QString filename = oldFilename.toLocalFile();
@@ -2158,7 +2158,7 @@ void MainWindow::runCommand()
 
     Editor *editor = currentEditor();
 
-    QUrl url = currentEditor()->fileName();
+    QUrl url = currentEditor()->filePath();
     QStringList selection = editor->selectedTexts();
     if (!url.isEmpty()) {
         cmd.replace("\%url\%", url.toString(QUrl::None));
@@ -2267,8 +2267,8 @@ void MainWindow::on_actionOpen_in_New_Window_triggered()
 {
     QStringList args;
     args.append(QApplication::arguments().first());
-    if (!currentEditor()->fileName().isEmpty()) {
-        args.append(currentEditor()->fileName().toString(QUrl::None));
+    if (!currentEditor()->filePath().isEmpty()) {
+        args.append(currentEditor()->filePath().toString(QUrl::None));
     }
 
     MainWindow *b = new MainWindow(args, 0);
@@ -2279,8 +2279,8 @@ void MainWindow::on_actionMove_to_New_Window_triggered()
 {
     QStringList args;
     args.append(QApplication::arguments().first());
-    if (!currentEditor()->fileName().isEmpty()) {
-        args.append(currentEditor()->fileName().toString(QUrl::None));
+    if (!currentEditor()->filePath().isEmpty()) {
+        args.append(currentEditor()->filePath().toString(QUrl::None));
     }
 
     EditorTabWidget *tabWidget = m_topEditorContainer->currentTabWidget();


### PR DESCRIPTION
Rename `Editor::fileName()` to `Editor::FilePath()` since it deals with the entire file path. 

Change `EditorTabWidget::setTabText()` to deal with KDE's automatic tab title modification. This is done by just storing the actual tab title inside `Editor`. This way we don't rely on `EditorTabWidget::tabText()` which returns bad tab titles. 

Fixes #286.