### PR TITLE
Improve AdvanchedSearchDock

### DIFF
--- a/src/ui/Search/advancedsearchdock.cpp
+++ b/src/ui/Search/advancedsearchdock.cpp
@@ -421,8 +421,8 @@ void AdvancedSearchDock::selectSearchFromHistory(int index)
     }
 
     if (m_currentSearchInstance) {
-        disconnect(m_currentSearchInstance, &SearchInstance::resultItemClicked,
-                   this, &AdvancedSearchDock::resultItemClicked);
+        disconnect(m_currentSearchInstance, &SearchInstance::itemInteracted,
+                   this, &AdvancedSearchDock::itemInteracted);
     }
 
     if (index==0) {
@@ -443,8 +443,8 @@ void AdvancedSearchDock::selectSearchFromHistory(int index)
                        this, &AdvancedSearchDock::onCurrentSearchInstanceCompleted);
         }
 
-        connect(m_currentSearchInstance, &SearchInstance::resultItemClicked,
-                   this, &AdvancedSearchDock::resultItemClicked);
+        connect(m_currentSearchInstance, &SearchInstance::itemInteracted,
+                   this, &AdvancedSearchDock::itemInteracted);
 
         m_dockWidget->setWidget( m_currentSearchInstance->getResultTreeWidget() );
         m_btnToggleReplaceOptions->setEnabled(true);
@@ -658,8 +658,8 @@ AdvancedSearchDock::AdvancedSearchDock(MainWindow* mainWindow)
         auto* editor = tabW->currentEditor();
 
         QString dir;
-        if(editor && !editor->fileName().isEmpty()) {
-            dir = QFileInfo(editor->fileName().toLocalFile()).dir().path();
+        if (editor && !editor->filePath().isEmpty()) {
+            dir = QFileInfo(editor->filePath().toLocalFile()).dir().path();
         }
         m_cmbSearchDirectory->setCurrentText(dir);
     });

--- a/src/ui/Search/searchinstance.cpp
+++ b/src/ui/Search/searchinstance.cpp
@@ -119,8 +119,10 @@ SearchInstance::SearchInstance(const SearchConfig& config)
         searchLocation = '"' + config.directory + '"'; break;
     }
 
+    m_contextMenu = new QMenu(treeWidget);
+
     // Create actions for the custom context menu
-    m_actionCopyLine = new QAction(tr("Copy Line to Clipboard"));
+    m_actionCopyLine = new QAction(tr("Copy Line to Clipboard"), m_contextMenu);
     connect(m_actionCopyLine, &QAction::triggered, this, [this, treeWidget](){
         auto* item = treeWidget->currentItem();
         auto it = m_resultMap.find(item);
@@ -128,7 +130,7 @@ SearchInstance::SearchInstance(const SearchConfig& config)
             QApplication::clipboard()->setText( m_resultMap.at(it->first)->matchLineString );
     });
 
-    m_actionOpenDocument = new QAction(tr("Open Document"));
+    m_actionOpenDocument = new QAction(tr("Open Document"), m_contextMenu);
     connect(m_actionOpenDocument, &QAction::triggered, this, [this, treeWidget](){
         auto* item = treeWidget->currentItem();
         auto it = m_resultMap.find(item);
@@ -137,7 +139,7 @@ SearchInstance::SearchInstance(const SearchConfig& config)
         emit itemInteracted( *docItem, resultItem, SearchUserInteraction::OpenDocument );
     });
 
-    m_actionOpenFolder = new QAction(tr("Open Folder in File Browser"));
+    m_actionOpenFolder = new QAction(tr("Open Folder in File Browser"), m_contextMenu);
     connect(m_actionOpenFolder, &QAction::triggered, this, [this, treeWidget](){
         auto* item = treeWidget->currentItem();
         auto it = m_resultMap.find(item);
@@ -146,7 +148,6 @@ SearchInstance::SearchInstance(const SearchConfig& config)
         emit itemInteracted( *docItem, resultItem, SearchUserInteraction::OpenContainingFolder );
     });
 
-    m_contextMenu = new QMenu(treeWidget);
     m_contextMenu->addAction(m_actionCopyLine);
     m_contextMenu->addAction(m_actionOpenDocument);
     m_contextMenu->addAction(m_actionOpenFolder);

--- a/src/ui/include/Search/advancedsearchdock.h
+++ b/src/ui/include/Search/advancedsearchdock.h
@@ -60,8 +60,10 @@ public:
 
 signals:
     /**
-     * @brief resultItemClicked Emitted when an item in the current tree widget is double-clicked.
-     *        If result is a nullptr, the interacted item was a top-level DocResult.
+     * @brief itemInteracted Emitted when an item in the current tree widget is interacted with.
+     * @param doc The selected DocResult
+     * @param result The selected MatchResult. If this is nullptr then the user only selected a DocResult
+     * @param type The kind of interaction requested by the user
      */
     void itemInteracted(const DocResult& doc, const MatchResult* result, SearchUserInteraction type);
 

--- a/src/ui/include/Search/advancedsearchdock.h
+++ b/src/ui/include/Search/advancedsearchdock.h
@@ -60,9 +60,10 @@ public:
 
 signals:
     /**
-     * @brief resultItemClicked Emitted when an item in the current tree widget is double-clicked
+     * @brief resultItemClicked Emitted when an item in the current tree widget is double-clicked.
+     *        If result is a nullptr, the interacted item was a top-level DocResult.
      */
-    void resultItemClicked(const DocResult& doc, const MatchResult& result, SearchUserInteraction type);
+    void itemInteracted(const DocResult& doc, const MatchResult* result, SearchUserInteraction type);
 
 private:
     MainWindow* m_mainWindow;

--- a/src/ui/include/Search/advancedsearchdock.h
+++ b/src/ui/include/Search/advancedsearchdock.h
@@ -62,7 +62,7 @@ signals:
     /**
      * @brief resultItemClicked Emitted when an item in the current tree widget is double-clicked
      */
-    void resultItemClicked(const DocResult& doc, const MatchResult& result);
+    void resultItemClicked(const DocResult& doc, const MatchResult& result, SearchUserInteraction type);
 
 private:
     MainWindow* m_mainWindow;
@@ -143,6 +143,7 @@ private:
     QComboBox*   m_cmbSearchPattern;
     QComboBox*   m_cmbSearchDirectory;
     QToolButton* m_btnSelectSearchDirectory;
+    QToolButton* m_btnSelectCurrentDirectory;
     QToolButton* m_btnSearch;
     QCheckBox*   m_chkMatchCase;
     QCheckBox*   m_chkMatchWords;

--- a/src/ui/include/Search/searchinstance.h
+++ b/src/ui/include/Search/searchinstance.h
@@ -72,7 +72,7 @@ signals:
     /**
      * @brief resultItemClicked Emitted when the user interacts with one of the MatchResults
      */
-    void resultItemClicked(const DocResult& doc, const MatchResult& result, SearchUserInteraction type);
+    void itemInteracted(const DocResult& doc, const MatchResult* result, SearchUserInteraction type);
 
 private:
     void onSearchProgress(int processed, int total);
@@ -86,7 +86,12 @@ private:
     QScopedPointer<QTreeWidget> m_treeWidget;
     SearchResult                m_searchResult;
     FileSearcher*               m_fileSearcher = nullptr;
+
+    // Context menu
     QMenu*                      m_contextMenu;
+    QAction*                    m_actionCopyLine;
+    QAction*                    m_actionOpenDocument;
+    QAction*                    m_actionOpenFolder;
 
     // These map each QTreeWidget item to their respective MatchResult or DocResult
     std::map<QTreeWidgetItem*, const MatchResult*>  m_resultMap;

--- a/src/ui/include/Search/searchinstance.h
+++ b/src/ui/include/Search/searchinstance.h
@@ -70,7 +70,10 @@ signals:
     void searchCompleted();
 
     /**
-     * @brief resultItemClicked Emitted when the user interacts with one of the MatchResults
+     * @brief itemInteracted Emitted when an item in the current tree widget is interacted with.
+     * @param doc The selected DocResult
+     * @param result The selected MatchResult. If this is nullptr then the user only selected a DocResult
+     * @param type The kind of interaction requested by the user
      */
     void itemInteracted(const DocResult& doc, const MatchResult* result, SearchUserInteraction type);
 

--- a/src/ui/include/Search/searchinstance.h
+++ b/src/ui/include/Search/searchinstance.h
@@ -70,9 +70,9 @@ signals:
     void searchCompleted();
 
     /**
-     * @brief resultItemClicked Emitted when an item in the tree widget is double-clicked
+     * @brief resultItemClicked Emitted when the user interacts with one of the MatchResults
      */
-    void resultItemClicked(const DocResult& doc, const MatchResult& result);
+    void resultItemClicked(const DocResult& doc, const MatchResult& result, SearchUserInteraction type);
 
 private:
     void onSearchProgress(int processed, int total);
@@ -86,6 +86,7 @@ private:
     QScopedPointer<QTreeWidget> m_treeWidget;
     SearchResult                m_searchResult;
     FileSearcher*               m_fileSearcher = nullptr;
+    QMenu*                      m_contextMenu;
 
     // These map each QTreeWidget item to their respective MatchResult or DocResult
     std::map<QTreeWidgetItem*, const MatchResult*>  m_resultMap;

--- a/src/ui/include/Search/searchobjects.h
+++ b/src/ui/include/Search/searchobjects.h
@@ -90,6 +90,11 @@ struct DocResult {
     QVector<MatchResult> results;
 };
 
+enum class SearchUserInteraction {
+    OpenDocument,
+    OpenContainingFolder
+};
+
 struct SearchResult {
 
     /**

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -77,7 +77,7 @@ private slots:
     void runCommand();
     void modifyRunCommands();
     void refreshEditorUiCursorInfo(Editor *editor);
-    void searchDockItemClicked(const DocResult& doc, const MatchResult& result);
+    void searchDockItemClicked(const DocResult& doc, const MatchResult& result, SearchUserInteraction type);
     void on_action_New_triggered();
     void on_customTabContextMenuRequested(QPoint point, EditorTabWidget *tabWidget, int tabIndex);
     void on_actionMove_to_Other_View_triggered();

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -77,7 +77,7 @@ private slots:
     void runCommand();
     void modifyRunCommands();
     void refreshEditorUiCursorInfo(Editor *editor);
-    void searchDockItemClicked(const DocResult& doc, const MatchResult& result, SearchUserInteraction type);
+    void searchDockItemInteracted(const DocResult& doc, const MatchResult* result, SearchUserInteraction type);
     void on_action_New_triggered();
     void on_customTabContextMenuRequested(QPoint point, EditorTabWidget *tabWidget, int tabIndex);
     void on_actionMove_to_Other_View_triggered();

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1255,8 +1255,16 @@ void MainWindow::refreshEditorUiCursorInfo(Editor *editor)
     }
 }
 
-void MainWindow::searchDockItemClicked(const DocResult& doc, const MatchResult& result)
+void MainWindow::searchDockItemClicked(const DocResult& doc, const MatchResult& result, SearchUserInteraction type)
 {
+    if (type == SearchUserInteraction::OpenContainingFolder) {
+        if (!QFile(doc.fileName).exists()) return;
+        QFileInfo fInfo(doc.fileName);
+        QString dirName = fInfo.dir().path();
+        QDesktopServices::openUrl(QUrl::fromLocalFile(dirName));
+        return;
+    }
+
     if(doc.docType == DocResult::TypeDocument) {
         // Make sure the editor is still open by searching for it first.
         Editor* found = doc.editor;

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -159,7 +159,7 @@ MainWindow::MainWindow(const QString &workingDirectory, const QStringList &argum
     // Initialize the advanced search dock and hook its signals up
     addDockWidget(Qt::BottomDockWidgetArea, m_advSearchDock->getDockWidget() );
     m_advSearchDock->getDockWidget()->hide(); // Hidden by default, user preference is applied via restoreWindowSettings()
-    connect(m_advSearchDock, &AdvancedSearchDock::resultItemClicked, this, &MainWindow::searchDockItemClicked);
+    connect(m_advSearchDock, &AdvancedSearchDock::itemInteracted, this, &MainWindow::searchDockItemInteracted);
 
     restoreWindowSettings();
 
@@ -1255,25 +1255,37 @@ void MainWindow::refreshEditorUiCursorInfo(Editor *editor)
     }
 }
 
-void MainWindow::searchDockItemClicked(const DocResult& doc, const MatchResult& result, SearchUserInteraction type)
+void MainWindow::searchDockItemInteracted(const DocResult& doc, const MatchResult* result, SearchUserInteraction type)
 {
     if (type == SearchUserInteraction::OpenContainingFolder) {
-        if (!QFile(doc.fileName).exists()) return;
-        QFileInfo fInfo(doc.fileName);
+        QUrl fileUrl;
+
+        if (doc.docType == DocResult::TypeDocument)
+            fileUrl = doc.editor->filePath();
+        else
+            fileUrl = stringToUrl(doc.fileName);
+
+        if (fileUrl.isEmpty())
+            return;
+
+        QFileInfo fInfo(fileUrl.toLocalFile());
         QString dirName = fInfo.dir().path();
         QDesktopServices::openUrl(QUrl::fromLocalFile(dirName));
         return;
     }
 
-    if(doc.docType == DocResult::TypeDocument) {
+    // Else: type == OpenDocument
+    if (doc.docType == DocResult::TypeDocument) {
         // Make sure the editor is still open by searching for it first.
         Editor* found = doc.editor;
         EditorTabWidget* parentWidget = m_topEditorContainer->tabWidgetFromEditor(found);
         if (!parentWidget) return;
 
         parentWidget->setCurrentWidget(found);
-        found->setSelection(result.lineNumber-1, result.positionInLine, //selection start
-                            result.lineNumber-1, result.positionInLine + result.matchLength); //selection end
+        if (result) {
+            found->setSelection(result->lineNumber-1, result->positionInLine, //selection start
+                                result->lineNumber-1, result->positionInLine + result->matchLength); //selection end
+        }
         found->setFocus();
 
     } else if (doc.docType == DocResult::TypeFile) {
@@ -1291,8 +1303,10 @@ void MainWindow::searchDockItemClicked(const DocResult& doc, const MatchResult& 
 
         Editor *editor = m_topEditorContainer->tabWidget(pos.first)->editor(pos.second);
 
-        editor->setSelection(result.lineNumber-1, result.positionInLine, //selection start
-                             result.lineNumber-1, result.positionInLine + result.matchLength); //selection end
+        if (result) {
+            editor->setSelection(result->lineNumber-1, result->positionInLine, //selection start
+                                result->lineNumber-1, result->positionInLine + result->matchLength); //selection end
+        }
         editor->setFocus();
     }
 }


### PR DESCRIPTION
* Add a button to select the directory of the currently active Editor for filesystem search.
* Make the "Include Subdirectories" option enabled by default for filesystem searches.
* Added a context menu to the SearchDock with the following actions:
* * Copy selected line to clipboard
* * Open document
* * Open Folder in File Browser