### PR TITLE
README: Notepadqq is now available in Solus

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ Alternatively it can be found in the AUR:
 Notepadqq is avilable in OpenSUSE's main repository:
 
      sudo zypper in notepadqq
+     
+#### Solus
+Notepadqq is available in the `shannon` (stable) repository:
+
+     sudo eopkg it notepadqq
 
 #### Others
 Use a package for a compatible distribution, or build from [source](https://github.com/notepadqq/notepadqq.git).


### PR DESCRIPTION
Hey, i'll be the new maintainer for `notepadqq` in Solus. Notepadqq is currently in the unstable repo and will be promoted to the stable repo this Friday (10/03), you might want to only merge this then to avoid any confusion.

You can find the build recipe [here](https://dev.solus-project.com/source/notepadqq/browse/master/package.yml)

I also noticed you guys don't provide any appstream data. If you guys could provide that in the future so notepadqq integrates nicely into our Software Centre that would be appreciated (I can create a separate issue for this)