### PR TITLE
Add Appstream metainfo

### DIFF
--- a/src/ui/ui.pro
+++ b/src/ui/ui.pro
@@ -272,7 +272,7 @@ unix:!macx {
     shortcuts.path = "$$INSTALL_ROOT$$PREFIX/share/applications/"
     shortcuts.files += "$$INSTALLFILESDIR/shortcuts/notepadqq.desktop"
     
-    appstream.path = "/usr/share/metainfo/"
+    appstream.path = "$$INSTALL_ROOT$$PREFIX/share/metainfo/"
     appstream.files += "$$INSTALLFILESDIR/notepadqq.appdata.xml"
 
     # == Dummy target used to fix permissions at the end of the install ==

--- a/src/ui/ui.pro
+++ b/src/ui/ui.pro
@@ -271,6 +271,9 @@ unix:!macx {
 
     shortcuts.path = "$$INSTALL_ROOT$$PREFIX/share/applications/"
     shortcuts.files += "$$INSTALLFILESDIR/shortcuts/notepadqq.desktop"
+    
+    appstream.path = "/usr/share/metainfo/"
+    appstream.files += "$$INSTALLFILESDIR/notepadqq.appdata.xml"
 
     # == Dummy target used to fix permissions at the end of the install ==
     # A random path. Without one, qmake refuses to create the rule.
@@ -281,7 +284,7 @@ unix:!macx {
     # MAKE INSTALL
     INSTALLS += target \
          icon_h16 icon_h22 icon_h24 icon_h32 icon_h48 icon_h64 icon_h96 icon_h128 icon_h256 icon_h512 icon_hscalable \
-         misc_data launch shortcuts \
+         misc_data launch shortcuts appstream \
          set_permissions
 
 }

--- a/support_files/notepadqq.appdata.xml
+++ b/support_files/notepadqq.appdata.xml
@@ -1,0 +1,32 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>notepadqq.desktop</id>
+  <metadata_license>MIT</metadata_license>
+  <project_license>GPL-3.0</project_license>
+  <name>Notepadqq</name>
+  <icon width="96" height="96">https://user-images.githubusercontent.com/4319621/36906314-e3f99680-1e35-11e8-90fd-f959c9641f36.png</icon>
+  <summary>An advanced text editor</summary>
+  <description>
+    <p>
+    Notepadqq is an advanced text editor designed to make life easier for developers.
+    </p>
+    <p>
+    It includes real-time syntax highlighting for over one hundred languages, regular expression searches, 
+    and text manipulation with multiple cursors.
+    </p>
+  </description>
+  <categories>
+    <category>Development</category>
+    <category>Utility</category>
+  </categories>
+  
+  <screenshots>
+    <screenshot type="default">
+      <image>https://camo.githubusercontent.com/7ad45b50ed7f7075ad4ba93ce23d3fa40e56fba2/68747470733a2f2f6e6f746570616471712e636f6d2f732f696d616765732f736e617073686f74312e706e67</image>
+    </screenshot>
+  </screenshots>
+  <developer_name>The Notepadqq Team</developer_name>
+  <url type="homepage">https://notepadqq.com/</url>
+  <url type="bugtracker">https://github.com/notepadqq/notepadqq/issues</url>
+  <url type="help">https://github.com/notepadqq/notepadqq/wiki</url>
+</component>

--- a/support_files/notepadqq.appdata.xml
+++ b/support_files/notepadqq.appdata.xml
@@ -26,7 +26,7 @@
     </screenshot>
   </screenshots>
   <developer_name>The Notepadqq Team</developer_name>
-  <url type="homepage">https://notepadqq.com/</url>
+  <url type="homepage">https://github.com/notepadqq/notepadqq</url>
   <url type="bugtracker">https://github.com/notepadqq/notepadqq/issues</url>
   <url type="help">https://github.com/notepadqq/notepadqq/wiki</url>
 </component>


### PR DESCRIPTION
Add a metadata file for AppStream and install it to /usr/share/metainfo on `make install`.

As far as I can gather, this is all we've got to do. And the XML file includes all necessary info.