### PR TITLE
Fix editor focus issues (fixes #265)

### DIFF
--- a/src/ui/EditorNS/customqwebview.cpp
+++ b/src/ui/EditorNS/customqwebview.cpp
@@ -36,9 +36,9 @@ namespace EditorNS
         }
     }
 
-    void CustomQWebView::focusInEvent(QFocusEvent* /*event*/)
+    void CustomQWebView::focusInEvent(QFocusEvent* event)
     {
+        QWebView::focusInEvent(event);
         emit gotFocus();
     }
-
 }

--- a/src/ui/EditorNS/customqwebview.cpp
+++ b/src/ui/EditorNS/customqwebview.cpp
@@ -36,4 +36,9 @@ namespace EditorNS
         }
     }
 
+    void CustomQWebView::focusInEvent(QFocusEvent* /*event*/)
+    {
+        emit gotFocus();
+    }
+
 }

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -81,6 +81,7 @@ namespace EditorNS
 
         connect(m_webView, &CustomQWebView::mouseWheel, this, &Editor::mouseWheel);
         connect(m_webView, &CustomQWebView::urlsDropped, this, &Editor::urlsDropped);
+        connect(m_webView, &CustomQWebView::gotFocus, this, &Editor::gotFocus);
 
         // TODO Display a message if a javascript error gets triggered.
         // Right now, if there's an error in the javascript code, we
@@ -150,8 +151,6 @@ namespace EditorNS
             emit cleanChanged(data.toBool());
         else if(msg == "J_EVT_CURSOR_ACTIVITY")
             emit cursorActivity();
-        else if(msg == "J_EVT_GOT_FOCUS")
-            emit gotFocus();
         else if(msg == "J_EVT_CURRENT_LANGUAGE_CHANGED") {
             QVariantMap map = data.toMap();
             emit currentLanguageChanged(map.value("id").toString(),

--- a/src/ui/Sessions/sessions.cpp
+++ b/src/ui/Sessions/sessions.cpp
@@ -349,6 +349,8 @@ void loadSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
         return;
     }
 
+    Editor* focusedEditor = nullptr;
+
     int viewCounter = 0;
     for (const auto& view : views) {
         // Each new view must be created if it does not yet exist.
@@ -421,13 +423,17 @@ void loadSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
                 emit docEngine->fileOnDiskChanged(tabW, idx, true);
             }
 
-
-            if(tab.active) activeIndex = idx;
+            if(tab.active) {
+                focusedEditor = editor;
+                activeIndex = idx;
+            }
 
             if(!tab.language.isEmpty()) editor->setLanguage(tab.language);
 
             editor->setScrollPosition(tab.scrollX, tab.scrollY);
 
+            // loadDocuments() explicitely calls setFocus() so we'll have to undo that.
+            editor->clearFocus();
         } // end for
 
         // In case a new tabwidget was created but no tabs were actually added to it,
@@ -446,6 +452,11 @@ void loadSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
     // If the last tabwidget still has no tabs in it at this point, we'll have to delete it.
     EditorTabWidget* lastTabW = editorContainer->tabWidget( editorContainer->count() -1);
     lastTabW->deleteIfEmpty();
+
+    if(focusedEditor)
+        focusedEditor->setFocus();
+
+    return;
 }
 
 } // namespace Sessions

--- a/src/ui/Sessions/sessions.cpp
+++ b/src/ui/Sessions/sessions.cpp
@@ -427,11 +427,8 @@ void loadSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
             if(!tab.language.isEmpty()) editor->setLanguage(tab.language);
 
             editor->setScrollPosition(tab.scrollX, tab.scrollY);
-            editor->clearFocus();
 
         } // end for
-
-        tabW->clearFocus();
 
         // In case a new tabwidget was created but no tabs were actually added to it,
         // we'll attempt to re-use the widget for the next view.
@@ -449,18 +446,6 @@ void loadSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
     // If the last tabwidget still has no tabs in it at this point, we'll have to delete it.
     EditorTabWidget* lastTabW = editorContainer->tabWidget( editorContainer->count() -1);
     lastTabW->deleteIfEmpty();
-
-    // Give focus to the last tab of the first tab widget.
-    EditorTabWidget* firstTabW = editorContainer->tabWidget(0);
-    Editor* lastEditor = firstTabW->editor(firstTabW->count()-1);
-    lastEditor->setFocus();
-
-    // This triggers `TopEditorContainer::on_currentTabChanged` and eventually
-    // `MainWindow::on_currentEditorChanged` which calls refreshEditorUiInfo() to
-    // get rid of the titlebar display bug when loading files from cache.
-    firstTabW->currentChanged(firstTabW->count()-1);
-
-    return;
 }
 
 } // namespace Sessions

--- a/src/ui/Sessions/sessions.cpp
+++ b/src/ui/Sessions/sessions.cpp
@@ -349,8 +349,6 @@ void loadSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
         return;
     }
 
-    Editor* focusedEditor = nullptr;
-
     int viewCounter = 0;
     for (const auto& view : views) {
         // Each new view must be created if it does not yet exist.
@@ -423,10 +421,7 @@ void loadSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
                 emit docEngine->fileOnDiskChanged(tabW, idx, true);
             }
 
-            if(tab.active) {
-                focusedEditor = editor;
-                activeIndex = idx;
-            }
+            if(tab.active) activeIndex = idx;
 
             if(!tab.language.isEmpty()) editor->setLanguage(tab.language);
 
@@ -449,14 +444,13 @@ void loadSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
     if (viewCounter <= 0)
         return;
 
+    // Give focus to the first tab widget
+    EditorTabWidget* firstTabW = editorContainer->tabWidget(0);
+    firstTabW->currentEditor()->setFocus();
+
     // If the last tabwidget still has no tabs in it at this point, we'll have to delete it.
     EditorTabWidget* lastTabW = editorContainer->tabWidget( editorContainer->count() -1);
     lastTabW->deleteIfEmpty();
-
-    if(focusedEditor)
-        focusedEditor->setFocus();
-
-    return;
 }
 
 } // namespace Sessions

--- a/src/ui/include/EditorNS/customqwebview.h
+++ b/src/ui/include/EditorNS/customqwebview.h
@@ -16,12 +16,13 @@ namespace EditorNS
     signals:
         void mouseWheel(QWheelEvent *ev);
         void urlsDropped(QList<QUrl> urls);
-    public slots:
+        void gotFocus();
 
     protected:
-        void wheelEvent(QWheelEvent *ev);
-        void keyPressEvent(QKeyEvent *ev);
-        void dropEvent(QDropEvent *ev);
+        void wheelEvent(QWheelEvent *ev) override;
+        void keyPressEvent(QKeyEvent *ev) override;
+        void dropEvent(QDropEvent *ev) override;
+        void focusInEvent(QFocusEvent* event) override;
     };
 
 }


### PR DESCRIPTION
Fix editor focus issues by using Qt's focus signals instead of CodeMirror's.

As far as I can see, this behaves just as the current master. But fixes a few quirks and needless focus changes. I also added a comment of why clearFocus() is still needed at one point. Would be nice to eventually get rid of it.