### PR TITLE
Back references now working for regex search using the search dock.

### DIFF
--- a/src/ui/Search/filesearcher.cpp
+++ b/src/ui/Search/filesearcher.cpp
@@ -170,12 +170,15 @@ DocResult FileSearcher::searchRegExp(const QRegularExpression& regex, const QStr
         result.positionInFile = offset;
         result.positionInLine = offset - lineStart;
         result.matchLength = match.capturedLength();
+        result.regexMatch = match;
         results.results.push_back(result);
 
         // Advance at least by one to avoit infinite loops when capturing
         // empty expressions.
         offset += std::max(1, result.matchLength);
     }
+
+    results.regexCaptureGroupCount = regex.captureCount();
 
     return results;
 }

--- a/src/ui/include/Search/filereplacer.h
+++ b/src/ui/include/Search/filereplacer.h
@@ -45,7 +45,7 @@ public:
      * @param replacement This is the replacement string
      * @return The number of successful replacements
      */
-    static int replaceAll(const DocResult& doc, QString& content, const QString& replacement);
+    static void replaceAll(const DocResult& doc, QString& content, const QString& replacement);
 
 protected:
     void run() override;

--- a/src/ui/include/Search/searchobjects.h
+++ b/src/ui/include/Search/searchobjects.h
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <QString>
 #include <QVector>
+#include <QRegularExpressionMatch>
 
 #include "include/Search/searchhelpers.h"
 
@@ -69,6 +70,7 @@ struct MatchResult {
     int positionInFile;      // The match's offset from the beginning of the file
     int positionInLine;      // The match's offset from the beginning of the line
     int matchLength;         // The match's length
+    QRegularExpressionMatch regexMatch; // Only valid if this MatchResult was created by a regex search
 
 private:
     static const int CUTOFF_LENGTH; //Number of characters before/after match result that will be shown in preview
@@ -88,6 +90,7 @@ struct DocResult {
     EditorNS::Editor* editor = nullptr; // Only used when docType==TypeDocument
     QString fileName;                   // Is a file path when docType==TypeFile and a file name when TypeDocument
     QVector<MatchResult> results;
+    int regexCaptureGroupCount = 0;     // Only used when DocResult was created by a regex search
 };
 
 enum class SearchUserInteraction {


### PR DESCRIPTION
As an added bonus, also improves replacement speed by removing unnecessary copies of (possibly) large strings.