### PR TITLE
Prevent appmenu-qt5 from removing our menubar

### DIFF
--- a/support_files/launch/notepadqq
+++ b/support_files/launch/notepadqq
@@ -27,6 +27,12 @@ PERSONAL_QT53=~/Qt/5.3/$GCC_DIR/lib
 
 export LD_LIBRARY_PATH="$OPT_QT510:$PERSONAL_QT510:$OPT_QT59:$PERSONAL_QT59:$OPT_QT58:$PERSONAL_QT58:$OPT_QT57:$PERSONAL_QT57:$OPT_QT56:$PERSONAL_QT56:$OPT_QT55:$PERSONAL_QT55:$OPT_QT54:$PERSONAL_QT54:$OPT_QT53:$PERSONAL_QT53:${LD_LIBRARY_PATH}"
 
+# In Ubuntu Unity, appmenu-qt5 will try to hide our menubar in order to show it as a global bar. 
+# This may sometimes fail and leave us with no menu bar. So we'll prevent appmenu-qt5 for doing this.
+if [ "$QT_QPA_PLATFORMTHEME" = "appmenu-qt5" ]; then
+    export QT_QPA_PLATFORMTHEME=""
+fi
+
 if [ -f "$SCRIPTPATH"/../lib/notepadqq/notepadqq-bin ]; then
     # Nqq is installed: this script is in bin/
     exec "$SCRIPTPATH"/../lib/notepadqq/notepadqq-bin "$@"


### PR DESCRIPTION
I searched for a better alternative but I've found none. It seems the best thing to do is to prevent Unity from turning Nqq's menubar into a global bar entirely. It messes with the overall look-n-feel of the platform and introduces a small bug (the window jumps upwards a little everytime it's reopened- likely a side-effect of unsetting `QT_QPA_PLATFORMTHEME`).

This isn't an issue with newer Ubuntu versions since they've ditched Unity and appmenu-qt5 in favor of GNOME which shows our menu bar as it should.