### PR TITLE
fix: Prefer GTK's icon theme if XDG_CURRENT_DESKTOP is not set

### DIFF
--- a/support_files/launch/notepadqq
+++ b/support_files/launch/notepadqq
@@ -33,6 +33,13 @@ if [ "$QT_QPA_PLATFORMTHEME" = "appmenu-qt5" ]; then
     export QT_QPA_PLATFORMTHEME=""
 fi
 
+# For less common desktop environments, this doesn't get set at all which will cause QT to default to
+# using KDE's icon theme settings and cause a lot of missing icon errors.  Most enviornments that don't
+# set this preference GTK's settings... so go with that by default.
+if [ -z "$XDG_CURRENT_DESKTOP" ]; then
+    export XDG_CURRENT_DESKTOP="GNOME"
+fi
+
 if [ -f "$SCRIPTPATH"/../lib/notepadqq/notepadqq-bin ]; then
     # Nqq is installed: this script is in bin/
     exec "$SCRIPTPATH"/../lib/notepadqq/notepadqq-bin "$@"


### PR DESCRIPTION
This fixes #552

Since quite a large margin of desktop environments tend to use GTK's icon theme preferences, this will probably be a better default.  Should fix any further complaints about  missing icons as well.  I use Openbox and it has always happened to me but I never even noticed.  

I tested the fix while running XFCE4 and i3 as well.  XFCE was just to make sure it wasn't interfering with desktops that do set that environment variable.