### PR TITLE
fix: Allow horizontal scrolling when holding shift + mouse wheel

### DIFF
--- a/src/ui/EditorNS/customqwebview.cpp
+++ b/src/ui/EditorNS/customqwebview.cpp
@@ -12,7 +12,12 @@ namespace EditorNS
     void CustomQWebView::wheelEvent(QWheelEvent *ev)
     {
         emit mouseWheel(ev);
-        QWebView::wheelEvent(ev);
+        if (ev->modifiers() & Qt::ShiftModifier) {
+            QWheelEvent hScroll (ev->pos(), ev->delta(), ev->buttons(), ev->modifiers(), Qt::Horizontal);
+	    QWebView::wheelEvent(&hScroll);
+        } else {
+            QWebView::wheelEvent(ev);
+        }
     }
 
     void CustomQWebView::keyPressEvent(QKeyEvent *ev)


### PR DESCRIPTION
This fixes #582.  Seems to work as expected and this is the normal semantic for more or less everything else I've come across so it makes sense to add it here for now until we get QWebEngine working properly again.