### PR TITLE
Refactored DocEngine::loadDocuments.

### DIFF
--- a/src/ui/Sessions/sessions.cpp
+++ b/src/ui/Sessions/sessions.cpp
@@ -374,7 +374,11 @@ void loadSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
             if (!fileExists && !cacheFileExists)
                 continue;
 
-            const bool success = docEngine->loadDocumentSilent(loadUrl, tabW);
+            const bool success = docEngine->getDocumentLoader()
+                                 .setUrl(loadUrl)
+                                 .setTabWidget(tabW)
+                                 .setRememberLastDir(false)
+                                 .execute();
 
             if (!success)
                 continue;


### PR DESCRIPTION
Here's what's done:

* Removed all the different loading functions from DocEngine (`loadDocument`, `loadDocuments`, `loadDocumentSilent`, `reloadDocument`, etc)
* Added a single new `loadDocuments(DocEngine::DocumentLoader&)` function.
* `DocumentLoader` is a simple wrapper class that contains all the possible arguments important for loading documents. This makes it much clearer what function invokation does what sort of work.

I was inspired to do this refactoring when I had to add yet another parameter to `loadDocuments` to handle:

* ~~Adding option to warn about loading large text files. (Can be set in Preferences)~~


An example of what this means for document loading. Instead of:

    m_docEngine->reloadDocument(tabWidget, tab, codec, bom); // What does this even do?!

It's now:

    m_docEngine->getDocumentLoader()
            .setUrl(editor->filePath())
            .setTabWidget(tabWidget)
            .setTextCodec(codec) // All those are optional
            .setBOM(bom)
            .setIsReload(true)
            .execute(); // Run the operation with the given params

I think this is a change for the better, especially if `loadDocuments` becomes even more complex in the future. But since it's a pretty significant change and might also affect the WebEngine branch I want to get your okay first, @danieleds.