### PR TITLE
Fix CodeMirror startup errors (Applies to WebEngine mostly)

### DIFF
--- a/src/editor/index.html
+++ b/src/editor/index.html
@@ -10,6 +10,9 @@
     <link rel="stylesheet" href="libs/codemirror/addon/fold/foldgutter.css">
     <link rel="stylesheet" href="libs/codemirror/addon/hint/show-hint.css">
 
+    <!-- Load this first to avoid CodeMirror.defineSimpleMode errors -->
+    <script src="libs/codemirror/addon/mode/simple.js"></script>
+
     <!-- MODES -->
     <script src="libs/codemirror/mode/apl/apl.js"></script>
     <script src="libs/codemirror/mode/asciiarmor/asciiarmor.js"></script>


### PR DESCRIPTION
Finally bothered to look into this and turns out it was a CodeMirror addon we forgot to load up front. This little change fixes the startup errors regarding defineSimpleMode missing as a function.

Decided to push this to the master branch because its something we overlooked in both the webengine branch as well as master.