### PR TITLE
feat: Add '--line' and '--column' commandline arguments.

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -616,57 +616,57 @@ void MainWindow::openCommandLineProvidedUrls(const QString &workingDirectory, co
     {
         // Open a new empty document
         ui->actionNew->trigger();
+        return;
     }
-    else
+
+    // Open selected files
+    QList<QUrl> files;
+    for(int i = 0; i < rawUrls.count(); i++)
     {
-        // Open selected files
-        QList<QUrl> files;
-        for(int i = 0; i < rawUrls.count(); i++)
-        {
-            files.append(stringToUrl(rawUrls.at(i), workingDirectory));
-        }
-
-        EditorTabWidget *tabW = m_topEditorContainer->currentTabWidget();
-        m_docEngine->loadDocuments(files, tabW);
-
-
-        // Handle --line and --column commandline arguments
-        if (!parser->isSet("line") && !parser->isSet("column"))
-            return;
-
-        if (rawUrls.size() > 1) {
-            qWarning() << tr("The '--line' and '--column' arguments will be ignored since more than one file is opened.");
-            return;
-        }
-
-        int l = 0;
-        if (parser->isSet("line")) {
-            bool okay;
-            l = parser->value("line").toInt(&okay);
-
-            if(!okay)
-                qWarning() << tr("Invalid value for '--line' argument: %1").arg(parser->value("line"));
-        }
-
-        int c = 0;
-        if (parser->isSet("column")) {
-            bool okay;
-            c = parser->value("column").toInt(&okay);
-
-            if(!okay)
-                qWarning() << tr("Invalid value for '--column' argument: %1").arg(parser->value("column"));
-        }
-
-        // This needs to sit inside a timer because CodeMirror apparently chokes on receiving a setCursorPosition()
-        // right after construction of the Editor.
-        Editor* ed = tabW->currentEditor();
-        QTimer* t = new QTimer();
-        connect(t, &QTimer::timeout, [t, l, c, ed](){
-            ed->setCursorPosition(l-1, c-1);
-            t->deleteLater();
-        });
-        t->start(0);
+        files.append(stringToUrl(rawUrls.at(i), workingDirectory));
     }
+
+    EditorTabWidget *tabW = m_topEditorContainer->currentTabWidget();
+    m_docEngine->loadDocuments(files, tabW);
+
+
+    // Handle --line and --column commandline arguments
+    if (!parser->isSet("line") && !parser->isSet("column"))
+        return;
+
+    if (rawUrls.size() > 1) {
+        qWarning() << tr("The '--line' and '--column' arguments will be ignored since more than one file is opened.");
+        return;
+    }
+
+    int l = 0;
+    if (parser->isSet("line")) {
+        bool okay;
+        l = parser->value("line").toInt(&okay);
+
+        if(!okay)
+            qWarning() << tr("Invalid value for '--line' argument: %1").arg(parser->value("line"));
+    }
+
+    int c = 0;
+    if (parser->isSet("column")) {
+        bool okay;
+        c = parser->value("column").toInt(&okay);
+
+        if(!okay)
+            qWarning() << tr("Invalid value for '--column' argument: %1").arg(parser->value("column"));
+    }
+
+    // This needs to sit inside a timer because CodeMirror apparently chokes on receiving a setCursorPosition()
+    // right after construction of the Editor.
+    Editor* ed = tabW->currentEditor();
+    QTimer* t = new QTimer();
+    connect(t, &QTimer::timeout, [t, l, c, ed](){
+        ed->setCursorPosition(l-1, c-1);
+        t->deleteLater();
+    });
+    t->start(0);
+
 }
 
 void MainWindow::dragEnterEvent(QDragEnterEvent *e)

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -660,9 +660,12 @@ void MainWindow::openCommandLineProvidedUrls(const QString &workingDirectory, co
         // This needs to sit inside a timer because CodeMirror apparently chokes on receiving a setCursorPosition()
         // right after construction of the Editor.
         Editor* ed = tabW->currentEditor();
-        QTimer::singleShot(0, [l, c, ed](){
+        QTimer* t = new QTimer();
+        connect(t, &QTimer::timeout, [t, l, c, ed](){
             ed->setCursorPosition(l-1, c-1);
+            t->deleteLater();
         });
+        t->start(0);
     }
 }
 

--- a/src/ui/notepadqq.cpp
+++ b/src/ui/notepadqq.cpp
@@ -87,6 +87,18 @@ QSharedPointer<QCommandLineParser> Notepadqq::getCommandLineArgumentsParser(cons
                                          .arg(QCoreApplication::applicationName()));
     parser->addOption(newWindowOption);
 
+    QCommandLineOption setLine({"l", "line"},
+                               QObject::tr("Open file at specified line."),
+                               "line",
+                               "0");
+    parser->addOption(setLine);
+
+    QCommandLineOption setCol({"c", "column"},
+                              QObject::tr("Open file at specified column."),
+                              "column",
+                              "0");
+    parser->addOption(setCol);
+
     QCommandLineOption allowRootOption("allow-root", QObject::tr("Allows Notepadqq to be run as root."));
     parser->addOption(allowRootOption);
 

--- a/support_files/manpage/notepadqq.1
+++ b/support_files/manpage/notepadqq.1
@@ -1,4 +1,4 @@
-.TH NOTEPADQQ "1" "April 2018" "1.3.0" "User Commands"
+.TH NOTEPADQQ "1" "April 2018" "1.3.1" "User Commands"
 .SH NAME
 Notepadqq \- Notepad++-like editor for Linux
 
@@ -24,6 +24,14 @@ programming languages, code folding, multiple selection, and much more.
 \fB\-\-new\-window\fR
 Open the files in a new window of an existing instance of
 .B notepadqq.
+
+.TP
+\fB\-l, \-\-line <line>\fR
+Opens the given file at line <line>.
+
+.TP
+\fB\-c, \-\-column <col>\fR
+Opens the given file at column <col>.
 
 .SH COPYRIGHT
 Copyright \(co 2010-2017, Daniele Di Sarli <danieleds0@gmail.com>


### PR DESCRIPTION
Adds `--line` and `--column` (and `-l` and `-c` in short) to open the file at the specified line and/or column. 

Does nothing when opening several files at once since `QCommandLineParser` doesn't allow arguments chains for specifying `-l` and `-c` for each positional argument.


I initially thought about appending optional parameters to the file path (`notepadqq path/to/file:10:1` for line 10, column 1) but `:` is a valid character in ext & friends and the extra processing to handle all cases would just set us up for headaches later down the road.