### PR TITLE
feat: Add warning when opening large text files.

### DIFF
--- a/src/ui/docengine.cpp
+++ b/src/ui/docengine.cpp
@@ -102,6 +102,7 @@ bool DocEngine::loadDocuments(const DocEngine::DocumentLoader& docLoader)
     auto* tabWidget = docLoader.tabWidget;
     const auto& codec = docLoader.textCodec;
     const auto& bom = docLoader.bom;
+    auto fileSizeAction = docLoader.fileSizeAction;
 
     if (fileNames.empty())
         return true;
@@ -141,6 +142,43 @@ bool DocEngine::loadDocuments(const DocEngine::DocumentLoader& docLoader)
 
             emit documentLoaded(tabW, openPos.second, true, rememberLastSelectedDir);
             continue;
+        }
+
+        const int warnAtSize = NqqSettings::getInstance().General.getWarnIfFileLargerThan() * 1024 * 1024;
+        const auto fileSize = fi.size();
+
+        // Only warn if warnAtSize is at least 1. Otherwise the warning is disabled.
+        const bool fileTooLarge = warnAtSize > 0 && fileSize > warnAtSize;
+        if (fileSizeAction!=FileSizeActionYesToAll && fileTooLarge) {
+            if (fileSizeAction==FileSizeActionNoToAll)
+                continue;
+
+            QMessageBox msgBox;
+            msgBox.setWindowTitle(QCoreApplication::applicationName());
+            msgBox.setText(tr("The file \"%1\" you are trying to open is %2 MiB in size. Do you want to continue?")
+                           .arg(fi.fileName())
+                           .arg(QString::number(fileSize / 1024.0 / 1024.0, 'f', 2)));
+
+            auto buttons = QMessageBox::Yes | QMessageBox::No;
+            if (fileNames.size() > 1)
+                buttons |= QMessageBox::YesToAll | QMessageBox::NoToAll;
+            msgBox.setStandardButtons(buttons);
+            msgBox.setDefaultButton(QMessageBox::No);
+            msgBox.setIcon(QMessageBox::Warning);
+            int ret = msgBox.exec();
+
+            switch(ret) {
+            case QMessageBox::YesToAll:
+                fileSizeAction = FileSizeActionYesToAll;
+                break;
+            case QMessageBox::Yes:
+                break;
+            case QMessageBox::NoToAll:
+                fileSizeAction = FileSizeActionNoToAll;
+                continue;
+            case QMessageBox::No:
+                continue;
+            }
         }
 
         int tabIndex;

--- a/src/ui/include/docengine.h
+++ b/src/ui/include/docengine.h
@@ -28,6 +28,12 @@ public:
         bool error = false;
     };
 
+    enum FileSizeAction {
+        FileSizeActionAsk,
+        FileSizeActionYesToAll,
+        FileSizeActionNoToAll
+    };
+
     /**
      * @brief The DocumentLoader struct is an aggregation of all possible arguments for document loading.
      *        Only setTabWidget and setUrl(s) are necessary settings. All others have sensible defaults.
@@ -37,6 +43,9 @@ public:
         // Set the URL(s) of files to be loaded
         DocumentLoader& setUrl(const QUrl& url) { this->urls << url; return *this; }
         DocumentLoader& setUrls(const QList<QUrl>& urls) { this->urls = urls; return *this; }
+
+        // Set how files should be handled that trigger a file-size warning.
+        DocumentLoader& setFileSizeWarning(FileSizeAction fsa) { fileSizeAction = fsa; return *this; }
 
         // If true, the documents' parent directory will be remembered as the last opened dir.
         DocumentLoader& setRememberLastDir(bool rld) { rememberLastDir = rld; return *this; }
@@ -69,6 +78,7 @@ public:
         bool isReload                   = false;
         bool rememberLastDir            = true;
         bool bom                        = false;
+        FileSizeAction fileSizeAction   = FileSizeActionAsk;
 
     private:
         friend class DocEngine;
@@ -81,7 +91,6 @@ public:
      *        Use this object to load or reload documents.
      */
     DocumentLoader getDocumentLoader() { return DocumentLoader(*this); }
-
 
     /**
      * Describes the result of a save process.

--- a/src/ui/include/nqqsettings.h
+++ b/src/ui/include/nqqsettings.h
@@ -84,6 +84,7 @@ public:
         NQQ_SETTING(LastSelectedDir,                QString,    ".")
         NQQ_SETTING(LastSelectedSessionDir,         QString,    QString())
         NQQ_SETTING(RecentDocuments,                QList<QVariant>, QList<QVariant>())
+        NQQ_SETTING(WarnIfFileLargerThan,           int,        1)
 
         NQQ_SETTING(NotepadqqVersion,               QString,    QString())
         NQQ_SETTING(SmartIndentation,               bool,       true)


### PR DESCRIPTION
Displays a warning dialog when opening files larger than X MiB.

![img](https://i.imgur.com/CYM6CV0.png)

By default this option is disabled and can be turned on in Preferences.

When testing file sizes I noticed that even just a 1MiB file makes Nqq seize up for seconds. Anything above 2MiB and you begin to wonder if it just crashed. So perhaps it's a good idea to enable this warning by default for files larger than 1MiB. Thoughts?