### PR TITLE
fix: Change snap confinment mode to classic

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,7 +5,7 @@ description: |
   It helps developers by providing all you can expect from a general purpose text editor, such as syntax highlighting for more than 100 different languages, code folding, color schemes, file monitoring, multiple selection and much more.
   You can search text using the power of regular expressions. You can organize documents side by side. You can use real-time highlighting to find near identifiers in no time.
 grade: stable
-confinement: strict
+confinement: classic
 icon: support_files/icons/hicolor/scalable/apps/notepadqq.svg
 
 


### PR DESCRIPTION
In response to https://github.com/notepadqq/notepadqq/issues/557#issuecomment-381610707

Snaps do not allow full disk access by default, and we can only use interfaces to grant access to a few locations. However, according to [this](https://insights.ubuntu.com/2017/01/09/how-to-snap-introducing-classic-confinement):

> Snaps declaring their confinement as “classic”, have access to the rest of the system, as most legacy (debian packages for example) packaged apps do, while still benefiting from the ci-integrated store model, with automated updates, rollbacks to older versions, release channels, etc.

I can't test this fix because this is quite literally the first time I've looked at snaps, so I don't know how to test them locally (yet). I'm relying on the documentation here.