### PR TITLE
fix: Use custom context menu to avoid reload bug #336

### DIFF
--- a/src/ui/EditorNS/customqwebview.cpp
+++ b/src/ui/EditorNS/customqwebview.cpp
@@ -1,5 +1,6 @@
 #include "include/EditorNS/customqwebview.h"
 #include <QMimeData>
+#include <QMenu>
 
 namespace EditorNS
 {
@@ -7,6 +8,19 @@ namespace EditorNS
     CustomQWebView::CustomQWebView(QWidget *parent) :
         QWebView(parent)
     {
+        setContextMenuPolicy(Qt::CustomContextMenu);
+        connect(this, &CustomQWebView::customContextMenuRequested,
+                this, &CustomQWebView::onCustomContextMenuRequested);
+    }
+
+    void CustomQWebView::onCustomContextMenuRequested(const QPoint& pos)
+    {
+        QMenu menu;
+        menu.addAction(page()->action(QWebPage::Cut));
+        menu.addAction(page()->action(QWebPage::Copy));
+        menu.addAction(page()->action(QWebPage::Paste));
+        menu.addAction(page()->action(QWebPage::SelectAll));
+        menu.exec(mapToGlobal(pos));
     }
 
     void CustomQWebView::wheelEvent(QWheelEvent *ev)

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -56,11 +56,6 @@ namespace EditorNS
         //QString content = QString("<html><body onload='setTimeout(function() { window.location=\"%1\"; }, 1);'>Loading...</body></html>").arg("file://" + Notepadqq::editorPath());
         //m_webView->setContent(content.toUtf8());
 
-		m_webView->pageAction(QWebPage::InspectElement)->setVisible(false);
-		m_webView->pageAction(QWebPage::SetTextDirectionDefault)->setVisible(false);
-		m_webView->pageAction(QWebPage::SetTextDirectionLeftToRight)->setVisible(false);
-		m_webView->pageAction(QWebPage::SetTextDirectionRightToLeft)->setVisible(false);
-
         m_webView->page()->setLinkDelegationPolicy(QWebPage::DelegateAllLinks);
 
         QWebSettings *pageSettings = m_webView->page()->settings();

--- a/src/ui/include/EditorNS/customqwebview.h
+++ b/src/ui/include/EditorNS/customqwebview.h
@@ -23,6 +23,9 @@ namespace EditorNS
         void keyPressEvent(QKeyEvent *ev) override;
         void dropEvent(QDropEvent *ev) override;
         void focusInEvent(QFocusEvent* event) override;
+
+    private slots:
+        void onCustomContextMenuRequested(const QPoint& pos);
     };
 
 }


### PR DESCRIPTION
This should fix #336.  I tested using the various amounts of info we had for that ticket and reload doesn't appear to show up in any of these cases now.