### PR TITLE
feat: Append file extension to suggested file names.

### DIFF
--- a/src/ui/include/EditorNS/editor.h
+++ b/src/ui/include/EditorNS/editor.h
@@ -225,6 +225,7 @@ namespace EditorNS
         Q_INVOKABLE QString getLanguageName() {return m_currentLanguage->name;}
         Q_INVOKABLE QString getLanguageMime() {return m_currentLanguage->mime;}
         Q_INVOKABLE QString getLanguageMode() {return m_currentLanguage->mode;}
+        const Language* getLanguage() { return m_currentLanguage; }
         Q_INVOKABLE void setLineWrap(const bool wrap);
         Q_INVOKABLE void setEOLVisible(const bool showeol);
         Q_INVOKABLE void setWhitespaceVisible(const bool showspace);

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1167,8 +1167,13 @@ QUrl MainWindow::getSaveDialogDefaultFileName(EditorTabWidget *tabWidget, int ta
     QUrl docFileName = tabWidget->editor(tab)->filePath();
 
     if (docFileName.isEmpty()) {
+        // For tabs that don't have a filename associated with them we'll composite one using
+        // its tab title and the language mode's file extension.
+        const auto& extensions = tabWidget->editor(tab)->getLanguage()->fileExtensions;
+        QString ext = extensions.isEmpty() ? "" : "." + extensions.first();
+
         return QUrl::fromLocalFile(m_settings.General.getLastSelectedDir()
-                                   + "/" + tabWidget->tabText(tab));
+                                   + "/" + tabWidget->tabText(tab) + ext);
     } else {
         return docFileName;
     }

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1151,7 +1151,7 @@ int MainWindow::saveAs(EditorTabWidget *tabWidget, int tab, bool copy)
                            tr("Save as"),
                            getSaveDialogDefaultFileName(tabWidget, tab).toLocalFile(),
                            tr("Any file (*)"),
-                           0, 0);
+                           nullptr, nullptr);
 
     if (filename != "") {
         m_settings.General.setLastSelectedDir(QFileInfo(filename).absolutePath());


### PR DESCRIPTION
When saving a "new X" tab we can suggest a file extension based on the highlighting/language mode selected. 

E.g. for a bash file the suggested name will now be `"new X.sh"`. For plain text files (the default) the suggested extension is `".txt"`.