### PR TITLE
refactor: Prefer using Language* over ID strings. Remove superflous Editor functions.

### DIFF
--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -250,7 +250,7 @@ namespace EditorNS
             return;
         }
         if (!m_customIndentationMode) {
-            setIndentationMode(lang->id);
+            setIndentationMode(lang);
         }
         m_currentLanguage = lang;
         sendMessage("C_CMD_SET_LANGUAGE", lang->mime.isEmpty() ? lang->mode : lang->mime);
@@ -285,15 +285,16 @@ namespace EditorNS
         setLanguageFromFileName(filePath().toString());
     }
 
-    void Editor::setIndentationMode(QString language)
+    void Editor::setIndentationMode(const Language* lang)
     {
+        QString langId = lang->id;
         NqqSettings& s = NqqSettings::getInstance();
 
-        if (s.Languages.getUseDefaultSettings(language))
-            language = "default";
+        if (s.Languages.getUseDefaultSettings(langId))
+            langId = "default";
 
-        setIndentationMode(!s.Languages.getIndentWithSpaces(language),
-                            s.Languages.getTabSize(language));
+        setIndentationMode(!s.Languages.getIndentWithSpaces(langId),
+                            s.Languages.getTabSize(langId));
     }
 
     void Editor::setIndentationMode(const bool useTabs, const int size)
@@ -328,7 +329,7 @@ namespace EditorNS
     void Editor::clearCustomIndentationMode()
     {
         m_customIndentationMode = false;
-        setIndentationMode(getLanguageId());
+        setIndentationMode(getLanguage());
     }
 
     bool Editor::isUsingCustomIndentationMode() const

--- a/src/ui/Sessions/sessions.cpp
+++ b/src/ui/Sessions/sessions.cpp
@@ -311,7 +311,7 @@ bool saveSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
             td.scrollX = scrollPos.first;
             td.scrollY = scrollPos.second;
             td.active = tabWidget->currentEditor() == editor;
-            td.language = editor->getLanguageId();
+            td.language = editor->getLanguage()->id;
             
             // Cache the custom indentation state of the file
             if (editor->isUsingCustomIndentationMode()) {

--- a/src/ui/frmpreferences.cpp
+++ b/src/ui/frmpreferences.cpp
@@ -111,7 +111,7 @@ void frmPreferences::updatePreviewEditorFont()
 
     // Re-setting language also updates the position of text selection. If not done, selected text
     // would often glitch out when changing the font causes the position of text characters to change.
-    m_previewEditor->setLanguage(m_previewEditor->getLanguageId());
+    m_previewEditor->setLanguage(m_previewEditor->getLanguage());
 }
 
 void frmPreferences::on_treeWidget_currentItemChanged(QTreeWidgetItem *current, QTreeWidgetItem * /*previous*/)
@@ -422,7 +422,7 @@ bool frmPreferences::applySettings()
             editor->setFont(fontFamily, fontSize, lineHeight);
 
             // Reset language-dependent settings (e.g. tab settings)
-            editor->setLanguage(editor->getLanguageId());
+            editor->setLanguage(editor->getLanguage());
 
             return true;
         });

--- a/src/ui/include/EditorNS/editor.h
+++ b/src/ui/include/EditorNS/editor.h
@@ -221,10 +221,10 @@ namespace EditorNS
         Q_INVOKABLE void setZoomFactor(const qreal &factor);
         Q_INVOKABLE void setSelectionsText(const QStringList &texts, selectMode mode);
         Q_INVOKABLE void setSelectionsText(const QStringList &texts);
-        Q_INVOKABLE QString getLanguageId() {return m_currentLanguage->id;}
+        /*Q_INVOKABLE QString getLanguageId() {return m_currentLanguage->id;}
         Q_INVOKABLE QString getLanguageName() {return m_currentLanguage->name;}
         Q_INVOKABLE QString getLanguageMime() {return m_currentLanguage->mime;}
-        Q_INVOKABLE QString getLanguageMode() {return m_currentLanguage->mode;}
+        Q_INVOKABLE QString getLanguageMode() {return m_currentLanguage->mode;}*/
         const Language* getLanguage() { return m_currentLanguage; }
         Q_INVOKABLE void setLineWrap(const bool wrap);
         Q_INVOKABLE void setEOLVisible(const bool showeol);
@@ -337,7 +337,7 @@ namespace EditorNS
         void fullConstructor(const Theme &theme);
 
         void setIndentationMode(const bool useTabs, const int size);
-        void setIndentationMode(QString language);
+        void setIndentationMode(const Language*);
 
     private slots:
         void on_javaScriptWindowObjectCleared();

--- a/src/ui/include/EditorNS/editor.h
+++ b/src/ui/include/EditorNS/editor.h
@@ -221,10 +221,6 @@ namespace EditorNS
         Q_INVOKABLE void setZoomFactor(const qreal &factor);
         Q_INVOKABLE void setSelectionsText(const QStringList &texts, selectMode mode);
         Q_INVOKABLE void setSelectionsText(const QStringList &texts);
-        /*Q_INVOKABLE QString getLanguageId() {return m_currentLanguage->id;}
-        Q_INVOKABLE QString getLanguageName() {return m_currentLanguage->name;}
-        Q_INVOKABLE QString getLanguageMime() {return m_currentLanguage->mime;}
-        Q_INVOKABLE QString getLanguageMode() {return m_currentLanguage->mode;}*/
         const Language* getLanguage() { return m_currentLanguage; }
         Q_INVOKABLE void setLineWrap(const bool wrap);
         Q_INVOKABLE void setEOLVisible(const bool showeol);

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1412,7 +1412,7 @@ void MainWindow::searchDockItemInteracted(const DocResult& doc, const MatchResul
 void MainWindow::refreshEditorUiInfo(Editor *editor)
 {
     // Update current language in statusbar
-    QString name = editor->getLanguageName();
+    QString name = editor->getLanguage()->name;
     m_statusBar_fileFormat->setText(name);
 
     // Update MainWindow title


### PR DESCRIPTION
Here we go.