### PR TITLE
feat: Unify document reload behavior. (fixes #603)

### DIFF
--- a/src/ui/docengine.cpp
+++ b/src/ui/docengine.cpp
@@ -169,9 +169,9 @@ void DocEngine::loadDocuments(const DocEngine::DocumentLoader& docLoader)
         QFileInfo fi(localFileName);
 
         const QPair<int, int> openPos = findOpenEditorByUrl(url);
-        const bool isReloading = openPos.first > -1; //'true' when we're reloading a tab
+        const bool isAlreadyOpen = openPos.first > -1; //'true' when we're reloading a tab
 
-        if(isReloading && reloadAction == ReloadActionDont) {
+        if(isAlreadyOpen && reloadAction == ReloadActionDont) {
             EditorTabWidget *tabW = static_cast<EditorTabWidget *>
                                     (m_topEditorContainer->widget(openPos.first));
 
@@ -210,7 +210,7 @@ void DocEngine::loadDocuments(const DocEngine::DocumentLoader& docLoader)
         }
 
         int tabIndex;
-        if (isReloading) {
+        if (isAlreadyOpen) {
             tabWidget = m_topEditorContainer->tabWidget(openPos.first);
             tabIndex = openPos.second;
         } else {
@@ -222,7 +222,7 @@ void DocEngine::loadDocuments(const DocEngine::DocumentLoader& docLoader)
         // In case of a reload, save cursor and scroll position
         QPair<int, int> scrollPosition;
         QPair<int, int> cursorPosition;
-        if (isReloading) {
+        if (isAlreadyOpen) {
             scrollPosition = editor->scrollPosition();
             cursorPosition = editor->cursorPosition();
         }
@@ -264,7 +264,7 @@ void DocEngine::loadDocuments(const DocEngine::DocumentLoader& docLoader)
         }
 
         // In case of reload, restore cursor and scroll position
-        if (isReloading) {
+        if (isAlreadyOpen) {
             editor->setScrollPosition(scrollPosition);
             editor->setCursorPosition(cursorPosition);
         }
@@ -288,7 +288,7 @@ void DocEngine::loadDocuments(const DocEngine::DocumentLoader& docLoader)
         }
 
         file.close();
-        if (isReloading) {
+        if (isAlreadyOpen) {
             editor->setFileOnDiskChanged(false);
         } else {
             editor->setFilePath(url);
@@ -304,7 +304,7 @@ void DocEngine::loadDocuments(const DocEngine::DocumentLoader& docLoader)
             tabWidget->editor(tabIndex)->setFocus();
         }
 
-        if (isReloading) {
+        if (isAlreadyOpen) {
             emit documentReloaded(tabWidget, tabIndex);
         } else {
             emit documentLoaded(tabWidget, tabIndex, false, rememberLastSelectedDir);

--- a/src/ui/docengine.cpp
+++ b/src/ui/docengine.cpp
@@ -168,7 +168,7 @@ void DocEngine::loadDocuments(const DocEngine::DocumentLoader& docLoader)
         QString localFileName = url.toLocalFile();
         QFileInfo fi(localFileName);
 
-        QPair<int, int> openPos = findOpenEditorByUrl(url);
+        const QPair<int, int> openPos = findOpenEditorByUrl(url);
         const bool isReloading = openPos.first > -1; //'true' when we're reloading a tab
 
         if(isReloading && reloadAction == ReloadActionDont) {

--- a/src/ui/include/docengine.h
+++ b/src/ui/include/docengine.h
@@ -34,6 +34,12 @@ public:
         FileSizeActionNoToAll
     };
 
+    enum ReloadAction {
+        ReloadActionDont,   // Don't reload documents, instead just focus them
+        ReloadActionAsk,    // Ask user to reload if it would cause unsaved changes to be discarded
+        ReloadActionDo      // Always reload documents
+    };
+
     /**
      * @brief The DocumentLoader struct is an aggregation of all possible arguments for document loading.
      *        Only setTabWidget and setUrl(s) are necessary settings. All others have sensible defaults.
@@ -59,8 +65,8 @@ public:
         // Set the TabWidget the documents should be loaded into
         DocumentLoader& setTabWidget(EditorTabWidget* tw) { tabWidget = tw; return *this; }
 
-        // If set, the given documents will only be reloaded. If a document isn't opened yet it will be ignored.
-        DocumentLoader& setIsReload(bool reload) { isReload = reload; return *this; }
+        // Determines how already opened documents should be treated.
+        DocumentLoader& setReloadAction(ReloadAction reload) { reloadAction = reload; return *this; }
 
         /**
          * @brief execute Runs the load operation.
@@ -74,7 +80,7 @@ public:
         QList<QUrl> urls;
         EditorTabWidget* tabWidget      = nullptr;
         QTextCodec* textCodec           = nullptr;
-        bool isReload                   = false;
+        ReloadAction reloadAction       = ReloadActionAsk;
         bool rememberLastDir            = true;
         bool bom                        = false;
         FileSizeAction fileSizeAction   = FileSizeActionAsk;

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -271,7 +271,6 @@ private:
     void                convertEditorEncoding(Editor *editor, QTextCodec *codec, bool bom);
     void                toggleOverwrite();
     void                checkIndentationMode(Editor *editor);
-    bool                reloadWithWarning(EditorTabWidget *tabWidget, int tab, QTextCodec *codec, bool bom);
     QStringList         currentWordOrSelections();
     QString             currentWordOrSelection();
     void                currentWordOnlineSearch(const QString &searchUrl);

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -885,44 +885,6 @@ void MainWindow::on_actionMath_Rendering_toggled(bool on)
     m_settings.General.setMathRendering(on);
 }
 
-bool MainWindow::reloadWithWarning(EditorTabWidget *tabWidget, int tab, QTextCodec *codec, bool bom)
-{
-    // Don't do anything if there is no file to reload from.
-    if (tabWidget->editor(tab)->filePath().isEmpty())
-        return false;
-
-    if (!tabWidget->editor(tab)->isClean()) {
-        QMessageBox msgBox(this);
-        QString name = tabWidget->tabText(tab).toHtmlEscaped();
-
-        msgBox.setWindowTitle(QCoreApplication::applicationName());
-        msgBox.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
-
-        msgBox.setText("<h3>" + tr("Your changes to «%1» will be discarded.").arg(name) + "</h3>");
-        msgBox.setButtonText(QMessageBox::Ok, tr("Reload"));
-
-        msgBox.setDefaultButton(QMessageBox::Cancel);
-        msgBox.setEscapeButton(QMessageBox::Cancel);
-
-        msgBox.exec();
-
-        if (msgBox.standardButton(msgBox.clickedButton()) == QMessageBox::Cancel)
-            return false;
-    }
-
-    Editor *editor = tabWidget->editor(tab);
-
-    m_docEngine->getDocumentLoader()
-            .setUrl(editor->filePath())
-            .setTabWidget(tabWidget)
-            .setTextCodec(codec)
-            .setBOM(bom)
-            .setIsReload(true)
-            .execute();
-
-    return true;
-}
-
 void MainWindow::on_actionMove_to_Other_View_triggered()
 {
     EditorTabWidget *curTabWidget = m_topEditorContainer->currentTabWidget();
@@ -1708,7 +1670,7 @@ void MainWindow::on_fileOnDiskChanged(EditorTabWidget *tabWidget, int tab, bool 
             m_docEngine->getDocumentLoader()
                     .setUrl(editor->filePath())
                     .setTabWidget(tabWidget)
-                    .setIsReload(true)
+                    .setReloadAction(DocEngine::ReloadActionDo)
                     .execute();
         });
     }
@@ -1979,10 +1941,15 @@ void MainWindow::on_actionReload_from_Disk_triggered()
     EditorTabWidget *tabWidget = m_topEditorContainer->currentTabWidget();
     Editor *editor = tabWidget->currentEditor();
 
-    reloadWithWarning(tabWidget,
-                      tabWidget->currentIndex(),
-                      editor->codec(),
-                      editor->bom());
+    if (editor->filePath().isEmpty())
+        return;
+
+    m_docEngine->getDocumentLoader()
+            .setUrl(editor->filePath())
+            .setTabWidget(tabWidget)
+            .setTextCodec(editor->codec())
+            .setBOM(editor->bom())
+            .execute();
 }
 
 void MainWindow::on_actionFind_Next_triggered()
@@ -2175,13 +2142,22 @@ void MainWindow::on_actionConvert_to_triggered()
 void MainWindow::on_actionReload_File_Interpreted_As_triggered()
 {
     Editor *editor = currentEditor();
+
+    if (editor->filePath().isEmpty())
+        return;
+
     frmEncodingChooser *dialog = new frmEncodingChooser(this);
     dialog->setEncoding(editor->codec());
     dialog->setInfoText(tr("Reload as:"));
 
     if (dialog->exec() == QDialog::Accepted) {
         EditorTabWidget *tabWidget = m_topEditorContainer->currentTabWidget();
-        reloadWithWarning(tabWidget, tabWidget->currentIndex(), dialog->selectedCodec(), false);
+
+        m_docEngine->getDocumentLoader()
+                .setUrl(editor->filePath())
+                .setTabWidget(tabWidget)
+                .setTextCodec(dialog->selectedCodec())
+                .execute();
     }
 
     dialog->deleteLater();


### PR DESCRIPTION
Last one for today!

This slightly changes the default behavior of DocEngine:

* Opening a document that isn't already open will happen as normal.
* Opening a document that is already open (and in a clean state) will quietly reload it.
* Opening a document that is already open (and in a dirty state) will now ask the user if he wants to reload.
* Only exception is the `FileChangedBanner`. Clicking `Reload` there won't ask but simply reload. That's how it currently works.

That means it's now DocEngine's responsibility to ask for reloading. Previously this happened in Mainwindow.
