### PR TITLE
refactor: Update editor to use more C++11-isms

### DIFF
--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -344,7 +344,10 @@ namespace EditorNS
 
     void Editor::setValue(const QString &value)
     {
-        setLanguage(LanguageService::getInstance().lookupByContent(value));
+        auto lang = LanguageService::getInstance().lookupByContent(value);
+        if (lang != nullptr) {
+            setLanguage(lang);
+        }
         sendMessage("C_CMD_SET_VALUE", value);
     }
 

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -590,9 +590,7 @@ namespace EditorNS
     QList<Editor::Theme> Editor::themes()
     {
         auto editorPath = QFileInfo(Notepadqq::editorPath());
-        auto bundledThemesDir = QDir(editorPath.absolutePath() + "/libs/codemirror/theme/");
-
-        bundledThemesDir.setNameFilters({"*.css"});
+        QDir bundledThemesDir(editorPath.absolutePath() + "/libs/codemirror/theme/", "*.css");
 
         QList<Theme> out;
         for (auto&& theme : bundledThemesDir.entryInfoList()) {

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -161,6 +161,7 @@ namespace EditorNS
                 }
             }
 
+
         } else if(msg == "J_EVT_READY") {
             m_loaded = true;
             emit editorReady();

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -333,10 +333,7 @@ namespace EditorNS
 
     void Editor::setValue(const QString &value)
     {
-        auto lang = LanguageService::getInstance().lookupByContent(value);
-        if (lang != nullptr) {
-            setLanguage(lang);
-        }
+        setLanguage(LanguageService::getInstance().lookupByContent(value));
         sendMessage("C_CMD_SET_VALUE", value);
     }
 

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -141,26 +141,23 @@ namespace EditorNS
         if (msg.startsWith("[ASYNC_REPLY]")) {
             QRegExp rgx("\\[ID=(\\d+)\\]$");
 
-            if(rgx.indexIn(msg) == -1)
-                return;
-
-            if (rgx.captureCount() != 1)
+            if(rgx.indexIn(msg) == -1 || rgx.captureCount() != 1)
                 return;
 
             unsigned int id = rgx.capturedTexts()[1].toInt();
 
             // Look into the list of callbacks
-            for (auto it = this->asyncReplies.begin(); it != this->asyncReplies.end(); ++it) {
-                if (it->id == id) {
-                    auto cb = it->callback;
-                    it->value->set_value(data);
-                    this->asyncReplies.erase(it);
+            auto it = std::find_if(asyncReplies.begin(), asyncReplies.end(), [&id] (const AsyncReply& reply) {
+                return (reply.id == id);
+            });
+            if (it == asyncReplies.end())
+                return;
+            auto cb = it->callback;
+            it->value->set_value(data);
+            this->asyncReplies.erase(it);
 
-                    if (cb != 0) {
-                        cb(data);
-                    }
-                    break;
-                }
+            if (cb != 0) {
+                cb(data);
             }
 
 

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -283,14 +283,11 @@ namespace EditorNS
 
     void Editor::setIndentationMode(const Language* lang)
     {
-        QString langId = lang->id;
-        NqqSettings& s = NqqSettings::getInstance();
+        const auto& s = NqqSettings::getInstance().Languages;
+        const bool useDefaults = s.getUseDefaultSettings(lang->id);
+        const auto& langId = useDefaults ? "default" : lang->id;
 
-        if (s.Languages.getUseDefaultSettings(langId))
-            langId = "default";
-
-        setIndentationMode(!s.Languages.getIndentWithSpaces(langId),
-                            s.Languages.getTabSize(langId));
+        setIndentationMode(!s.getIndentWithSpaces(langId), s.getTabSize(langId));
     }
 
     void Editor::setIndentationMode(const bool useTabs, const int size)

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -20,8 +20,6 @@ namespace EditorNS
     {
 
         QString themeName = NqqSettings::getInstance().Appearance.getColorScheme();
-        if (themeName == "")
-            themeName = "default";
 
         fullConstructor(themeFromName(themeName));
     }

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -139,23 +139,26 @@ namespace EditorNS
         if (msg.startsWith("[ASYNC_REPLY]")) {
             QRegExp rgx("\\[ID=(\\d+)\\]$");
 
-            if (rgx.indexIn(msg) == -1 || rgx.captureCount() != 1)
+            if(rgx.indexIn(msg) == -1)
+                return;
+
+            if (rgx.captureCount() != 1)
                 return;
 
             unsigned int id = rgx.capturedTexts()[1].toInt();
 
             // Look into the list of callbacks
-            auto it = std::find_if(asyncReplies.begin(), asyncReplies.end(), [&id] (const AsyncReply& reply) {
-                return (reply.id == id);
-            });
-            if (it == asyncReplies.end())
-                return;
-            auto cb = it->callback;
-            it->value->set_value(data);
-            this->asyncReplies.erase(it);
+            for (auto it = this->asyncReplies.begin(); it != this->asyncReplies.end(); ++it) {
+                if (it->id == id) {
+                    auto cb = it->callback;
+                    it->value->set_value(data);
+                    this->asyncReplies.erase(it);
 
-            if (cb != nullptr) {
-                cb(data);
+                    if (cb != 0) {
+                        cb(data);
+                    }
+                    break;
+                }
             }
 
         } else if (msg == "J_EVT_READY") {

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -565,26 +565,16 @@ namespace EditorNS
 
     Editor::Theme Editor::themeFromName(QString name)
     {
-        Theme defaultTheme;
-        defaultTheme.name = "default";
-        defaultTheme.path = "";
+        if (name == "default" || name.isEmpty())
+            return Theme();
 
-        if (name == "default" || name == "")
-            return defaultTheme;
+        QFileInfo editorPath(Notepadqq::editorPath());
+        QDir bundledThemesDir(editorPath.absolutePath() + "/libs/codemirror/theme/");
 
-        QFileInfo editorPath = QFileInfo(Notepadqq::editorPath());
-        QDir bundledThemesDir = QDir(editorPath.absolutePath() + "/libs/codemirror/theme/");
+        if (bundledThemesDir.exists(name + ".css"))
+            return Theme(name, bundledThemesDir.filePath(name + ".css"));
 
-        Theme t;
-        QString themeFile = bundledThemesDir.filePath(name + ".css");
-        if (QFile(themeFile).exists()) {
-            t.name = name;
-            t.path = themeFile;
-        } else {
-            t = defaultTheme;
-        }
-
-        return t;
+        return Theme();
     }
 
     QList<Editor::Theme> Editor::themes()
@@ -594,17 +584,14 @@ namespace EditorNS
 
         QList<Theme> out;
         for (auto&& theme : bundledThemesDir.entryInfoList()) {
-            out.append({theme.completeBaseName(), theme.filePath()});
+            out.append(Theme(theme.completeBaseName(), theme.filePath()));
         }
         return out;
     }
 
     void Editor::setTheme(Theme theme)
     {
-        QMap<QString, QVariant> tmap;
-        tmap.insert("name", theme.name == "" ? "default" : theme.name);
-        tmap.insert("path", theme.path);
-        sendMessage("C_CMD_SET_THEME", tmap);
+        sendMessage("C_CMD_SET_THEME", QVariantMap{{"name",theme.name},{"path",theme.path}});
     }
 
     QList<Editor::Selection> Editor::selections()

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -670,7 +670,7 @@ namespace EditorNS
         // 2. Set WebView's bg-color to white to prevent visual artifacts when printing less than one page.
         // 3. Set C_CMD_DISPLAY_PRINT_STYLE to hide UI elements like the gutter.
 
-        setTheme(themeFromName("Default"));
+        setTheme(themeFromName("default"));
         m_webView->setStyleSheet("background-color: white");
         sendMessage("C_CMD_DISPLAY_PRINT_STYLE");
         m_webView->print(printer);

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -161,14 +161,14 @@ namespace EditorNS
                 }
             }
 
-        } else if (msg == "J_EVT_READY") {
+        } else if(msg == "J_EVT_READY") {
             m_loaded = true;
             emit editorReady();
-        } else if (msg == "J_EVT_CONTENT_CHANGED")
+        } else if(msg == "J_EVT_CONTENT_CHANGED")
             emit contentChanged();
-        else if (msg == "J_EVT_CLEAN_CHANGED")
+        else if(msg == "J_EVT_CLEAN_CHANGED")
             emit cleanChanged(data.toBool());
-        else if (msg == "J_EVT_CURSOR_ACTIVITY")
+        else if(msg == "J_EVT_CURSOR_ACTIVITY")
             emit cursorActivity();
     }
 

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -504,7 +504,7 @@ namespace EditorNS
 
     void Editor::setSelection(int fromLine, int fromCol, int toLine, int toCol)
     {
-        QList<QVariant> arg{fromLine, fromCol, toLine, toCol};
+        QVariantList arg{fromLine, fromCol, toLine, toCol};
         sendMessage("C_CMD_SET_SELECTION", QVariant(arg));
     }
 
@@ -595,13 +595,9 @@ namespace EditorNS
         bundledThemesDir.setNameFilters({"*.css"});
 
         QList<Theme> out;
-        for (auto&& themeStr : bundledThemesDir.entryList()) {
-            auto theme = QFileInfo(themeStr);
-            QString nameWithoutExt = theme.fileName()
-                    .replace(QRegularExpression("\\.css$"), "");
-            out.append({nameWithoutExt, bundledThemesDir.filePath(themeStr)});
+        for (auto&& theme : bundledThemesDir.entryInfoList()) {
+            out.append({theme.completeBaseName(), theme.filePath()});
         }
-
         return out;
     }
 

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -429,26 +429,23 @@ namespace EditorNS
         return m_webView->zoomFactor();
     }
 
-    void Editor::setSelectionsText(const QStringList &texts, selectMode mode)
+    void Editor::setSelectionsText(const QStringList &texts, SelectMode mode)
     {
-        QString modeStr = "";
-        if (mode == selectMode_cursorAfter)
-            modeStr = "after";
-        else if (mode == selectMode_cursorBefore)
-            modeStr = "before";
-        else
-            modeStr = "selected";
-
-        QVariantMap data;
-        data.insert("text", texts);
-        data.insert("select", modeStr);
-
+        QVariantMap data {{"text", texts}};
+        switch (mode) {
+            case SelectMode::After:
+                data.insert("select", "after"); break;
+            case SelectMode::Before:
+                data.insert("select", "before"); break;
+            default:
+                data.insert("select", "selected"); break;
+        }
         sendMessage("C_CMD_SET_SELECTIONS_TEXT", data);
     }
 
     void Editor::setSelectionsText(const QStringList &texts)
     {
-        setSelectionsText(texts, selectMode_cursorAfter);
+        setSelectionsText(texts, SelectMode::After);
     }
 
     void Editor::insertBanner(QWidget *banner)
@@ -602,25 +599,17 @@ namespace EditorNS
 
     QList<Editor::Theme> Editor::themes()
     {
-        QFileInfo editorPath = QFileInfo(Notepadqq::editorPath());
-        QDir bundledThemesDir = QDir(editorPath.absolutePath() + "/libs/codemirror/theme/");
+        auto editorPath = QFileInfo(Notepadqq::editorPath());
+        auto bundledThemesDir = QDir(editorPath.absolutePath() + "/libs/codemirror/theme/");
 
-        QStringList filters;
-        filters << "*.css";
-        bundledThemesDir.setNameFilters(filters);
-
-        QStringList themeFiles = bundledThemesDir.entryList();
+        bundledThemesDir.setNameFilters({"*.css"});
 
         QList<Theme> out;
-        for (QString themeStr : themeFiles) {
-            QFileInfo theme = QFileInfo(themeStr);
+        for (auto&& themeStr : bundledThemesDir.entryList()) {
+            auto theme = QFileInfo(themeStr);
             QString nameWithoutExt = theme.fileName()
                     .replace(QRegularExpression("\\.css$"), "");
-
-            Theme t;
-            t.name = nameWithoutExt;
-            t.path = bundledThemesDir.filePath(themeStr);
-            out.append(t);
+            out.append({nameWithoutExt, bundledThemesDir.filePath(themeStr)});
         }
 
         return out;

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -463,9 +463,8 @@ namespace EditorNS
 
     void Editor::removeBanner(QString objectName)
     {
-        QList<QWidget *> list = findChildren<QWidget *>(objectName);
-        for (int i = 0; i < list.length(); i++) {
-            removeBanner(list[i]);
+        for (auto&& banner : findChildren<QWidget *>(objectName)) {
+            removeBanner(banner);
         }
     }
 
@@ -492,13 +491,12 @@ namespace EditorNS
     QPair<int, int> Editor::cursorPosition()
     {
         QList<QVariant> cursor = asyncSendMessageWithResult("C_FUN_GET_CURSOR").get().toList();
-        return QPair<int, int>(cursor[0].toInt(), cursor[1].toInt());
+        return {cursor[0].toInt(), cursor[1].toInt()};
     }
 
     void Editor::setCursorPosition(const int line, const int column)
     {
-        QList<QVariant> arg = QList<QVariant>({line, column});
-        sendMessage("C_CMD_SET_CURSOR", QVariant(arg));
+        sendMessage("C_CMD_SET_CURSOR", QList<QVariant>{line, column});
     }
 
     void Editor::setCursorPosition(const QPair<int, int> &position)

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -141,7 +141,7 @@ namespace EditorNS
         if (msg.startsWith("[ASYNC_REPLY]")) {
             QRegExp rgx("\\[ID=(\\d+)\\]$");
 
-            if(rgx.indexIn(msg) == -1 || rgx.captureCount() != 1)
+            if (rgx.indexIn(msg) == -1 || rgx.captureCount() != 1)
                 return;
 
             unsigned int id = rgx.capturedTexts()[1].toInt();
@@ -160,15 +160,14 @@ namespace EditorNS
                 cb(data);
             }
 
-
-        } else if(msg == "J_EVT_READY") {
+        } else if (msg == "J_EVT_READY") {
             m_loaded = true;
             emit editorReady();
-        } else if(msg == "J_EVT_CONTENT_CHANGED")
+        } else if (msg == "J_EVT_CONTENT_CHANGED")
             emit contentChanged();
-        else if(msg == "J_EVT_CLEAN_CHANGED")
+        else if (msg == "J_EVT_CLEAN_CHANGED")
             emit cleanChanged(data.toBool());
-        else if(msg == "J_EVT_CURSOR_ACTIVITY")
+        else if (msg == "J_EVT_CURSOR_ACTIVITY")
             emit cursorActivity();
     }
 

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -371,8 +371,7 @@ namespace EditorNS
     {
         waitAsyncLoad();
 
-        QString funCall = "UiDriver.messageReceived('" +
-                jsStringEscape(msg) + "');";
+        auto funCall = QString("UiDriver.messageReceived('%1');").arg(jsStringEscape(msg));
 
         m_jsToCppProxy->setMsgData(data);
 
@@ -505,20 +504,19 @@ namespace EditorNS
 
     void Editor::setSelection(int fromLine, int fromCol, int toLine, int toCol)
     {
-        QList<QVariant> arg = QList<QVariant>({fromLine, fromCol, toLine, toCol});
+        QList<QVariant> arg{fromLine, fromCol, toLine, toCol};
         sendMessage("C_CMD_SET_SELECTION", QVariant(arg));
     }
 
     QPair<int, int> Editor::scrollPosition()
     {
-        QList<QVariant> scroll = asyncSendMessageWithResult("C_FUN_GET_SCROLL_POS").get().toList();
-        return QPair<int, int>(scroll[0].toInt(), scroll[1].toInt());
+        QVariantList scroll = asyncSendMessageWithResult("C_FUN_GET_SCROLL_POS").get().toList();
+        return {scroll[0].toInt(), scroll[1].toInt()};
     }
 
     void Editor::setScrollPosition(const int left, const int top)
     {
-        QList<QVariant> arg = QList<QVariant>({left, top});
-        sendMessage("C_CMD_SET_SCROLL_POS", QVariant(arg));
+        sendMessage("C_CMD_SET_SCROLL_POS", QVariantList{left, top});
     }
 
     void Editor::setScrollPosition(const QPair<int, int> &position)

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -295,10 +295,8 @@ namespace EditorNS
 
     void Editor::setIndentationMode(const bool useTabs, const int size)
     {
-        QMap<QString, QVariant> data;
-        data.insert("useTabs", useTabs);
-        data.insert("size", size);
-        sendMessage("C_CMD_SET_INDENTATION_MODE", data);
+        sendMessage("C_CMD_SET_INDENTATION_MODE",
+            QVariantMap{{"useTabs", useTabs}, {"size", size}});
     }
 
     Editor::IndentationMode Editor::indentationMode()

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -156,7 +156,7 @@ namespace EditorNS
             it->value->set_value(data);
             this->asyncReplies.erase(it);
 
-            if (cb != 0) {
+            if (cb != nullptr) {
                 cb(data);
             }
 

--- a/src/ui/include/EditorNS/editor.h
+++ b/src/ui/include/EditorNS/editor.h
@@ -167,10 +167,10 @@ namespace EditorNS
         Q_INVOKABLE bool fileOnDiskChanged() const;
         Q_INVOKABLE void setFileOnDiskChanged(bool fileOnDiskChanged);
 
-        enum selectMode {
-            selectMode_cursorBefore,
-            selectMode_cursorAfter,
-            selectMode_selected
+        enum class SelectMode {
+            Before,
+            After,
+            Selected
         };
 
         void insertBanner(QWidget *banner);
@@ -219,7 +219,7 @@ namespace EditorNS
         Q_INVOKABLE void setSmartIndent(bool enabled);
         Q_INVOKABLE qreal zoomFactor() const;
         Q_INVOKABLE void setZoomFactor(const qreal &factor);
-        Q_INVOKABLE void setSelectionsText(const QStringList &texts, selectMode mode);
+        Q_INVOKABLE void setSelectionsText(const QStringList &texts, SelectMode mode);
         Q_INVOKABLE void setSelectionsText(const QStringList &texts);
         const Language* getLanguage() { return m_currentLanguage; }
         Q_INVOKABLE void setLineWrap(const bool wrap);

--- a/src/ui/include/EditorNS/editor.h
+++ b/src/ui/include/EditorNS/editor.h
@@ -80,6 +80,10 @@ namespace EditorNS
         struct Theme {
             QString name;
             QString path;
+            Theme(const QString& name = "default", const QString& path = "") {
+                this->name = name;
+                this->path = path;
+            }
         };
 
         explicit Editor(const Theme &theme, QWidget *parent = 0);

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1779,7 +1779,7 @@ void MainWindow::transformSelectedText(std::function<QString (const QString &)> 
         sel.replace(i, func(sel.at(i)));
     }
 
-    editor->setSelectionsText(sel, Editor::selectMode_selected);
+    editor->setSelectionsText(sel, Editor::SelectMode::Selected);
 }
 
 void MainWindow::on_actionUPPERCASE_triggered()


### PR DESCRIPTION
This just updates some of the older code in editor to use C++11 constructs.  Also fixes a small regression from the LanguageService PR where frmpreferences doesn't select the correct highlighting mode for editor preview.