### PR TITLE
fix: Fix regex use in search panel. (fixes #644)

### DIFF
--- a/src/ui/Search/frmsearchreplace.cpp
+++ b/src/ui/Search/frmsearchreplace.cpp
@@ -123,7 +123,7 @@ QString frmSearchReplace::regexModifiersFromSearchOptions(SearchHelpers::SearchO
 
 void frmSearchReplace::search(QString string, SearchHelpers::SearchMode searchMode, bool forward, SearchHelpers::SearchOptions searchOptions) {
     if (!string.isEmpty()) {
-        QString rawSearch = SearchString::toRaw(string, searchMode, searchOptions);
+        QString rawSearch = SearchString::format(string, searchMode, searchOptions);
 
         Editor *editor = currentEditor();
 
@@ -141,7 +141,7 @@ void frmSearchReplace::search(QString string, SearchHelpers::SearchMode searchMo
 
 void frmSearchReplace::replace(QString string, QString replacement, SearchHelpers::SearchMode searchMode, bool forward, SearchHelpers::SearchOptions searchOptions) {
     if (!string.isEmpty()) {
-        QString rawSearch = SearchString::toRaw(string, searchMode, searchOptions);
+        QString rawSearch = SearchString::format(string, searchMode, searchOptions);
         if (searchMode == SearchHelpers::SearchMode::SpecialChars) {
             replacement = SearchString::unescape(replacement);
         }
@@ -163,7 +163,7 @@ void frmSearchReplace::replace(QString string, QString replacement, SearchHelper
 }
 
 int frmSearchReplace::replaceAll(QString string, QString replacement, SearchHelpers::SearchMode searchMode, SearchHelpers::SearchOptions searchOptions) {
-    QString rawSearch = SearchString::toRaw(string, searchMode, searchOptions);
+    QString rawSearch = SearchString::format(string, searchMode, searchOptions);
     if (searchMode == SearchHelpers::SearchMode::SpecialChars) {
             replacement = SearchString::unescape(replacement);
     }
@@ -178,7 +178,7 @@ int frmSearchReplace::replaceAll(QString string, QString replacement, SearchHelp
 }
 
 int frmSearchReplace::selectAll(QString string, SearchHelpers::SearchMode searchMode, SearchHelpers::SearchOptions searchOptions) {
-    QString rawSearch = SearchString::toRaw(string, searchMode, searchOptions);
+    QString rawSearch = SearchString::format(string, searchMode, searchOptions);
 
     QList<QVariant> data = QList<QVariant>();
     data.append(rawSearch);

--- a/src/ui/Search/searchstring.cpp
+++ b/src/ui/Search/searchstring.cpp
@@ -1,23 +1,22 @@
 #include "include/Search/searchstring.h"
 #include <QRegularExpression>
 
-QString SearchString::toRaw(const QString &data, const SearchHelpers::SearchMode &searchMode, const SearchHelpers::SearchOptions &searchOptions)
+QString SearchString::format(QString regex, SearchHelpers::SearchMode searchMode, const SearchHelpers::SearchOptions& searchOptions)
 {
-    QString rawSearch = toRegex(data, searchOptions.MatchWholeWord);
-
-    if (searchMode == SearchHelpers::SearchMode::SpecialChars) {
-        rawSearch = rawSearch.replace("\\\\", "\\");
+    // CodeMirror only knows regex search. So if user asks for "regular" search
+    // we'll have to escape all regex characters.
+    if (searchMode != SearchHelpers::SearchMode::Regex) {
+        regex = QRegularExpression::escape(regex);
     }
 
-    return rawSearch;
-}
-
-QString SearchString::toRegex(const QString &data, bool matchWholeWord)
-{
-    QString regex = QRegularExpression::escape(data);
-    if (matchWholeWord) {
+    if (searchOptions.MatchWholeWord) {
         regex = "\\b" + regex + "\\b";
     }
+
+    if (searchMode == SearchHelpers::SearchMode::SpecialChars) {
+        regex = regex.replace("\\\\", "\\");
+    }
+
     return regex;
 }
 

--- a/src/ui/include/Search/searchstring.h
+++ b/src/ui/include/Search/searchstring.h
@@ -1,25 +1,19 @@
-#ifndef __SEARCHSTRING_H__
-#define __SEARCHSTRING_H__
+#ifndef SEARCHSTRING_H
+#define SEARCHSTRING_H
 #include "include/Search/searchhelpers.h"
 #include <QString>
 
 class SearchString {
 public:
    /**
-    * @brief Build a raw version of `data` to be used for the search.
-    * @param `data`:          The string to be worked on.
-    * @param `searchMode`:    The search mode to be used.
-    * @param `searchOptions`: The search options to be used.
-    * @return `QString`:      Converted string based on `searchMode` and `searchOptions`
+    * @brief Formats a search string for use in CodeMirror.
+    * @param regex          The string to be worked on, either regex or not.
+    * @param searchMode     If mode==regex, will return an escaped string
+    * @param searchOptions  Handles wholeWord search option
+    * @return QString       A regex string
     */
-    static QString toRaw(const QString &data, const SearchHelpers::SearchMode &searchMode, const SearchHelpers::SearchOptions &searchOptions);
-   /**
-    * @brief Convert string to its regex counterpart.
-    * @param `data`:           The string to be worked on.
-    * @param `matchWholeWord`: Whether to add boundary checks to converted string.
-    * @return `QString`:       String converted for use in regex operations.
-    */
-    static QString toRegex(const QString &data, bool matchWholeWord);
+    static QString format(QString regex, SearchHelpers::SearchMode searchMode, const SearchHelpers::SearchOptions &searchOptions);
+
    /**
     * @brief Unescape escape sequences in `data`
     * @param `data`:     The string to be worked on.
@@ -28,4 +22,4 @@ public:
     static QString unescape(const QString &data);
 };
 
-#endif //__SEARCHSTRING_H_
+#endif // SEARCHSTRING_H


### PR DESCRIPTION
Simple regex search must have gotten borked at some point- perhaps when adding AdvSearchDock. Basically the search string will always be escaped which leads to regex characters *never* working.

This PR fixes that and also simplifies the formatting logic and refactors a tiny bit of code.