### PR TITLE
fix: Wayland icon not showing properly.

### DIFF
--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
     QCoreApplication::setApplicationName("Notepadqq");
     QCoreApplication::setApplicationVersion(Notepadqq::version);
 
-#if QT_VERSION > QT_VERSION_CHECK(5, 7, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
     QGuiApplication::setDesktopFileName("notepadqq");
 #endif
 

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -50,6 +50,10 @@ int main(int argc, char *argv[])
     QCoreApplication::setApplicationName("Notepadqq");
     QCoreApplication::setApplicationVersion(Notepadqq::version);
 
+#if QT_VERSION > QT_VERSION_CHECK(5, 7, 0)
+    QGuiApplication::setDesktopFileName("notepadqq");
+#endif
+
     QSettings::setDefaultFormat(QSettings::IniFormat);
 
 


### PR DESCRIPTION
This "should" fix #515.  I'll need somebody to test this change to ensure it actually works.  KDE Plasma Wayland runs in a very grotesque manner on my computer due to Nvidia blob driver issues.