### PR TITLE
fix: Remove white flash when opening new tab

### DIFF
--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -53,6 +53,7 @@ namespace EditorNS
         m_webView->page()->setWebChannel(channel);
         channel->registerObject(QStringLiteral("cpp_ui_driver"), m_jsToCppProxy);
 
+        m_webView->page()->setBackgroundColor(qApp->palette().color(QPalette::Background));
         m_webView->setUrl(url);
 
         // To load the page in the background (http://stackoverflow.com/a/10520029):


### PR DESCRIPTION
During page load the page just shows a white canvas which is very unpleasing to the eye. It's better to use the current color palette's background color. 

Even better would be to query the current theme's background color but we don't have an easy way of doing that.