### PR TITLE
feat: Checks API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 language: cpp
 sudo: false
 
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: NQQ_BUILD_TYPE=FORMAT
+jobs:
   include:
-    - os: linux
+    - stage: format
       env: NQQ_BUILD_TYPE=FORMAT
       addons:
         apt:
@@ -15,7 +12,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - clang-format-6.0
-    - os: linux
+    - stage: compile
       env: NQQ_BUILD_TYPE=COMPILE
       sudo: true
       services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ language: cpp
 sudo: false
 
 jobs:
+  allow_failures:
+    - env: NQQ_BUILD_TYPE=FORMAT
   include:
-    - stage: format
+    - stage: build
       env: NQQ_BUILD_TYPE=FORMAT
       addons:
         apt:
@@ -12,7 +14,7 @@ jobs:
             - ubuntu-toolchain-r-test
           packages:
             - clang-format-6.0
-    - stage: compile
+    - stage: build
       env: NQQ_BUILD_TYPE=COMPILE
       sudo: true
       services:


### PR DESCRIPTION
This enables Checks API integration on Github.  This will allow you to click on the "Checks" tab to view whether the formatting job failed or not without having to look deep in Travis itself.

This is closer to what we were looking for in the first place.