### PR TITLE
refac: Modernize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
-MAINTAINER Notepadqq
+LABEL maintainer="Notepadqq"
 
-RUN apt-get -qq update && apt-get -y install \
+RUN apt-get -qq update && apt-get --no-install-recommends -y install \
     build-essential \
     clang-format-6.0 \
     coreutils \


### PR DESCRIPTION
This adds --no-install-recommends to apt as well as uses the proper maintainer "LABEL maintainer=" format.

All in all this results in 151 less packages being pulled for the build, which improves build time enough that it's a significant change.  I've posted a screenshot below for compared results to before/after:

![20180513-194628](https://user-images.githubusercontent.com/2869605/39973540-8e6ac268-56e6-11e8-935d-ba0c25dd72ed.png)

Over the course of the next few weeks I'm going back to focusing on code quality changes.  I've setup CodeFactor on my github repository to help guide things along so I can make sound modifications which should improve readability of code and make future changes easier.