### PR TITLE
Add a '*' behind the file name displayed in the titlebar for dirty files

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1415,8 +1415,9 @@ void MainWindow::refreshEditorUiInfo(Editor *editor)
                                            QUrl::StripTrailingSlash
                                            );
 
-        newTitle = QString("%1 (%2) - %3")
+        newTitle = QString("%1%2 (%3) - %5")
                    .arg(Notepadqq::fileNameFromUrl(editor->filePath()))
+                   .arg(editor->isClean() ? "" : "*")
                    .arg(path)
                    .arg(QApplication::applicationName());
 

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1416,11 +1416,10 @@ void MainWindow::refreshEditorUiInfo(Editor *editor)
                                            );
 
         newTitle = QString("%1%2 (%3) - %5")
-                   .arg(Notepadqq::fileNameFromUrl(editor->filePath()))
-                   .arg(editor->isClean() ? "" : "*")
-                   .arg(path)
-                   .arg(QApplication::applicationName());
-
+                       .arg(Notepadqq::fileNameFromUrl(editor->filePath()))
+                       .arg(editor->isClean() ? "" : "*")
+                       .arg(path)
+                       .arg(QApplication::applicationName());
     }
 
     if (newTitle != windowTitle()) {


### PR DESCRIPTION
As title says. Will show `somefile.txt* (/path/to/file) - Notepadqq` as the title if `somefile.txt` is modified. Won't show the `*` for `new X` files since that doesn't really make sense.