### PR TITLE
refac: Allow the status bar to show tooltip messages.

### DIFF
--- a/src/editor/app.js
+++ b/src/editor/app.js
@@ -667,6 +667,17 @@ UiDriver.registerEventHandler("C_CMD_EOL_TO_SPACE", function(msg, data, prevRetu
     editor.setValue(text.replace(/\n/gm," "));
 });
 
+function getActivityInfo()
+{
+    var map = new Object();
+    var selections = editor.getSelection("\n");
+    var cursor = editor.getCursor("head");
+    map["cursor"] = [cursor.line, cursor.ch];
+    map["selections"] = [selections.split(/\r\n|\r|\n/).length, selections.length];
+    map["content"] = [editor.lineCount(), editor.getValue().length];
+    return map;
+}
+
 $(document).ready(function () {
     editor = CodeMirror($(".editor")[0], {
         lineNumbers: true,
@@ -712,12 +723,17 @@ $(document).ready(function () {
         UiDriver.sendMessage("J_EVT_CLEAN_CHANGED", isCleanOrForced(changeGeneration));
     });
 
-    editor.on("cursorActivity", function(instance, changeObj) {
-        UiDriver.sendMessage("J_EVT_CURSOR_ACTIVITY");
+    editor.on("cursorActivity", function(instance) {
+        UiDriver.sendMessage("J_EVT_CURSOR_ACTIVITY", getActivityInfo());
     });
 
     editor.on("focus", function() {
         UiDriver.sendMessage("J_EVT_GOT_FOCUS");
+        UiDriver.sendMessage("J_EVT_CURSOR_ACTIVITY", getActivityInfo());
+    });
+
+    $(document).mouseenter(function() {
+        UiDriver.sendMessage("J_EVT_CURSOR_ACTIVITY", getActivityInfo());
     });
 
     UiDriver.sendMessage("J_EVT_READY", null);

--- a/src/editor/app.js
+++ b/src/editor/app.js
@@ -667,7 +667,7 @@ UiDriver.registerEventHandler("C_CMD_EOL_TO_SPACE", function(msg, data, prevRetu
     editor.setValue(text.replace(/\n/gm," "));
 });
 
-function getActivityInfo()
+function getDocumentInfo()
 {
     var map = new Object();
     var selections = editor.getSelection("\n");
@@ -677,6 +677,13 @@ function getActivityInfo()
     map["content"] = [editor.lineCount(), editor.getValue().length];
     return map;
 }
+
+/**
+* @brief Replies to the request for document information. 
+*/
+UiDriver.registerEventHandler("C_CMD_GET_DOCUMENT_INFO", function(msg, data, prevReturn) {
+    UiDriver.sendMessage("J_EVT_DOCUMENT_INFO", getDocumentInfo());
+});
 
 $(document).ready(function () {
     editor = CodeMirror($(".editor")[0], {
@@ -724,16 +731,11 @@ $(document).ready(function () {
     });
 
     editor.on("cursorActivity", function(instance) {
-        UiDriver.sendMessage("J_EVT_CURSOR_ACTIVITY", getActivityInfo());
+        UiDriver.sendMessage("J_EVT_CURSOR_ACTIVITY", getDocumentInfo());
     });
 
     editor.on("focus", function() {
         UiDriver.sendMessage("J_EVT_GOT_FOCUS");
-        UiDriver.sendMessage("J_EVT_CURSOR_ACTIVITY", getActivityInfo());
-    });
-
-    $(document).mouseenter(function() {
-        UiDriver.sendMessage("J_EVT_CURSOR_ACTIVITY", getActivityInfo());
     });
 
     UiDriver.sendMessage("J_EVT_READY", null);

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -176,8 +176,9 @@ namespace EditorNS
                 emit contentChanged();
             else if(msg == "J_EVT_CLEAN_CHANGED")
                 emit cleanChanged(data.toBool());
-            else if(msg == "J_EVT_CURSOR_ACTIVITY")
-                emit cursorActivity();
+            else if(msg == "J_EVT_CURSOR_ACTIVITY") {
+                emit cursorActivity(data.toMap());
+            }
 
         });
     }

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -176,7 +176,7 @@ namespace EditorNS
                 emit contentChanged();
             else if(msg == "J_EVT_CLEAN_CHANGED")
                 emit cleanChanged(data.toBool());
-            else if(msg == "J_EVT_CURSOR_ACTIVITY") {
+            else if (msg == "J_EVT_CURSOR_ACTIVITY") {
                 emit cursorActivity(data.toMap());
             }
 

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -178,8 +178,9 @@ namespace EditorNS
                 emit cleanChanged(data.toBool());
             else if (msg == "J_EVT_CURSOR_ACTIVITY") {
                 emit cursorActivity(data.toMap());
+            } else if (msg == "J_EVT_DOCUMENT_INFO") {
+                emit documentInfoRequested(data.toMap());
             }
-
         });
     }
 
@@ -590,6 +591,11 @@ namespace EditorNS
              return QPair<int, int>(cursor[0].toInt(), cursor[1].toInt());
         });
 
+    }
+
+    void Editor::requestDocumentInfo()
+    {
+        asyncSendMessageWithResultP("C_CMD_GET_DOCUMENT_INFO");
     }
 
     QPair<int, int> Editor::cursorPosition()

--- a/src/ui/include/EditorNS/editor.h
+++ b/src/ui/include/EditorNS/editor.h
@@ -238,6 +238,12 @@ namespace EditorNS
         void setCursorPosition(const Cursor &cursor);
 
         /**
+         * @brief Tells the editor that mainwindow needs an update on the contents,
+         *        selection, and cursor position of the current document
+         */
+        void requestDocumentInfo();
+
+        /**
          * @brief Get the current scroll position
          * @return a <left, top> pair.
          */
@@ -352,6 +358,7 @@ namespace EditorNS
         // Pre-interpreted messages:
         void contentChanged();
         void cursorActivity(QMap<QString, QVariant> data);
+        void documentInfoRequested(QMap<QString, QVariant> data);
         void cleanChanged(bool isClean);
         void fileNameChanged(const QUrl &oldFileName, const QUrl &newFileName);
 

--- a/src/ui/include/EditorNS/editor.h
+++ b/src/ui/include/EditorNS/editor.h
@@ -351,7 +351,7 @@ namespace EditorNS
 
         // Pre-interpreted messages:
         void contentChanged();
-        void cursorActivity();
+        void cursorActivity(QMap<QString, QVariant> data);
         void cleanChanged(bool isClean);
         void fileNameChanged(const QUrl &oldFileName, const QUrl &newFileName);
 

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -80,6 +80,7 @@ public:
     void generateRunMenu();
 public slots:
     void refreshEditorUiInfo(Editor *editor);
+    void refreshEditorUiCursorInfo(QMap<QString, QVariant> data);
 
 protected:
     void closeEvent(QCloseEvent *event);
@@ -205,10 +206,10 @@ private:
     DocEngine*            m_docEngine;
     QMenu*                m_tabContextMenu;
     QList<QAction *>      m_tabContextMenuActions;
-    QLabel*               m_statusBar_fileFormat;
-    QLabel*               m_statusBar_EOLstyle;
-    QLabel*               m_statusBar_textFormat;
-    QLabel*               m_statusBar_overtypeNotify;
+    QPushButton*          m_sbFileFormatBtn;
+    QPushButton*          m_sbEOLFormatBtn;
+    QPushButton*          m_sbTextFormatBtn;
+    QPushButton*          m_sbOvertypeBtn;
     NqqSettings&          m_settings;
     frmSearchReplace*     m_frmSearchReplace = 0;
     bool                  m_overwrite = false; // Overwrite mode vs Insert mode

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -91,7 +91,6 @@ protected:
 private slots:
     void runCommand();
     void modifyRunCommands();
-    void refreshEditorUiCursorInfo(Editor *editor);
     void searchDockItemInteracted(const DocResult& doc, const MatchResult* result, SearchUserInteraction type);
     void on_actionNew_triggered();
     void on_customTabContextMenuRequested(QPoint point, EditorTabWidget *tabWidget, int tabIndex);
@@ -107,7 +106,7 @@ private slots:
     void on_actionCut_triggered();
     void on_currentEditorChanged(EditorTabWidget* tabWidget, int tab);
     void on_editorAdded(EditorTabWidget* tabWidget, int tab);
-    void on_cursorActivity();
+    void on_cursorActivity(QMap<QString, QVariant> data);
     void on_actionDelete_triggered();
     void on_actionSelect_All_triggered();
     void on_actionAbout_Notepadqq_triggered();
@@ -207,9 +206,6 @@ private:
     QMenu*                m_tabContextMenu;
     QList<QAction *>      m_tabContextMenuActions;
     QLabel*               m_statusBar_fileFormat;
-    QLabel*               m_statusBar_length_lines;
-    QLabel*               m_statusBar_curPos;
-    QLabel*               m_statusBar_selection;
     QLabel*               m_statusBar_EOLstyle;
     QLabel*               m_statusBar_textFormat;
     QLabel*               m_statusBar_overtypeNotify;

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -206,10 +206,10 @@ private:
     DocEngine*            m_docEngine;
     QMenu*                m_tabContextMenu;
     QList<QAction *>      m_tabContextMenuActions;
-    QPushButton*          m_sbFileFormatBtn;
-    QPushButton*          m_sbEOLFormatBtn;
-    QPushButton*          m_sbTextFormatBtn;
-    QPushButton*          m_sbOvertypeBtn;
+    QPushButton* m_sbFileFormatBtn;
+    QPushButton* m_sbEOLFormatBtn;
+    QPushButton* m_sbTextFormatBtn;
+    QPushButton* m_sbOvertypeBtn;
     NqqSettings&          m_settings;
     frmSearchReplace*     m_frmSearchReplace = 0;
     bool                  m_overwrite = false; // Overwrite mode vs Insert mode

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -234,7 +234,6 @@ private:
      */
     bool                finalizeAllTabs();
 
-    void                createStatusBar();
     int                 askIfWantToSave(EditorTabWidget *tabWidget, int tab, int reason);
 
     /**
@@ -296,6 +295,7 @@ private:
      * @brief Initialize UI from settings
      */
     void configureUserInterface();
+    void configureStatusBar();
 
     /**
      * @brief Update symbol options using parameter `on` and Show_All_Characters toggle status.

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -206,6 +206,7 @@ private:
     DocEngine*            m_docEngine;
     QMenu*                m_tabContextMenu;
     QList<QAction *>      m_tabContextMenuActions;
+    QLabel* m_sbDocumentInfoLabel;
     QPushButton* m_sbFileFormatBtn;
     QPushButton* m_sbEOLFormatBtn;
     QPushButton* m_sbTextFormatBtn;

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -323,19 +323,23 @@ void MainWindow::loadIcons()
 
 void MainWindow::createStatusBar()
 {
+    m_sbDocumentInfoLabel = new QLabel;
+    m_sbDocumentInfoLabel->setMinimumWidth(1);
+    statusBar()->addWidget(m_sbDocumentInfoLabel);
     auto createStatusButton = [&](const QString& txt, int minWidth, QMenu* mnu = nullptr) {
         auto* btn = new QPushButton(txt);
         btn->setFlat(true);
         btn->setMenu(mnu);
         btn->setMinimumWidth(minWidth);
-        btn->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
+        btn->setMaximumWidth(minWidth);
+        btn->setFocusPolicy(Qt::NoFocus);
         statusBar()->addPermanentWidget(btn);
         return btn;
     };
-    m_sbFileFormatBtn = createStatusButton("File Format", 110, ui->menu_Language);
-    m_sbEOLFormatBtn = createStatusButton("EOL", 84, ui->menuEOL_Conversion);
-    m_sbTextFormatBtn = createStatusButton("Encoding", 110, ui->menu_Encoding);
-    m_sbOvertypeBtn = createStatusButton("INS", 36);
+    m_sbFileFormatBtn = createStatusButton("File Format", 120, ui->menu_Language);
+    m_sbEOLFormatBtn = createStatusButton("EOL", 92, ui->menuEOL_Conversion);
+    m_sbTextFormatBtn = createStatusButton("Encoding", 120, ui->menu_Encoding);
+    m_sbOvertypeBtn = createStatusButton("INS", 40);
     connect(m_sbOvertypeBtn, &QPushButton::clicked, this, &MainWindow::toggleOverwrite);
 }
 
@@ -1208,7 +1212,7 @@ void MainWindow::refreshEditorUiCursorInfo(QMap<QString, QVariant> data)
     QString msg = tr("Ln %1, Col %2").arg(curData[0].toInt() + 1).arg(curData[1].toInt() + 1);
     msg += tr("    Sel %1 (%2)").arg(selData[1].toInt()).arg(selData[0].toInt());
     msg += tr("    %1 chars, %2 lines").arg(conData[1].toInt()).arg(conData[0].toInt());
-    statusBar()->showMessage(msg);
+    m_sbDocumentInfoLabel->setText(msg);
 }
 
 void MainWindow::on_currentLanguageChanged(QString /*id*/, QString /*name*/)

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1289,7 +1289,6 @@ void MainWindow::refreshEditorUiInfo(Editor *editor)
     QString name = editor->getLanguage()->name;
     m_sbFileFormatBtn->setText(name);
 
-
     // Update MainWindow title
     QString newTitle;
     if (editor->filePath().isEmpty()) {

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -110,7 +110,7 @@ MainWindow::MainWindow(const QString &workingDirectory, const QStringList &argum
     connect(m_topEditorContainer, &TopEditorContainer::tabBarDoubleClicked,
             this, &MainWindow::on_tabBarDoubleClicked);
 
-    createStatusBar();
+    configureStatusBar();
 
     updateRecentDocsInMenu();
 
@@ -321,7 +321,7 @@ void MainWindow::loadIcons()
     ui->actionSave_Currently_Recorded_Macro->setIcon(IconProvider::fromTheme("document-save-as"));
 }
 
-void MainWindow::createStatusBar()
+void MainWindow::configureStatusBar()
 {
     m_sbDocumentInfoLabel = new QLabel;
     m_sbDocumentInfoLabel->setMinimumWidth(1);

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -330,8 +330,6 @@ void MainWindow::createStatusBar()
         auto* btn = new QPushButton(txt);
         btn->setFlat(true);
         btn->setMenu(mnu);
-        btn->setMinimumWidth(minWidth);
-        btn->setMaximumWidth(minWidth);
         btn->setFocusPolicy(Qt::NoFocus);
         statusBar()->addPermanentWidget(btn);
         return btn;

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1207,7 +1207,7 @@ void MainWindow::on_cursorActivity(QMap<QString, QVariant> data)
         auto curData = data["cursor"].toList();
         auto selData = data["selections"].toList();
         auto conData = data["content"].toList();
-        QString msg = tr("Ln %1, Col %2").arg(curData[0].toInt()).arg(curData[1].toInt());
+        QString msg = tr("Ln %1, Col %2").arg(curData[0].toInt() + 1).arg(curData[1].toInt() + 1);
         msg += tr("    Sel %1 (%2)").arg(selData[1].toInt()).arg(selData[0].toInt());
         msg += tr("    %1 chars, %2 lines").arg(conData[1].toInt()).arg(conData[0].toInt());
         statusBar()->showMessage(msg);

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -326,7 +326,6 @@ void MainWindow::createStatusBar()
     auto createStatusLabel = [&](const QString& txt, int minWidth, bool clickable = false, bool right = false) {
         QLabel* label = clickable ? new ClickableLabel(txt) : new QLabel(txt);
         QMargins marginFix = label->contentsMargins();
-//        marginFix.setRight(marginFix.right() + 10);
         label->setContentsMargins(marginFix);
         if (right) {
             statusBar()->addPermanentWidget(label);
@@ -342,10 +341,10 @@ void MainWindow::createStatusBar()
     m_statusBar_EOLstyle = createStatusLabel("EOL", 84, false, true);
     m_statusBar_textFormat = createStatusLabel("Encoding", 110, true, true);
     m_statusBar_overtypeNotify = createStatusLabel("INS", 32, false, true);
-    connect(dynamic_cast<ClickableLabel*>(m_statusBar_fileFormat), &ClickableLabel::clicked, [this](){
+    connect(dynamic_cast<ClickableLabel*>(m_statusBar_fileFormat), &ClickableLabel::clicked, [this]() {
         ui->menu_Language->exec( QCursor::pos() );
     });
-    connect(dynamic_cast<ClickableLabel*>(m_statusBar_textFormat), &ClickableLabel::clicked, [this](){
+    connect(dynamic_cast<ClickableLabel*>(m_statusBar_textFormat), &ClickableLabel::clicked, [this]() {
         ui->menu_Encoding->exec(QCursor::pos());
     });
 }

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -323,29 +323,34 @@ void MainWindow::loadIcons()
 
 void MainWindow::createStatusBar()
 {
-    auto createStatusLabel = [&](const QString& txt, int minWidth, bool clickable = false, bool right = false) {
-        QLabel* label = clickable ? new ClickableLabel(txt) : new QLabel(txt);
+    auto createStatusLabel = [&](const QString& txt, int minWidth) {
+        QLabel* label = new ClickableLabel(txt);
         QMargins marginFix = label->contentsMargins();
         label->setContentsMargins(marginFix);
-        if (right) {
-            statusBar()->addPermanentWidget(label);
-        } else {
-            statusBar()->addWidget(label);
-        }
         label->setMinimumWidth(minWidth);
         label->setFrameStyle(QFrame::StyledPanel /*| QFrame::Sunken*/);
         label->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
+        statusBar()->addPermanentWidget(label);
         return label;
     };
-    m_statusBar_fileFormat = createStatusLabel("File Format", 110, true, true);
-    m_statusBar_EOLstyle = createStatusLabel("EOL", 84, false, true);
-    m_statusBar_textFormat = createStatusLabel("Encoding", 110, true, true);
-    m_statusBar_overtypeNotify = createStatusLabel("INS", 32, false, true);
+    m_statusBar_fileFormat = createStatusLabel("File Format", 110);
+    m_statusBar_EOLstyle = createStatusLabel("EOL", 84);
+    m_statusBar_textFormat = createStatusLabel("Encoding", 110);
+    m_statusBar_overtypeNotify = createStatusLabel("INS", 36);
     connect(dynamic_cast<ClickableLabel*>(m_statusBar_fileFormat), &ClickableLabel::clicked, [this]() {
         ui->menu_Language->exec( QCursor::pos() );
     });
+
+    connect(dynamic_cast<ClickableLabel*>(m_statusBar_EOLstyle), &ClickableLabel::clicked, [this]() {
+        ui->menuEOL_Conversion->exec(QCursor::pos());
+    });
+
     connect(dynamic_cast<ClickableLabel*>(m_statusBar_textFormat), &ClickableLabel::clicked, [this]() {
         ui->menu_Encoding->exec(QCursor::pos());
+    });
+
+    connect(dynamic_cast<ClickableLabel*>(m_statusBar_overtypeNotify), &ClickableLabel::clicked, [this]() {
+        toggleOverwrite();
     });
 }
 


### PR DESCRIPTION
This change modifies how the status bar currently operates.  As it stands we were using quite a few hacky methods to get the status bar to display properly.

I've made some slight modifications which cleans up a lot of the status bar code and allows some of its UI elements to be updated via signals/slots instead of a request.  Namely content, selections, and current char/line.

In order for this to work properly I had to move the current language status label to the right side, which isn't necessarily a huge change but could take a little getting used to.  This will enable us to add status tips to all of our actions which display when you hover over one of them.

Here's how it looks now:
![20180520-012629](https://user-images.githubusercontent.com/2869605/40276333-fd8b7e90-5bcc-11e8-863b-178fcf850031.png)
