### PR TITLE
refac: Add clang-formatted files to commit before completion.

### DIFF
--- a/build-tools/githooks/pre-commit
+++ b/build-tools/githooks/pre-commit
@@ -1,10 +1,13 @@
 #!/bin/sh
 
-# Run the format
+# Perform git clang-format on the necessary files
 echo "========== Formatting =========="
 git clang-format --style file --extensions 'cpp,h'
 echo "============= Done ============="
 
+# Only add the files that have been previously staged for commit
 echo "==== Adding files to commit ===="
-git add -v -u
+for f in $(git commit --short | awk '/^[AM]/{print $2}');do
+    git add -v "$f"
+done
 echo "============= Done ============="

--- a/build-tools/githooks/pre-commit
+++ b/build-tools/githooks/pre-commit
@@ -1,5 +1,10 @@
 #!/bin/sh
 
-echo -n "Formatting..."
+# Run the format
+echo "========== Formatting =========="
 git clang-format --style file --extensions 'cpp,h'
-echo "Done."
+echo "============= Done ============="
+
+echo "==== Adding files to commit ===="
+git add -v -u
+echo "============= Done ============="


### PR DESCRIPTION
Changes a bit of the output of the git hook and automatically adds the changed files to the commit tree prior to commit.  This will prevent having to commit twice when this hook is being used.  It also only adds files that already have staged changes so we don't accidentally pull anything extra in.