### PR TITLE
use loop to only add the first existing Qt path

### DIFF
--- a/support_files/launch/notepadqq
+++ b/support_files/launch/notepadqq
@@ -1,31 +1,23 @@
 #!/bin/sh
 SCRIPTPATH="$(dirname "$(readlink -f "$0")")"
 
-if [ `getconf LONG_BIT` = "64" ]
-then
+if [ "$(getconf LONG_BIT)" = "64" ]; then
     GCC_DIR=gcc_64
 else
     GCC_DIR=gcc
 fi
 
-OPT_QT510=/opt/Qt/5.10/$GCC_DIR/lib
-OPT_QT59=/opt/Qt/5.9/$GCC_DIR/lib
-OPT_QT58=/opt/Qt/5.8/$GCC_DIR/lib
-OPT_QT57=/opt/Qt/5.7/$GCC_DIR/lib
-OPT_QT56=/opt/Qt/5.6/$GCC_DIR/lib
-OPT_QT55=/opt/Qt/5.5/$GCC_DIR/lib
-OPT_QT54=/opt/Qt/5.4/$GCC_DIR/lib
-OPT_QT53=/opt/Qt/5.3/$GCC_DIR/lib
-PERSONAL_QT510=~/Qt/5.10/$GCC_DIR/lib
-PERSONAL_QT59=~/Qt/5.9/$GCC_DIR/lib
-PERSONAL_QT58=~/Qt/5.8/$GCC_DIR/lib
-PERSONAL_QT57=~/Qt/5.7/$GCC_DIR/lib
-PERSONAL_QT56=~/Qt/5.6/$GCC_DIR/lib
-PERSONAL_QT55=~/Qt/5.5/$GCC_DIR/lib
-PERSONAL_QT54=~/Qt/5.4/$GCC_DIR/lib
-PERSONAL_QT53=~/Qt/5.3/$GCC_DIR/lib
-
-export LD_LIBRARY_PATH="$OPT_QT510:$PERSONAL_QT510:$OPT_QT59:$PERSONAL_QT59:$OPT_QT58:$PERSONAL_QT58:$OPT_QT57:$PERSONAL_QT57:$OPT_QT56:$PERSONAL_QT56:$OPT_QT55:$PERSONAL_QT55:$OPT_QT54:$PERSONAL_QT54:$OPT_QT53:$PERSONAL_QT53:${LD_LIBRARY_PATH}"
+for VER in 10.1 10 9 8 7 6 5 4 3; do
+    opt_path="/opt/Qt/5.$VER/$GCC_DIR/lib"
+    personal_path="$HOME/Qt/5.$VER/$GCC_DIR/lib"
+    if [ -e "$opt_path" ]; then
+        export LD_LIBRARY_PATH="${opt_path}:${LD_LIBRARY_PATH}"
+        break
+    elif [ -e "$personal_path" ]; then
+        export LD_LIBRARY_PATH="${personal_path}:${LD_LIBRARY_PATH}"
+        break
+    fi
+done
 
 # In Ubuntu Unity, appmenu-qt5 will try to hide our menubar in order to show it as a global bar. 
 # This may sometimes fail and leave us with no menu bar. So we'll prevent appmenu-qt5 for doing this.


### PR DESCRIPTION
No point to add multiple Qt paths. Added support for 5.10.1.
I didn't add 5.11 because of https://github.com/notepadqq/notepadqq/issues/699
