### PR TITLE
Fix crash on Mac after launching #702

### DIFF
--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -239,7 +239,7 @@ namespace EditorNS
     bool Editor::isClean()
     {
         QVariant data(0);
-        return asyncSendMessageWithResult("C_FUN_IS_CLEAN",data).get().toBool();
+        return asyncSendMessageWithResult("C_FUN_IS_CLEAN", data).get().toBool();
     }
 
     QPromise<void> Editor::markClean()

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -238,7 +238,7 @@ namespace EditorNS
 
     bool Editor::isClean()
     {
-        QVariant data(0); // avoid crash on Mac OS X
+        QVariant data(0); // avoid crash on Mac OS X, see issue #702
         return asyncSendMessageWithResult("C_FUN_IS_CLEAN", data).get().toBool();
     }
 

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -238,7 +238,7 @@ namespace EditorNS
 
     bool Editor::isClean()
     {
-        QVariant data(0);
+        QVariant data(0); // avoid crash on Mac OS X
         return asyncSendMessageWithResult("C_FUN_IS_CLEAN", data).get().toBool();
     }
 

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -238,7 +238,8 @@ namespace EditorNS
 
     bool Editor::isClean()
     {
-        return asyncSendMessageWithResult("C_FUN_IS_CLEAN", QVariant(0)).get().toBool();
+        QVariant data(0);
+        return asyncSendMessageWithResult("C_FUN_IS_CLEAN",data).get().toBool();
     }
 
     QPromise<void> Editor::markClean()


### PR DESCRIPTION
This fix has low risk, just fix the crash bug on Mac( which I have already open a bug #702).
Now it works well on Mac.
However I see some other crash related to preference dialog, which I may submit a new fix later.