### PR TITLE
fix: Don't ask for permission to open larger files when restoring a session

### DIFF
--- a/src/ui/Sessions/sessions.cpp
+++ b/src/ui/Sessions/sessions.cpp
@@ -394,11 +394,12 @@ void loadSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
                 continue;
 
             docEngine->getDocumentLoader()
-                     .setUrl(loadUrl)
-                     .setTabWidget(tabW)
-                     .setRememberLastDir(false)
-                     .execute()
-                     .wait(); // FIXME Transform to async
+                .setUrl(loadUrl)
+                .setTabWidget(tabW)
+                .setRememberLastDir(false)
+                .setFileSizeWarning(DocEngine::FileSizeActionYesToAll)
+                .execute()
+                .wait(); // FIXME Transform to async
 
             int idx = tabW->findOpenEditorByUrl(loadUrl);
 


### PR DESCRIPTION
User already acknowledged this when opening the first initially. And this can show up when starting Nqq, making it pretty annoying.