### PR TITLE
fix: Discard file path when performing language detection based on file names (fixes #694)

### DIFF
--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -286,23 +286,25 @@ namespace EditorNS
         }
     }
 
-    void Editor::setLanguageFromFileName(const QString& fileName)
+    void Editor::setLanguageFromFilePath(const QString& filePath)
     {
+        auto name = QFileInfo(filePath).fileName();
+
         auto& cache = LanguageService::getInstance();
-        auto lang = cache.lookupByFileName(fileName);
+        auto lang = cache.lookupByFileName(name);
         if (lang != nullptr) {
             setLanguage(lang);
             return;
         }
-        lang = cache.lookupByExtension(fileName);
+        lang = cache.lookupByExtension(name);
         if (lang != nullptr) {
             setLanguage(lang);
         }
     }
 
-    void Editor::setLanguageFromFileName()
+    void Editor::setLanguageFromFilePath()
     {
-        setLanguageFromFileName(filePath().toString());
+        setLanguageFromFilePath(filePath().toString());
     }
 
     QPromise<void> Editor::setIndentationMode(const Language* lang)

--- a/src/ui/Sessions/sessions.cpp
+++ b/src/ui/Sessions/sessions.cpp
@@ -411,7 +411,7 @@ void loadSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
 
             if (cacheFileExists) {
                 editor->markDirty();
-                editor->setLanguageFromFileName();
+                editor->setLanguageFromFilePath();
                 // Since we loaded from cache we want to unmonitor the cache file.
                 docEngine->unmonitorDocument(editor);
             }

--- a/src/ui/docengine.cpp
+++ b/src/ui/docengine.cpp
@@ -295,7 +295,7 @@ QPromise<void> DocEngine::loadDocuments(const DocEngine::DocumentLoader& docLoad
         } else {
             editor->setFilePath(url);
             tabWidget->setTabToolTip(tabIndex, fi.absoluteFilePath());
-            editor->setLanguageFromFileName();
+            editor->setLanguageFromFilePath();
         }
 
         monitorDocument(editor);
@@ -720,7 +720,7 @@ int DocEngine::saveDocument(EditorTabWidget *tabWidget, int tab, QUrl outFileNam
         if (!copy) {
             if (editor->filePath() != outFileName) {
                 editor->setFilePath(outFileName);
-                editor->setLanguageFromFileName();
+                editor->setLanguageFromFilePath();
             }
             editor->markClean();
             editor->setFileOnDiskChanged(false);

--- a/src/ui/frmpreferences.cpp
+++ b/src/ui/frmpreferences.cpp
@@ -29,7 +29,7 @@ frmPreferences::frmPreferences(TopEditorContainer *topEditorContainer, QWidget *
     //setWindowFlags((windowFlags() | Qt::CustomizeWindowHint) & ~Qt::WindowMaximizeButtonHint);
 
     m_previewEditor = Editor::getNewEditorUnmanagedPtr(this);
-    m_previewEditor->setLanguageFromFileName("test.js");
+    m_previewEditor->setLanguageFromFilePath("test.js");
     m_previewEditor->setValue(R"(var enabled = false;)" "\n"
                               R"()" "\n"
                               R"(function example(a, b) {)" "\n"

--- a/src/ui/include/EditorNS/editor.h
+++ b/src/ui/include/EditorNS/editor.h
@@ -196,8 +196,8 @@ namespace EditorNS
          */
         Q_INVOKABLE void setLanguage(const Language* language);
         Q_INVOKABLE void setLanguage(const QString &language);
-        Q_INVOKABLE void setLanguageFromFileName(const QString& fileName);
-        Q_INVOKABLE void setLanguageFromFileName();
+        Q_INVOKABLE void setLanguageFromFilePath(const QString& filePath);
+        Q_INVOKABLE void setLanguageFromFilePath();
         Q_INVOKABLE QPromise<void> setValue(const QString &value);
         Q_INVOKABLE QString value();
 


### PR DESCRIPTION
File name detection didn't work because we were trying to match the whole file path to a known file *name*. Fixed that and, to make it more clear, renamed the `setLanguageFromFileName` functions to `setLanguageFromFilePath`.