### PR TITLE
fix: Remove initial addEditorToBuffer due to js errors.

### DIFF
--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -126,8 +126,6 @@ int main(int argc, char *argv[])
     // There are no other instances: start a new server.
     a.startServer();
 
-    Editor::addEditorToBuffer(10);
-
     QFile file(Notepadqq::editorPath());
     if (!file.open(QIODevice::ReadOnly)) {
         qCritical() << "Can't open file: " + file.fileName();


### PR DESCRIPTION
QT 5.11 fails to start notepadqq due to this sometimes.... for no apparent reason at all, in fact.  When I removed this the javascript errors disappeared and Notepadqq starts reliably again.

I have noticed that on occasion it does start slower than usual though, but from testing this appears to be a lockup in the Editor's event loop handling, rather than not having pre-initialized editor buffers.

Anyways, this should fix #699