### PR TITLE
Removed Icon line from appdata.xml

### DIFF
--- a/support_files/notepadqq.appdata.xml
+++ b/support_files/notepadqq.appdata.xml
@@ -4,7 +4,6 @@
   <metadata_license>MIT</metadata_license>
   <project_license>GPL-3.0</project_license>
   <name>Notepadqq</name>
-  <icon width="96" height="96">https://user-images.githubusercontent.com/4319621/36906314-e3f99680-1e35-11e8-90fd-f959c9641f36.png</icon>
   <summary>An advanced text editor</summary>
   <description>
     <p>


### PR DESCRIPTION
After adding the notepadqq.appdata.xml to my Fedora SPEC file (and validating it), I came across the fact that the Icon line is not allowed.

appdata-util validate-relax gave an error that the line was not allowed.