### PR TITLE
Also show 'Retry as Root' option when pkexec is installed.

### DIFF
--- a/src/ui/docengine.cpp
+++ b/src/ui/docengine.cpp
@@ -627,6 +627,10 @@ QString DocEngine::getAvailableSudoProgram() const
     p.start("which gksu");
     p.waitForFinished(10);
     if (p.exitCode() == 0) return "gksu";
+    
+    p.start("which pkexec");
+    p.waitForFinished(10);
+    if (p.exitCode() == 0) return "pkexec";
 
     return "";
 }
@@ -657,6 +661,8 @@ bool DocEngine::trySudoSave(QString sudoProgram, QUrl outFileName, Editor* edito
                 << "-S" << "-m" << tr("Notepadqq asks permission to overwrite the following file:\n\n%1")
                 .arg(outFileName.toLocalFile())
                 << "cp" << filePath << outFileName.toLocalFile());
+    else if (sudoProgram == "pkexec")
+        p.start("pkexec", QStringList() << "cp" << filePath << outFileName.toLocalFile());
     else
         return false;
 

--- a/src/ui/include/docengine.h
+++ b/src/ui/include/docengine.h
@@ -197,13 +197,13 @@ private:
 
     /**
      * @brief getAvailableSudoProgram Queries the system to find a supported graphical sudo tool.
-     * @return Empty string if none found. Else either 'kdesu' or 'gksu'.
+     * @return Empty string if none found. Else either 'kdesu', 'gksu', or 'pkexec'.
      */
     QString getAvailableSudoProgram() const;
 
     /**
      * @brief Attempts to save the contents of editor to outFileName using a graphical sudo program.
-     * @param sudoProgram Name of the sudo tool to use. Only 'kdesu' and 'gksu' supported.
+     * @param sudoProgram Name of the sudo tool to use. Only 'kdesu', 'gksu' and 'pkexec' supported.
      * @param outFileName Target location of file
      * @param editor Editor to be saved
      * @return True if successful.


### PR DESCRIPTION
Newer Ubuntu versions have deprecated/removed 'gksu' but we can use polkit's 'pkexec' as an alternative as well.