### PR TITLE
Added Begin/End Selection Functionality

### DIFF
--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -105,6 +105,7 @@ private slots:
     void on_actionCopy_triggered();
     void on_actionPaste_triggered();
     void on_actionCut_triggered();
+    void on_actionBegin_End_Select_triggered();
     void on_currentEditorChanged(EditorTabWidget* tabWidget, int tab);
     void on_editorAdded(EditorTabWidget* tabWidget, int tab);
     void on_cursorActivity(QMap<QString, QVariant> data);
@@ -216,6 +217,8 @@ private:
     bool                  m_overwrite = false; // Overwrite mode vs Insert mode
     QString               m_workingDirectory;
     QMap<QSharedPointer<Extensions::Extension>, QMenu*> m_extensionMenus;
+    QPair<int, int>       beginSelectPosition;
+    bool                  beginSelectPositionSet = false;
 
     AdvancedSearchDock*  m_advSearchDock;
 

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1161,6 +1161,19 @@ void MainWindow::on_actionCut_triggered()
     currentEditor()->setSelectionsText(QStringList(""));
 }
 
+void MainWindow::on_actionBegin_End_Select_triggered()
+{
+    if (!beginSelectPositionSet) {
+        beginSelectPosition = currentEditor()->cursorPosition();
+        beginSelectPositionSet = true;
+    } else {
+        QPair<int, int> endSelectPosition = currentEditor()->cursorPosition();
+        currentEditor()->setSelection(
+            beginSelectPosition.first, beginSelectPosition.second, endSelectPosition.first, endSelectPosition.second);
+        beginSelectPositionSet = false;
+    }
+}
+
 void MainWindow::on_currentEditorChanged(EditorTabWidget *tabWidget, int tab)
 {
     if (tab != -1) {

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -145,6 +145,7 @@
     <addaction name="actionPaste"/>
     <addaction name="actionDelete"/>
     <addaction name="actionSelect_All"/>
+    <addaction name="actionBegin_End_Select"/>
     <addaction name="separator"/>
     <addaction name="menuCopy_to_Clipboard"/>
     <addaction name="menuConvert_Case_to"/>
@@ -1036,6 +1037,14 @@
    </property>
    <property name="text">
     <string>S&amp;how Toolbar</string>
+   </property>
+  </action>
+  <action name="actionBegin_End_Select">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Begin/End Select</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Greetings,

I have implemented the Notepad++ Begin/End Select feature that has been requested ( #393 ).
This should allow users to mark a beginning cursor location for a selection, then use go-to-line and set an end cursor location for the selection without losing the initial cursor location.

I would be happy to modify it's implementation or make other changes to allow it to match the project structure better. Any feedback would be great.

Dan