### PR TITLE
fix: Use custom event filter for QWebEngineView.

### DIFF
--- a/src/ui/EditorNS/customqwebview.cpp
+++ b/src/ui/EditorNS/customqwebview.cpp
@@ -61,4 +61,35 @@ namespace EditorNS
 
         menu->popup(event->globalPos());
     }
+
+    bool EditorNS::CustomQWebView::eventFilter(QObject* obj, QEvent* ev)
+    {
+        if (obj != childObj)
+            return QWebEngineView::eventFilter(obj, ev);
+
+        switch (ev->type()) {
+        case QEvent::FocusIn:
+            focusInEvent(static_cast<QFocusEvent*>(ev));
+            break;
+        case QEvent::KeyPress:
+            keyPressEvent(static_cast<QKeyEvent*>(ev));
+            break;
+        }
+
+        return QWebEngineView::eventFilter(obj, ev);
+    }
+
+    bool EditorNS::CustomQWebView::event(QEvent* evt)
+    {
+        if (evt->type() == QEvent::ChildPolished) {
+            QChildEvent* child_ev = static_cast<QChildEvent*>(evt);
+            childObj = child_ev->child();
+
+            if (childObj) {
+                childObj->installEventFilter(this);
+            }
+        }
+
+        return QWebEngineView::event(evt);
+    }
 }

--- a/src/ui/include/EditorNS/customqwebview.h
+++ b/src/ui/include/EditorNS/customqwebview.h
@@ -24,6 +24,17 @@ namespace EditorNS
         void dropEvent(QDropEvent *ev) override;
         void focusInEvent(QFocusEvent* event) override;
         void contextMenuEvent(QContextMenuEvent* ev) override;
+
+        /*
+         * QWebEngineView eats various types of events. Since we still need them
+         * we'll have to install a custom event filter on the WebView's child delegate
+         * QOpenGLWidget.
+         */
+        bool event(QEvent* evt) override;
+        bool eventFilter(QObject *obj, QEvent *ev) override;
+
+    private:
+        QObject *childObj = nullptr;
     };
 
 }


### PR DESCRIPTION
QWebEngineView doesn't propagate a number of events, inclusing FocusIn and KeyPress which we need. There's something of a hack where an event filter installed in the right child object can be used to sniff out those events.

It fixes switching between INS and OVR, and proper tab change when clicking on editors.

Would be nice if someone could test it too since it's kind of a big change in event handling. I don't see any ill effects though.