### PR TITLE
Implemented Toggling to Most Recent Tab

### DIFF
--- a/src/ui/editortabwidget.cpp
+++ b/src/ui/editortabwidget.cpp
@@ -21,6 +21,8 @@ EditorTabWidget::EditorTabWidget(QWidget *parent) :
     this->setTabBarHidden(false);
     this->setTabBarHighlight(false);
 
+    connect(this, &EditorTabWidget::currentChanged, this, &EditorTabWidget::on_currentTabChanged);
+
 #ifdef Q_OS_MACX
     this->tabBar()->setExpanding(true);
     this->setUsesScrollButtons(true);
@@ -354,4 +356,18 @@ void EditorTabWidget::on_fileNameChanged(const QUrl & /*oldFileName*/, const QUr
 
     setTabText(index, fileName);
     setTabToolTip(index, fullFileName);
+}
+
+int EditorTabWidget::formerTabIndex()
+{
+    return m_formerTabIndex;
+}
+
+void EditorTabWidget::on_currentTabChanged(int index)
+{
+    // Store current index to become former index on next tab change.
+    if (m_mostRecentTabIndex != index) {
+        m_formerTabIndex = m_mostRecentTabIndex;
+        m_mostRecentTabIndex = index;
+    }
 }

--- a/src/ui/include/editortabwidget.h
+++ b/src/ui/include/editortabwidget.h
@@ -66,12 +66,17 @@ public:
     void setTabText(Editor* editor, const QString& text);
     void setTabText(int index, const QString& text);
 
+    int formerTabIndex();
+
 private:
 
     // Smart pointers to the editors within this TabWidget
     QHash<Editor*, QSharedPointer<Editor>> m_editorPointers;
 
     qreal m_zoomFactor = 1;
+
+    int m_formerTabIndex = 0;
+    int m_mostRecentTabIndex = 0;
 
     void setTabBarHidden(bool yes);
     void setTabBarHighlight(bool yes);
@@ -91,6 +96,7 @@ private slots:
     void on_cleanChanged(bool isClean); 
     void on_editorMouseWheel(QWheelEvent *ev);
     void on_fileNameChanged(const QUrl &, const QUrl &newFileName);
+    void on_currentTabChanged(int index);
 signals:
     void gotFocus();
     void editorAdded(int index);

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -197,6 +197,7 @@ private slots:
     void on_actionShow_Menubar_toggled(bool arg1);
     void on_actionShow_Toolbar_toggled(bool arg1);
     void on_actionMath_Rendering_toggled(bool on);
+    void on_actionToggle_To_Former_Tab_triggered();
 
 private:
     static QList<MainWindow*> m_instances;

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2609,3 +2609,9 @@ void MainWindow::on_actionShow_Toolbar_toggled(bool arg1)
 {
     m_mainToolBar->setVisible(arg1);
 }
+
+void MainWindow::on_actionToggle_To_Former_Tab_triggered()
+{
+    EditorTabWidget* curTabWidget = m_topEditorContainer->currentTabWidget();
+    curTabWidget->setCurrentIndex(curTabWidget->formerTabIndex());
+}

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -206,6 +206,7 @@
     <addaction name="menuMove_Clone_Current_Document"/>
     <addaction name="actionWord_wrap"/>
     <addaction name="actionMath_Rendering"/>
+    <addaction name="actionToggle_To_Former_Tab"/>
     <addaction name="separator"/>
     <addaction name="separator"/>
     <addaction name="actionFull_Screen"/>
@@ -1045,6 +1046,17 @@
    </property>
    <property name="text">
     <string>Begin/End Select</string>
+   </property>
+  </action>
+  <action name="actionToggle_To_Former_Tab">
+   <property name="text">
+    <string>Toggle To Former Tab</string>
+   </property>
+   <property name="toolTip">
+    <string>Toggle Back to Former Tab</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+T</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
I have added a shortcut (Ctrl + T) to toggle to the most recent tab the user was on prior to the current. It allows toggling back and forth, and for each view in a window. It implements the open Issue #469.  This feature depends on the functionality in the current pull request #731 in order to function as expected.

In my tests with that pull request's branch this feature works one/two views and has no problems with multiple windows.

I tried to keep it simple to avoid adding too many functions and changing too many. If any changes are requested I am more than happy to update this and will make sure to update it for TravisCI.