### PR TITLE
Update Polish translations

### DIFF
--- a/src/translations/notepadqq_pl.ts
+++ b/src/translations/notepadqq_pl.ts
@@ -2,19 +2,271 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="pl_PL">
 <context>
+    <name>AdvancedSearchDock</name>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="161"/>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="651"/>
+        <source>Advanced Search</source>
+        <translation>Wyszukiwanie zaawansowane</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="166"/>
+        <source>Clear Search History</source>
+        <translation>Wyczyść historię wyszukiwania</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="175"/>
+        <source>Go To Previous Result (Shift+F4)</source>
+        <translation>Przejdź do poprzedniego wyniku (Shift+F4)</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="180"/>
+        <source>Go To Next Result (F4)</source>
+        <translation>Przejdź do następnego wyniku (F4)</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="184"/>
+        <source>Expand/Collapse All</source>
+        <translation>Rozwiń/zwiń wszystko</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="186"/>
+        <source>Redo Search</source>
+        <translation>Ponów wyszukiwanie</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="187"/>
+        <source>Copy Selected Contents To Clipboard</source>
+        <translation>Skopiuj zaznaczoną treść do schowka</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="188"/>
+        <source>Show Full Lines</source>
+        <translation>Wyświetl pełne linie</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="190"/>
+        <source>Remove This Search</source>
+        <translation>Usuń to wyszukanie</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="195"/>
+        <source>More Options</source>
+        <translation>Więcej opcji</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="200"/>
+        <source>Replace Options</source>
+        <translation>Opcje zastąpienia</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="226"/>
+        <source>Dock/Undock this panel</source>
+        <translation>Przypnij/odepnij ten panel</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="252"/>
+        <source>Replace Text</source>
+        <translation>Zastąp tekst</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="260"/>
+        <source>Replace Selected</source>
+        <translation>Zastąp zaznaczone</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="261"/>
+        <source>Replace all selected search results.</source>
+        <translation>Zastąp wszystkie zaznaczone wyniki wyszukiwania.</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="263"/>
+        <source>Use Special Characters (&apos;\n&apos;, &apos;\t&apos;, ...)</source>
+        <translation>Użyj znaków specjalnych (&apos;\n&apos;, &apos;\t&apos;, ...)</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="264"/>
+        <source>Replace strings like &apos;\n&apos; with their respective special characters.</source>
+        <translation>Zastąp ciągi typu &apos;\n&apos; odpowiadającymi im specjalnymi znakami.</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="300"/>
+        <source>Search String</source>
+        <translation>Wyszukiwany ciąg</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="307"/>
+        <source>Search in Current Document</source>
+        <translation>Szukaj w bieżącym dokumencie</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="308"/>
+        <source>Search in All Open Documents</source>
+        <translation>Szukaj we wszystkich otwartych dokumentach</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="309"/>
+        <source>Search in Files on File System</source>
+        <translation>Szukaj w plikach</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="324"/>
+        <source>Directory</source>
+        <translation>Katalog</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="333"/>
+        <source>Select the directory of the active document</source>
+        <translation>Wybierz katalog aktywnego dokumentu</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="337"/>
+        <source>Select search directory</source>
+        <translation>Wybierz katalog wyszukiwania</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="344"/>
+        <source>Search</source>
+        <translation>Szukaj</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="347"/>
+        <source>Scope:</source>
+        <translation>Zakres:</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="349"/>
+        <source>Search:</source>
+        <translation>Szukaj:</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="351"/>
+        <source>Pattern:</source>
+        <translation>Wzór:</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="353"/>
+        <source>Location:</source>
+        <translation>Lokalizacja:</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="356"/>
+        <source>Match Case</source>
+        <translation>Dopasuj rozmiar liter</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="357"/>
+        <source>Match Whole Words Only</source>
+        <translation>Dopasuj jedynie całe wyrazy</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="358"/>
+        <source>Use Regular Expressions</source>
+        <translation>Użyj wyrażeń regularnych</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="359"/>
+        <source>Use Special Characters (&apos;\t&apos;, &apos;\n&apos;, ...)</source>
+        <translation>Użyj znaków specjalnych (&apos;\t&apos;, &apos;\n&apos;, ...)</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="360"/>
+        <source>If set, character sequences like &apos;\t&apos; will be replaced by their respective special characters.</source>
+        <translation>Jeśli zaznaczone, ciągi znaków typu &apos;\t&apos; będą zamienione przez odpowiadające im znaki specjalne.</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="361"/>
+        <source>Include Subdirectories</source>
+        <translation>Włącznie z podkatalogami</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="425"/>
+        <source>&lt;h3&gt;One or more searches are still in progress&lt;/h3&gt;</source>
+        <translation>&lt;h3&gt;Jedno lub więcej wyszukań jest nadal w ciągu&lt;/h3&gt;</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="426"/>
+        <source>All searches will be canceled and their results discarded if you continue.</source>
+        <translation>Wszystkie wyszukiwania będą anulowane, a ich wyniki odrzucone, jeśli kontynuujesz.</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="440"/>
+        <source>New Search</source>
+        <translation>Nowe wyszukiwanie</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="742"/>
+        <source>Search in progress</source>
+        <translation>Wyszukiwanie w trakcie</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="743"/>
+        <source>&lt;h3&gt;This search is still in progress.&lt;/h3&gt; The search will be canceled and all results discarded if you continue.</source>
+        <translation>&lt;h3&gt;To wyszukiwanie jest nadal w ciągu.&lt;/h3&gt; Wyszukiwanie zostanie anulowane, a wszystkie wyniki odrzucone, jeśli kontynuujesz.</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="854"/>
+        <source>Error</source>
+        <translation>Błąd</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="855"/>
+        <source>Specified directory does not exist.</source>
+        <translation>Wybrany katalog nie istnieje.</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="885"/>
+        <source>Matches in %1 of %2 files replaced.</source>
+        <translation>Dopasowania w %1 z %2 plików zastąpione.</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="893"/>
+        <source>&lt;h3&gt;Replacing selected matches...&lt;/h3&gt;</source>
+        <translation>&lt;h3&gt;Zastępowanie zaznaczonych dopasowań...&lt;/h3&gt;</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="894"/>
+        <source>Replacing in progress</source>
+        <translation>Zastępowanie w trakcie</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="906"/>
+        <source>Replacing was unsuccessful for %1 file(s):
+</source>
+        <translation>Zastępowanie nie udało się dla %1 pliku(ów):
+</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="912"/>
+        <source>And %1 more.</source>
+        <translation>Oraz %1 więcej.</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="915"/>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="918"/>
+        <source>Replacement Results</source>
+        <translation>Wyniki zastąpienia</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="919"/>
+        <source>All selected matches successfully replaced.</source>
+        <translation>Wszystkie zaznaczone dopasowania pomyślnie zastąpione.</translation>
+    </message>
+</context>
+<context>
     <name>BannerFileChanged</name>
     <message>
-        <location filename="../ui/EditorNS/bannerfilechanged.cpp" line="13"/>
+        <location filename="../ui/EditorNS/bannerfilechanged.cpp" line="14"/>
         <source>This file has been changed outside of Notepadqq.</source>
         <translation>Ten plik został zmieniony poza Notepadqq.</translation>
     </message>
     <message>
-        <location filename="../ui/EditorNS/bannerfilechanged.cpp" line="15"/>
+        <location filename="../ui/EditorNS/bannerfilechanged.cpp" line="16"/>
         <source>Reload</source>
         <translation>Odśwież</translation>
     </message>
     <message>
-        <location filename="../ui/EditorNS/bannerfilechanged.cpp" line="18"/>
+        <location filename="../ui/EditorNS/bannerfilechanged.cpp" line="19"/>
         <source>Ignore</source>
         <translation>Ignoruj</translation>
     </message>
@@ -22,17 +274,17 @@
 <context>
     <name>BannerFileRemoved</name>
     <message>
-        <location filename="../ui/EditorNS/bannerfileremoved.cpp" line="13"/>
+        <location filename="../ui/EditorNS/bannerfileremoved.cpp" line="14"/>
         <source>This file has been deleted from the file system.</source>
         <translation>Ten plik został usunięty z systemu.</translation>
     </message>
     <message>
-        <location filename="../ui/EditorNS/bannerfileremoved.cpp" line="15"/>
+        <location filename="../ui/EditorNS/bannerfileremoved.cpp" line="16"/>
         <source>Save</source>
         <translation>Zapisz</translation>
     </message>
     <message>
-        <location filename="../ui/EditorNS/bannerfileremoved.cpp" line="18"/>
+        <location filename="../ui/EditorNS/bannerfileremoved.cpp" line="19"/>
         <source>Ignore</source>
         <translation>Ignoruj</translation>
     </message>
@@ -40,44 +292,44 @@
 <context>
     <name>BannerIndentationDetected</name>
     <message>
-        <location filename="../ui/EditorNS/bannerindentationdetected.cpp" line="18"/>
+        <location filename="../ui/EditorNS/bannerindentationdetected.cpp" line="19"/>
         <source>This file is indented with %1, but your current settings specify to use %2.</source>
-        <translation>Ten plik jest wcięty %1, ale twoje obecne ustawienia określają, by posługiwać się %2. </translation>
+        <translation>Ten plik jest wcięty %1, ale twoje obecne ustawienia określają, by posługiwać się %2.</translation>
     </message>
     <message>
-        <location filename="../ui/EditorNS/bannerindentationdetected.cpp" line="20"/>
-        <location filename="../ui/EditorNS/bannerindentationdetected.cpp" line="25"/>
+        <location filename="../ui/EditorNS/bannerindentationdetected.cpp" line="21"/>
+        <location filename="../ui/EditorNS/bannerindentationdetected.cpp" line="26"/>
         <source>spaces</source>
         <translation>spacjami</translation>
     </message>
     <message>
-        <location filename="../ui/EditorNS/bannerindentationdetected.cpp" line="20"/>
-        <location filename="../ui/EditorNS/bannerindentationdetected.cpp" line="25"/>
+        <location filename="../ui/EditorNS/bannerindentationdetected.cpp" line="21"/>
+        <location filename="../ui/EditorNS/bannerindentationdetected.cpp" line="26"/>
         <source>tabs</source>
         <translation>tabulatorami</translation>
     </message>
     <message>
-        <location filename="../ui/EditorNS/bannerindentationdetected.cpp" line="22"/>
+        <location filename="../ui/EditorNS/bannerindentationdetected.cpp" line="23"/>
         <source>Use spaces</source>
         <translation>Używaj spacji</translation>
     </message>
     <message>
-        <location filename="../ui/EditorNS/bannerindentationdetected.cpp" line="27"/>
+        <location filename="../ui/EditorNS/bannerindentationdetected.cpp" line="28"/>
         <source>Use tabs</source>
         <translation>Używaj tabulatorów</translation>
     </message>
     <message>
-        <location filename="../ui/EditorNS/bannerindentationdetected.cpp" line="31"/>
+        <location filename="../ui/EditorNS/bannerindentationdetected.cpp" line="32"/>
         <source>This file is indented with %1 spaces, but your current settings specify to use %2 spaces.</source>
-        <translation>Ten plik jest wcięty %1 spacjami, ale twoje obecne ustawienia określają, by używać %2 spacji. </translation>
+        <translation>Ten plik jest wcięty %1 spacjami, ale twoje obecne ustawienia określają, by używać %2 spacji.</translation>
     </message>
     <message>
-        <location filename="../ui/EditorNS/bannerindentationdetected.cpp" line="34"/>
+        <location filename="../ui/EditorNS/bannerindentationdetected.cpp" line="35"/>
         <source>Use %1 spaces</source>
         <translation>Używaj %1 spacji</translation>
     </message>
     <message>
-        <location filename="../ui/EditorNS/bannerindentationdetected.cpp" line="38"/>
+        <location filename="../ui/EditorNS/bannerindentationdetected.cpp" line="39"/>
         <source>Ignore</source>
         <translation>Ignoruj</translation>
     </message>
@@ -85,46 +337,70 @@
 <context>
     <name>DocEngine</name>
     <message>
-        <location filename="../ui/docengine.cpp" line="34"/>
+        <location filename="../ui/docengine.cpp" line="40"/>
         <source>new %1</source>
         <translation>nowy %1</translation>
     </message>
     <message>
-        <location filename="../ui/docengine.cpp" line="183"/>
+        <location filename="../ui/docengine.cpp" line="250"/>
         <source>Error trying to open &quot;%1&quot;</source>
         <translation>Błąd podczas próby otwarcia &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../ui/docengine.cpp" line="258"/>
-        <location filename="../ui/docengine.cpp" line="453"/>
+        <location filename="../ui/docengine.cpp" line="164"/>
+        <location filename="../ui/docengine.cpp" line="755"/>
         <source>Protocol not supported for file &quot;%1&quot;.</source>
         <translation>Protokół nieobsługiwany dla pliku &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../ui/docengine.cpp" line="413"/>
+        <location filename="../ui/docengine.cpp" line="661"/>
+        <source>Notepadqq asks permission to overwrite the following file:
+
+%1</source>
+        <translation>Notepadqq prosi o pozwolenie, by nadpisać następujący plik:
+
+%1</translation>
+    </message>
+    <message>
+        <location filename="../ui/docengine.cpp" line="699"/>
         <source>Error trying to write to &quot;%1&quot;</source>
         <translation>Błąd podczas próby zapisu do &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../ui/docengine.cpp" line="701"/>
+        <source>Abort</source>
+        <translation>Przerwij</translation>
+    </message>
+    <message>
+        <location filename="../ui/docengine.cpp" line="702"/>
+        <source>Retry</source>
+        <translation>Spróbuj ponownie</translation>
+    </message>
+    <message>
+        <location filename="../ui/docengine.cpp" line="704"/>
+        <source>Retry as Root</source>
+        <translation>Spróbuj ponownie jako root</translation>
     </message>
 </context>
 <context>
     <name>Extension</name>
     <message>
-        <location filename="../ui/Extensions/extension.cpp" line="22"/>
+        <location filename="../ui/Extensions/extension.cpp" line="24"/>
         <source>name missing or invalid</source>
         <translation>nieprawidłowa lub brakująca nazwa</translation>
     </message>
     <message>
-        <location filename="../ui/Extensions/extension.cpp" line="50"/>
+        <location filename="../ui/Extensions/extension.cpp" line="52"/>
         <source>unable to read nqq-manifest.json</source>
         <translation>nie można odczytać nqq-manifest.json</translation>
     </message>
     <message>
-        <location filename="../ui/Extensions/extension.cpp" line="97"/>
+        <location filename="../ui/Extensions/extension.cpp" line="99"/>
         <source>failed to start. Check your runtime: %1</source>
         <translation>nie powiodło się uruchomienie. Sprawdź swoje środowisko wykonawcze: %1</translation>
     </message>
     <message>
-        <location filename="../ui/Extensions/extension.cpp" line="106"/>
+        <location filename="../ui/Extensions/extension.cpp" line="108"/>
         <source>Failed to load %1: %2</source>
         <translation>Nie powiodło się załadowanie %1: %2</translation>
     </message>
@@ -132,22 +408,14 @@
 <context>
     <name>Extensions::InstallExtension</name>
     <message>
-        <location filename="../ui/Extensions/installextension.cpp" line="178"/>
+        <location filename="../ui/Extensions/installextension.cpp" line="180"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
     <message>
-        <location filename="../ui/Extensions/installextension.cpp" line="178"/>
+        <location filename="../ui/Extensions/installextension.cpp" line="180"/>
         <source>Unsupported runtime: %1</source>
         <translation>Niewspierane środowisko wykonawcze: %1</translation>
-    </message>
-</context>
-<context>
-    <name>FileSearchResultsWidget</name>
-    <message>
-        <location filename="../ui/Search/filesearchresultswidget.cpp" line="29"/>
-        <source>Clear</source>
-        <translation>Wyczyść</translation>
     </message>
 </context>
 <context>
@@ -168,44 +436,44 @@
         <translation>Zainstaluj</translation>
     </message>
     <message>
-        <location filename="../ui/Extensions/installextension.cpp" line="43"/>
+        <location filename="../ui/Extensions/installextension.cpp" line="45"/>
         <source>Version %1, %2</source>
         <translation>Wersja %1, %2</translation>
     </message>
     <message>
-        <location filename="../ui/Extensions/installextension.cpp" line="44"/>
-        <location filename="../ui/Extensions/installextension.cpp" line="53"/>
+        <location filename="../ui/Extensions/installextension.cpp" line="46"/>
+        <location filename="../ui/Extensions/installextension.cpp" line="55"/>
         <source>unknown version</source>
         <translation>nieznana wersja</translation>
     </message>
     <message>
-        <location filename="../ui/Extensions/installextension.cpp" line="45"/>
+        <location filename="../ui/Extensions/installextension.cpp" line="47"/>
         <source>unknown author</source>
         <translation>nieznany autor</translation>
     </message>
     <message>
-        <location filename="../ui/Extensions/installextension.cpp" line="55"/>
+        <location filename="../ui/Extensions/installextension.cpp" line="57"/>
         <source>(current version is %1)</source>
         <translation>(aktualna wersja to %1)</translation>
     </message>
     <message>
-        <location filename="../ui/Extensions/installextension.cpp" line="56"/>
+        <location filename="../ui/Extensions/installextension.cpp" line="58"/>
         <source>Update</source>
         <translation>Aktualizuj</translation>
     </message>
     <message>
-        <location filename="../ui/Extensions/installextension.cpp" line="105"/>
-        <location filename="../ui/Extensions/installextension.cpp" line="127"/>
+        <location filename="../ui/Extensions/installextension.cpp" line="107"/>
+        <location filename="../ui/Extensions/installextension.cpp" line="129"/>
         <source>Error installing the extension</source>
         <translation>Błąd podczas instalowania rozszerzenia</translation>
     </message>
     <message>
-        <location filename="../ui/Extensions/installextension.cpp" line="116"/>
+        <location filename="../ui/Extensions/installextension.cpp" line="118"/>
         <source>Extension installed</source>
         <translation>Rozszerzenie zainstalowane</translation>
     </message>
     <message>
-        <location filename="../ui/Extensions/installextension.cpp" line="117"/>
+        <location filename="../ui/Extensions/installextension.cpp" line="119"/>
         <source>The extension has been successfully installed!</source>
         <translation>Rozszerzenie zostało pomyślnie zainstalowane!</translation>
     </message>
@@ -213,12 +481,12 @@
 <context>
     <name>KeyGrabber</name>
     <message>
-        <location filename="../ui/keygrabber.cpp" line="13"/>
+        <location filename="../ui/keygrabber.cpp" line="10"/>
         <source>Action</source>
         <translation>Akcja</translation>
     </message>
     <message>
-        <location filename="../ui/keygrabber.cpp" line="13"/>
+        <location filename="../ui/keygrabber.cpp" line="10"/>
         <source>Keyboard Shortcut</source>
         <translation>Skrót klawiaturowy</translation>
     </message>
@@ -246,218 +514,129 @@
         <translation>&amp;Edycja</translation>
     </message>
     <message>
-        <source>End of line</source>
-        <translation type="vanished">Znak końca linii</translation>
-    </message>
-    <message>
-        <source>Copy to Clipboard</source>
-        <translation type="vanished">Kopiuj do schowka</translation>
-    </message>
-    <message>
-        <source>Convert Case to</source>
-        <translation type="vanished">Zmień wielkość liter</translation>
-    </message>
-    <message>
-        <source>Indentation</source>
-        <translation type="vanished">Wcięcie</translation>
-    </message>
-    <message>
-        <source>Line Operations</source>
-        <translation type="vanished">Operacje na liniach</translation>
-    </message>
-    <message>
-        <source>Blank Operations</source>
-        <translation type="vanished">Operacje na białych znakach</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="158"/>
+        <location filename="../ui/mainwindow.ui" line="159"/>
         <source>&amp;Search</source>
-        <translation>&amp;Wyszukiwanie</translation>
+        <translation>&amp;Szukaj</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="171"/>
+        <location filename="../ui/mainwindow.ui" line="172"/>
         <source>&amp;View</source>
         <translation>&amp;Widok</translation>
     </message>
     <message>
-        <source>Show Symbol</source>
-        <translation type="vanished">Pokaż niewidoczne znaki</translation>
-    </message>
-    <message>
-        <source>Zoom</source>
-        <translation type="vanished">Powiększenie</translation>
-    </message>
-    <message>
-        <source>Move/Clone Current Document</source>
-        <translation type="vanished">Przenieś/sklonuj bieżący dokument</translation>
-    </message>
-    <message>
-        <source>Encoding</source>
-        <translation type="vanished">Kodowanie</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="232"/>
+        <location filename="../ui/mainwindow.ui" line="234"/>
         <source>&amp;Language</source>
         <translation>&amp;Język</translation>
     </message>
     <message>
-        <source>Se&amp;ttings</source>
-        <translation type="vanished">Us&amp;tawienia</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="245"/>
+        <location filename="../ui/mainwindow.ui" line="250"/>
         <source>&amp;?</source>
         <translation>&amp;?</translation>
     </message>
     <message>
-        <source>Run</source>
-        <translation type="vanished">Uruchamianie</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="259"/>
+        <location filename="../ui/mainwindow.ui" line="264"/>
         <source>&amp;Window</source>
         <translation>&amp;Okno</translation>
     </message>
     <message>
-        <source>Extensions</source>
-        <translation type="vanished">Rozszerzenia</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="284"/>
-        <source>Toolbar</source>
-        <translation>Pasek narzędzi</translation>
-    </message>
-    <message>
-        <source>Find result</source>
-        <translation type="vanished">Znajdź wynik</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="352"/>
+        <location filename="../ui/mainwindow.ui" line="290"/>
         <source>&amp;Open...</source>
         <translation>&amp;Otwórz...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="355"/>
+        <location filename="../ui/mainwindow.ui" line="293"/>
         <source>Ctrl+O</source>
         <translation>Ctrl+O</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="360"/>
+        <location filename="../ui/mainwindow.ui" line="298"/>
         <source>&amp;New</source>
         <translation>&amp;Nowy</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="363"/>
+        <location filename="../ui/mainwindow.ui" line="301"/>
         <source>Ctrl+N</source>
         <translation>Ctrl+N</translation>
     </message>
     <message>
-        <source>Reload from Disk</source>
-        <translation type="vanished">Odśwież z dysku</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="373"/>
+        <location filename="../ui/mainwindow.ui" line="311"/>
         <source>&amp;Save</source>
         <translation>&amp;Zapisz</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="376"/>
+        <location filename="../ui/mainwindow.ui" line="314"/>
         <source>Ctrl+S</source>
         <translation>Ctrl+S</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="381"/>
+        <location filename="../ui/mainwindow.ui" line="319"/>
         <source>Save &amp;As...</source>
         <translation>Zapisz &amp;jako...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="384"/>
+        <location filename="../ui/mainwindow.ui" line="322"/>
         <source>Save As...</source>
         <translation>Zapisz jako...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="387"/>
+        <location filename="../ui/mainwindow.ui" line="325"/>
         <source>Ctrl+Alt+S</source>
         <translation>Ctrl+Alt+S</translation>
     </message>
     <message>
-        <source>Save a Copy As...</source>
-        <translation type="vanished">Zapisz kopię jako...</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="397"/>
+        <location filename="../ui/mainwindow.ui" line="335"/>
         <source>Sav&amp;e All</source>
-        <translation>Zap&amp;isz wszystko</translation>
+        <translation>Zapisz &amp;wszystko</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="400"/>
+        <location filename="../ui/mainwindow.ui" line="338"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-        <source>Rename...</source>
-        <translation type="vanished">Zmień nazwę...</translation>
-    </message>
-    <message>
-        <source>Close</source>
-        <translation type="vanished">Zamknij</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="413"/>
+        <location filename="../ui/mainwindow.ui" line="351"/>
         <source>Ctrl+W</source>
         <translation>Ctrl+W</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="418"/>
+        <location filename="../ui/mainwindow.ui" line="356"/>
         <source>C&amp;lose All</source>
-        <translation>Z&amp;amknij wszystko</translation>
+        <translation>Zamknij wsz&amp;ystko</translation>
     </message>
     <message>
-        <source>Close All BUT Current Document</source>
-        <translation type="vanished">Zamknij wszystko poza bieżącym dokumentem</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="428"/>
+        <location filename="../ui/mainwindow.ui" line="366"/>
         <source>Load Session...</source>
         <translation>Załaduj sesję...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="433"/>
+        <location filename="../ui/mainwindow.ui" line="371"/>
         <source>Save Session...</source>
         <translation>Zapisz sesję...</translation>
     </message>
     <message>
-        <source>Print...</source>
-        <translation type="vanished">Drukuj...</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="441"/>
+        <location filename="../ui/mainwindow.ui" line="382"/>
         <source>Ctrl+P</source>
         <translation>Ctrl+P</translation>
     </message>
     <message>
-        <source>Print Now</source>
-        <translation type="vanished">Drukuj teraz</translation>
-    </message>
-    <message>
         <location filename="../ui/mainwindow.ui" line="88"/>
         <source>&amp;End of line</source>
-        <translation>&amp;Znak końca linii</translation>
+        <translation>Znak końca &amp;linii</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.ui" line="96"/>
         <source>C&amp;opy to Clipboard</source>
-        <translation>K&amp;opiuj do schowka</translation>
+        <translation>Kopiuj do &amp;schowka</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.ui" line="104"/>
         <source>Co&amp;nvert Case to</source>
-        <translation>Zm&amp;ień litery na</translation>
+        <translation>Zmień &amp;rozmiar liter</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.ui" line="111"/>
         <source>&amp;Indentation</source>
-        <translation>&amp;Wcięcie</translation>
+        <translation>Wc&amp;ięcie</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.ui" line="120"/>
@@ -467,1077 +646,914 @@
     <message>
         <location filename="../ui/mainwindow.ui" line="129"/>
         <source>&amp;Blank Operations</source>
-        <translation>&amp;Operacje na białych znakach</translation>
+        <translation>Operacje na &amp;białych znakach</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="175"/>
+        <location filename="../ui/mainwindow.ui" line="176"/>
         <source>&amp;Show Symbol</source>
         <translation>&amp;Pokaż niewidoczne znaki</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="187"/>
+        <location filename="../ui/mainwindow.ui" line="188"/>
         <source>&amp;Zoom</source>
-        <translation>&amp;Powiększenie</translation>
+        <translation>Powięk&amp;szenie</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="195"/>
+        <location filename="../ui/mainwindow.ui" line="196"/>
         <source>&amp;Move/Clone Current Document</source>
-        <translation>&amp;Przenieś/sklonuj bieżący dokument</translation>
+        <translation>Przenieś/&amp;klonuj bieżący dokument</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="214"/>
+        <location filename="../ui/mainwindow.ui" line="216"/>
         <source>En&amp;coding</source>
         <translation>&amp;Kodowanie</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="239"/>
+        <location filename="../ui/mainwindow.ui" line="241"/>
         <source>Settin&amp;gs</source>
-        <translation>Us&amp;tawienia</translation>
+        <translation>&amp;Ustawienia</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="252"/>
+        <location filename="../ui/mainwindow.ui" line="257"/>
         <source>&amp;Run</source>
-        <translation>&amp;Uruchom</translation>
+        <translation>U&amp;ruchom</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="265"/>
+        <location filename="../ui/mainwindow.ui" line="270"/>
         <source>E&amp;xtensions</source>
         <translation>R&amp;ozszerzenia</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="328"/>
-        <source>Find res&amp;ult</source>
-        <translation>Znajdź wyn&amp;ik</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="368"/>
+        <location filename="../ui/mainwindow.ui" line="306"/>
         <source>&amp;Reload from Disk</source>
-        <translation>&amp;Odśwież z dysku</translation>
+        <translation>Odśwież z dysk&amp;u</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="392"/>
+        <location filename="../ui/mainwindow.ui" line="330"/>
         <source>Sa&amp;ve a Copy As...</source>
         <translation>Za&amp;pisz kopię jako...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="405"/>
+        <location filename="../ui/mainwindow.ui" line="343"/>
         <source>Rena&amp;me...</source>
         <translation>Zmień n&amp;azwę...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="410"/>
+        <location filename="../ui/mainwindow.ui" line="348"/>
         <source>&amp;Close</source>
-        <translation>&amp;Zamknij</translation>
+        <translation>Za&amp;mknij</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="423"/>
+        <location filename="../ui/mainwindow.ui" line="361"/>
         <source>Close All &amp;BUT Current Document</source>
-        <translation>Zamknij wszystko &amp;poza bieżącym dokumentem</translation>
+        <translation>Zamknij wszystko poza &amp;bieżącym dokumentem</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="438"/>
+        <location filename="../ui/mainwindow.ui" line="379"/>
         <source>&amp;Print...</source>
         <translation>&amp;Drukuj...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="449"/>
+        <location filename="../ui/mainwindow.ui" line="393"/>
         <source>Pr&amp;int Now</source>
         <translation>Dr&amp;ukuj teraz</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="457"/>
+        <location filename="../ui/mainwindow.ui" line="401"/>
         <source>Open All Recent Files</source>
-        <translation>Otwórz wszystkie ostatnio używane pliki </translation>
+        <translation>Otwórz wszystkie ostatnio używane pliki</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="462"/>
+        <location filename="../ui/mainwindow.ui" line="406"/>
         <source>Empty Recent Files List</source>
         <translation>Wyczyść listę ostatnio używanych plików</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="467"/>
+        <location filename="../ui/mainwindow.ui" line="411"/>
         <source>E&amp;xit</source>
-        <translation>Z&amp;akończ</translation>
+        <translation>Zakoń&amp;cz</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="470"/>
+        <location filename="../ui/mainwindow.ui" line="414"/>
         <source>Alt+F4</source>
         <translation>Alt+F4</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="475"/>
+        <location filename="../ui/mainwindow.ui" line="419"/>
         <source>&amp;Undo</source>
         <translation>&amp;Cofnij</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="478"/>
+        <location filename="../ui/mainwindow.ui" line="422"/>
         <source>Ctrl+Z</source>
         <translation>Ctrl+Z</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="483"/>
+        <location filename="../ui/mainwindow.ui" line="427"/>
         <source>&amp;Redo</source>
         <translation>&amp;Ponów</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="486"/>
+        <location filename="../ui/mainwindow.ui" line="430"/>
         <source>Ctrl+Y</source>
         <translation>Ctrl+Y</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="491"/>
+        <location filename="../ui/mainwindow.ui" line="435"/>
         <source>Cu&amp;t</source>
         <translation>Wy&amp;tnij</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="494"/>
+        <location filename="../ui/mainwindow.ui" line="438"/>
         <source>Ctrl+X</source>
         <translation>Ctrl+X</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="499"/>
+        <location filename="../ui/mainwindow.ui" line="443"/>
         <source>&amp;Copy</source>
         <translation>&amp;Kopiuj</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="502"/>
+        <location filename="../ui/mainwindow.ui" line="446"/>
         <source>Ctrl+C</source>
         <translation>Ctrl+C</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="507"/>
+        <location filename="../ui/mainwindow.ui" line="451"/>
         <source>&amp;Paste</source>
         <translation>&amp;Wklej</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="510"/>
+        <location filename="../ui/mainwindow.ui" line="454"/>
         <source>Ctrl+V</source>
         <translation>Ctrl+V</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="515"/>
+        <location filename="../ui/mainwindow.ui" line="459"/>
         <source>&amp;Delete</source>
         <translation>&amp;Usuń</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="518"/>
+        <location filename="../ui/mainwindow.ui" line="462"/>
         <source>Del</source>
         <translation>Del</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="523"/>
+        <location filename="../ui/mainwindow.ui" line="467"/>
         <source>Select &amp;All</source>
-        <translation>Zaznacz &amp;wszystko</translation>
+        <translation>&amp;Zaznacz wszystko</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="526"/>
+        <location filename="../ui/mainwindow.ui" line="470"/>
         <source>Ctrl+A</source>
         <translation>Ctrl+A</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="531"/>
+        <location filename="../ui/mainwindow.ui" line="475"/>
         <source>About &amp;Notepadqq...</source>
-        <translation>O programie &amp;Notepadqq...</translation>
+        <translation>O &amp;Notepadqq...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="539"/>
+        <location filename="../ui/mainwindow.ui" line="483"/>
         <source>&amp;About Qt...</source>
-        <translation>&amp;O bibliotece Qt...</translation>
+        <translation>O &amp;Qt...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="547"/>
+        <location filename="../ui/mainwindow.ui" line="491"/>
         <source>&amp;Windows Format</source>
         <translation>&amp;Format Windows</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="558"/>
+        <location filename="../ui/mainwindow.ui" line="502"/>
         <source>&amp;UNIX / OS X Format</source>
-        <translation>&amp;Format UNIX / OS X</translation>
+        <translation>Form&amp;at UNIX / OS X</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="566"/>
+        <location filename="../ui/mainwindow.ui" line="510"/>
         <source>&amp;Old Mac Format</source>
-        <translation>&amp;Stary format MAC</translation>
+        <translation>Stary format &amp;Mac</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="574"/>
+        <location filename="../ui/mainwindow.ui" line="518"/>
         <source>Show &amp;End of Line</source>
         <translation>Pokaż znak &amp;końca linii</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="582"/>
+        <location filename="../ui/mainwindow.ui" line="526"/>
         <source>&amp;Show Tabs</source>
-        <translation>&amp;Pokaż tabulatory</translation>
+        <translation>Pokaż &amp;tabulatory</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="590"/>
+        <location filename="../ui/mainwindow.ui" line="534"/>
         <source>Show All &amp;Characters</source>
-        <translation>Pokaż wszystkie &amp;znaki</translation>
+        <translation>Pokaż &amp;wszystkie znaki</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="601"/>
+        <location filename="../ui/mainwindow.ui" line="545"/>
         <source>Show &amp;Indent Guide</source>
-        <translation>Pokaż &amp;prowadnice poziomów</translation>
+        <translation>P&amp;okaż prowadnice poziomów</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="609"/>
+        <location filename="../ui/mainwindow.ui" line="553"/>
         <source>Show &amp;Wrap Symbol</source>
-        <translation>Pokaż &amp;symbol zawijania</translation>
+        <translation>Pokaż s&amp;ymbol zawijania</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="617"/>
+        <location filename="../ui/mainwindow.ui" line="561"/>
         <source>&amp;Word wrap</source>
         <translation>&amp;Zawijanie wierszy</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="625"/>
-        <source>&amp;Text Direction RTL</source>
-        <translation>&amp;Kierunek tekstu z prawej do lewej</translation>
+        <location filename="../ui/mainwindow.ui" line="569"/>
+        <source>&amp;Math Rendering</source>
+        <translation>Renderowanie &amp;matematyki</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="630"/>
+        <location filename="../ui/mainwindow.ui" line="882"/>
+        <source>&amp;Advanced Search</source>
+        <translation>&amp;Wyszukiwanie zaawansowane</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="1029"/>
+        <source>&amp;Show Menubar</source>
+        <translation>Pokaż &amp;menu</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="1032"/>
+        <source>Ctrl+M</source>
+        <translation>Ctrl+M</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="1040"/>
+        <source>S&amp;how Toolbar</source>
+        <translation>Pokaż pasek &amp;narzędzi</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="1048"/>
+        <source>Begin/End Select</source>
+        <translation>Rozpocznij/zakończ zaznaczenie</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="1053"/>
+        <source>Toggle To Former Tab</source>
+        <translation>Przełącz na poprzednią kartę</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="1056"/>
+        <source>Toggle Back to Former Tab</source>
+        <translation>Przełącz z powrotem do poprzedniej karty</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="1059"/>
+        <source>Ctrl+T</source>
+        <translation>Ctrl+T</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="574"/>
         <source>&amp;Copy Full Path to Clipboard</source>
-        <translation>&amp;Skopiuj pełną ścieżkę pliku do schowka</translation>
+        <translation>Kopiu&amp;j pełną ścieżkę pliku do schowka</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="635"/>
+        <location filename="../ui/mainwindow.ui" line="579"/>
         <source>Copy &amp;Filename to Clipboard</source>
-        <translation>Skopiuj &amp;nazwę pliku do schowka</translation>
+        <translation>Kopiuj &amp;nazwę pliku do schowka</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="640"/>
+        <location filename="../ui/mainwindow.ui" line="584"/>
         <source>Copy &amp;Directory to Clipboard</source>
-        <translation>Skopiuj &amp;ścieżkę katalogu do schowka</translation>
+        <translation>Kopiuj ścieżkę katalogu &amp;do schowka</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="661"/>
+        <location filename="../ui/mainwindow.ui" line="605"/>
         <source>&amp;Restore Default Zoom</source>
-        <translation>&amp;Przywróć domyślne powiększenie</translation>
+        <translation>Przywróć &amp;domyślne powiększenie</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="669"/>
+        <location filename="../ui/mainwindow.ui" line="613"/>
         <source>&amp;Move to Other View</source>
-        <translation>&amp;Przenieś do innego widoku</translation>
+        <translation>Przenieś do innego &amp;widoku</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="674"/>
+        <location filename="../ui/mainwindow.ui" line="618"/>
         <source>&amp;Clone to Other View</source>
-        <translation>&amp;Sklonuj do innego widoku</translation>
+        <translation>Klonuj do &amp;innego widoku</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="679"/>
+        <location filename="../ui/mainwindow.ui" line="626"/>
         <source>Move to a &amp;New Window</source>
         <translation>Przenieś do &amp;nowego okna</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="684"/>
+        <location filename="../ui/mainwindow.ui" line="631"/>
         <source>&amp;Open in a New Window</source>
         <translation>&amp;Otwórz w nowym oknie</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="748"/>
+        <location filename="../ui/mainwindow.ui" line="695"/>
         <source>&amp;UPPERCASE</source>
-        <translation>&amp;WIELKIE LITERY</translation>
+        <translation>WI&amp;ELKIE LITERY</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="756"/>
+        <location filename="../ui/mainwindow.ui" line="703"/>
         <source>&amp;lowercase</source>
         <translation>&amp;małe litery</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="764"/>
+        <location filename="../ui/mainwindow.ui" line="711"/>
         <source>&amp;Convert to UTF-8</source>
-        <translation>&amp;Konwertuj na format UTF-8</translation>
+        <translation>Konwertuj na &amp;format UTF-8</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="769"/>
+        <location filename="../ui/mainwindow.ui" line="716"/>
         <source>Convert to UTF-&amp;16BE (UCS-2 Big Endian)</source>
         <translation>Konwertuj na format UTF-&amp;16BE (UCS-2 Big Endian)</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="774"/>
+        <location filename="../ui/mainwindow.ui" line="721"/>
         <source>Convert to UTF-16LE (UCS-&amp;2 Little Endian)</source>
         <translation>Konwertuj na format UTF-16LE (UCS-&amp;2 Little Endian)</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="779"/>
+        <location filename="../ui/mainwindow.ui" line="726"/>
         <source>Convert to &amp;UTF-8 without BOM</source>
         <translation>Konwertuj na format &amp;UTF-8 bez BOM</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="829"/>
+        <location filename="../ui/mainwindow.ui" line="776"/>
         <source>&amp;Preferences...</source>
         <translation>&amp;Preferencje...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="858"/>
+        <location filename="../ui/mainwindow.ui" line="805"/>
         <source>&amp;Plain text</source>
         <translation>&amp;Zwykły tekst</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="863"/>
+        <location filename="../ui/mainwindow.ui" line="810"/>
         <source>&amp;Replace...</source>
-        <translation>&amp;Zamień...</translation>
+        <translation>Z&amp;amień...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="871"/>
+        <location filename="../ui/mainwindow.ui" line="818"/>
         <source>&amp;Reload file interpreted as...</source>
         <translation>&amp;Odśwież plik interpretowany jako...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="876"/>
+        <location filename="../ui/mainwindow.ui" line="823"/>
         <source>C&amp;onvert to...</source>
-        <translation>&amp;Konwertuj na format...</translation>
+        <translation>&amp;Konwertuj do formatu...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="881"/>
+        <location filename="../ui/mainwindow.ui" line="828"/>
         <source>Interpret as UTF-16BE (UCS-2 &amp;Big Endian)</source>
         <translation>Interpretuj jako UTF-16BE (UCS-2 &amp;Big Endian)</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="886"/>
+        <location filename="../ui/mainwindow.ui" line="833"/>
         <source>Interpret as UTF-&amp;8 without BOM</source>
         <translation>Interpretuj jako UTF-&amp;8 bez BOM</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="891"/>
+        <location filename="../ui/mainwindow.ui" line="838"/>
         <source>&amp;Interpret as UTF-8</source>
         <translation>&amp;Interpretuj jako UTF-8</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="896"/>
+        <location filename="../ui/mainwindow.ui" line="843"/>
         <source>Interpret as UTF-16LE (UCS-2 &amp;Little Endian)</source>
         <translation>Interpretuj jako UTF-16LE (UCS-2 &amp;Little Endian)</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="907"/>
+        <location filename="../ui/mainwindow.ui" line="854"/>
         <source>&amp;Default settings</source>
-        <translation>&amp;Ustawienia domyślne</translation>
+        <translation>Ustawienia &amp;domyślne</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="915"/>
+        <location filename="../ui/mainwindow.ui" line="862"/>
         <source>&amp;Custom...</source>
         <translation>&amp;Niestandardowe...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="920"/>
+        <location filename="../ui/mainwindow.ui" line="867"/>
         <source>I&amp;nterpret as...</source>
-        <translation>I&amp;nterpretuj jako...</translation>
+        <translation>Interpretuj &amp;jako...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="930"/>
+        <location filename="../ui/mainwindow.ui" line="877"/>
         <source>&amp;Open a New Window</source>
-        <translation>&amp;Otwórz w nowym oknie</translation>
+        <translation>Otwórz &amp;nowe okno</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="935"/>
-        <source>Find &amp;in Files...</source>
-        <translation>Znajdź &amp;w plikach...</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="943"/>
+        <location filename="../ui/mainwindow.ui" line="890"/>
         <source>Delete &amp;Current Line</source>
-        <translation>Usuń &amp;bieżącą linię</translation>
+        <translation>Usuń bi&amp;eżącą linię</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="954"/>
+        <location filename="../ui/mainwindow.ui" line="901"/>
         <source>&amp;Duplicate Current Line</source>
-        <translation>&amp;Powiel bieżącą linię</translation>
+        <translation>Powiel bieżącą li&amp;nię</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="912"/>
+        <source>&amp;Move Line Up</source>
+        <translation>Przesuń linię w &amp;górę</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="923"/>
+        <source>Move &amp;Line Down</source>
+        <translation>Przesuń linię w &amp;dół</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="950"/>
+        <source>T&amp;rim Leading and Trailing Space</source>
+        <translation>Usuń spacj&amp;e na początkach i końcach linii</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="955"/>
+        <source>&amp;EOL to Space</source>
+        <translation>Za&amp;mień EOL na spację</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.ui" line="960"/>
+        <source>TA&amp;B to Space</source>
+        <translation>Zamień tabulator na spac&amp;ję</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.ui" line="965"/>
-        <source>&amp;Move Line Up</source>
-        <translation>&amp;Przesuń linię do dołu</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="976"/>
-        <source>Move &amp;Line Down</source>
-        <translation>Przesuń &amp;linię do dołu</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="1003"/>
-        <source>T&amp;rim Leading and Trailing Space</source>
-        <translation>U&amp;suń spacje na początkach i końcach linii</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="1008"/>
-        <source>&amp;EOL to Space</source>
-        <translation>&amp;Zamień znak końca linii na spację</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="1013"/>
-        <source>TA&amp;B to Space</source>
-        <translation>Zamień tab&amp;ulator na spację</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="1018"/>
         <source>&amp;Space to TAB (All)</source>
-        <translation>&amp;Zamień spacje na tabulatory (wszędzie)</translation>
+        <translation>Zamień spacje na tabulatory (wszę&amp;dzie)</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="1023"/>
+        <location filename="../ui/mainwindow.ui" line="970"/>
         <source>S&amp;pace to TAB (Leading)</source>
         <translation>Z&amp;amień spacje na tabulatory (początkowe)</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="1028"/>
+        <location filename="../ui/mainwindow.ui" line="975"/>
         <source>Open &amp;Folder...</source>
         <translation>Otwórz &amp;katalog...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="1033"/>
+        <location filename="../ui/mainwindow.ui" line="980"/>
         <source>&amp;Go to line...</source>
-        <translation>&amp;Przejdź do linii...</translation>
+        <translation>Przejdź do &amp;linii...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="1041"/>
+        <location filename="../ui/mainwindow.ui" line="988"/>
         <source>&amp;Install Extension...</source>
         <translation>&amp;Zainstaluj rozszerzenie...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="1049"/>
+        <location filename="../ui/mainwindow.ui" line="996"/>
         <source>&amp;Full Screen</source>
-        <translation>&amp;Pełny ekran</translation>
+        <translation>Pełny &amp;ekran</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="1074"/>
+        <location filename="../ui/mainwindow.ui" line="1021"/>
         <source>&amp;Enable Smart Indent</source>
-        <translation>&amp;Włącz inteligentne wcięcie</translation>
+        <translation>Włącz int&amp;eligentne wcięcie</translation>
     </message>
     <message>
-        <source>About Notepadqq...</source>
-        <translation type="vanished">O programie Notepadqq...</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="534"/>
+        <location filename="../ui/mainwindow.ui" line="478"/>
         <source>F1</source>
         <translation>F1</translation>
     </message>
     <message>
-        <source>About Qt...</source>
-        <translation type="vanished">O Qt...</translation>
-    </message>
-    <message>
-        <source>Windows Format</source>
-        <translation type="vanished">Format Windows</translation>
-    </message>
-    <message>
-        <source>UNIX / OS X Format</source>
-        <translation type="vanished">Format UNIX / OS X</translation>
-    </message>
-    <message>
-        <source>Old Mac Format</source>
-        <translation type="vanished">Stary format MAC</translation>
-    </message>
-    <message>
-        <source>Show End of Line</source>
-        <translation type="vanished">Pokaż znak końca linii</translation>
-    </message>
-    <message>
-        <source>Show Tabs</source>
-        <translation type="vanished">Pokaż tabulatory</translation>
-    </message>
-    <message>
-        <source>Show All Characters</source>
-        <translation type="vanished">Pokaż wszystkie znaki</translation>
-    </message>
-    <message>
-        <source>Show Indent Guide</source>
-        <translation type="vanished">Pokaż prowadnice poziomów</translation>
-    </message>
-    <message>
-        <source>Show Wrap Symbol</source>
-        <translation type="vanished">Pokaż symbol zawijania</translation>
-    </message>
-    <message>
-        <source>Word wrap</source>
-        <translation type="vanished">Zawijanie wierszy</translation>
-    </message>
-    <message>
-        <source>Text Direction RTL</source>
-        <translation type="vanished">Kierunek tekstu z prawej do lewej</translation>
-    </message>
-    <message>
-        <source>Copy Full Path to Clipboard</source>
-        <translation type="vanished">Skopiuj pełną ścieżkę pliku do schowka</translation>
-    </message>
-    <message>
-        <source>Copy Filename to Clipboard</source>
-        <translation type="vanished">Skopiuj nazwę pliku do schowka</translation>
-    </message>
-    <message>
-        <source>Copy Directory to Clipboard</source>
-        <translation type="vanished">Skopiuj ścieżkę katalogu do schowka</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="645"/>
+        <location filename="../ui/mainwindow.ui" line="589"/>
         <source>Zoom &amp;In</source>
         <translation>Po&amp;większ</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="648"/>
+        <location filename="../ui/mainwindow.ui" line="592"/>
         <source>Ctrl++</source>
         <translation>Ctrl++</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="653"/>
+        <location filename="../ui/mainwindow.ui" line="597"/>
         <source>Zoom &amp;Out</source>
         <translation>Po&amp;mniejsz</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="656"/>
+        <location filename="../ui/mainwindow.ui" line="600"/>
         <source>Ctrl+-</source>
         <translation>Ctrl+-</translation>
     </message>
     <message>
-        <source>Restore Default Zoom</source>
-        <translation type="vanished">Przywróć domyślne powiększenie</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="664"/>
+        <location filename="../ui/mainwindow.ui" line="608"/>
         <source>Ctrl+0</source>
         <translation>Ctrl+0</translation>
     </message>
     <message>
-        <source>Move to Other View</source>
-        <translation type="vanished">Przenieś do innego widoku</translation>
-    </message>
-    <message>
-        <source>Clone to Other View</source>
-        <translation type="vanished">Sklonuj do innego widoku</translation>
-    </message>
-    <message>
-        <source>Move to a New Window</source>
-        <translation type="vanished">Przenieś do nowego okna</translation>
-    </message>
-    <message>
-        <source>Open in a New Window</source>
-        <translation type="vanished">Otwórz w nowym oknie</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="689"/>
+        <location filename="../ui/mainwindow.ui" line="636"/>
         <source>&amp;Start Recording</source>
         <translation>&amp;Rozpocznij nagrywanie</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="700"/>
+        <location filename="../ui/mainwindow.ui" line="647"/>
         <source>&amp;Stop Recording</source>
         <translation>&amp;Zatrzymaj nagrywanie</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="711"/>
+        <location filename="../ui/mainwindow.ui" line="658"/>
         <source>&amp;Playback</source>
         <translation>&amp;Odtwórz</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="722"/>
+        <location filename="../ui/mainwindow.ui" line="669"/>
         <source>Save Currently Recorded Macro</source>
         <translation>Zapisz bieżące makro</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="730"/>
+        <location filename="../ui/mainwindow.ui" line="677"/>
         <source>Run a Macro Multiple Times...</source>
         <translation>Uruchom makro wielokrotnie...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="738"/>
+        <location filename="../ui/mainwindow.ui" line="685"/>
         <source>Trim Trailing and save</source>
         <translation>Usuń spacje na końcach linii i zapisz</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="743"/>
+        <location filename="../ui/mainwindow.ui" line="690"/>
         <source>Modify Shortcut/Delete Macro...</source>
         <translation>Zmodyfikuj skrót/usuń makro...</translation>
     </message>
     <message>
-        <source>UPPERCASE</source>
-        <translation type="vanished">WIELKIE LITERY</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="751"/>
+        <location filename="../ui/mainwindow.ui" line="698"/>
         <source>Ctrl+Shift+U</source>
         <translation>Ctrl+Shift+U</translation>
     </message>
     <message>
-        <source>lowercase</source>
-        <translation type="vanished">małe litery</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="759"/>
+        <location filename="../ui/mainwindow.ui" line="706"/>
         <source>Ctrl+U</source>
         <translation>Ctrl+U</translation>
     </message>
     <message>
-        <source>Convert to UTF-8</source>
-        <translation type="vanished">Konwertuj na format UTF-8</translation>
-    </message>
-    <message>
-        <source>Convert to UTF-16BE (UCS-2 Big Endian)</source>
-        <translation type="vanished">Konwertuj na format UTF-16BE (UCS-2 Big Endian)</translation>
-    </message>
-    <message>
-        <source>Convert to UTF-16LE (UCS-2 Little Endian)</source>
-        <translation type="vanished">Konwertuj na format UTF-16LE (UCS-2 Little Endian)</translation>
-    </message>
-    <message>
-        <source>Convert to UTF-8 without BOM</source>
-        <translation type="vanished">Konwertuj na format UTF-8 bez BOM</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="784"/>
+        <location filename="../ui/mainwindow.ui" line="731"/>
         <source>&amp;Run...</source>
-        <translation>&amp;Uruchom...</translation>
+        <translation>U&amp;ruchom...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="789"/>
+        <location filename="../ui/mainwindow.ui" line="736"/>
         <source>Launch in Firefox</source>
         <translation>Uruchom w programie Firefox</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="794"/>
+        <location filename="../ui/mainwindow.ui" line="741"/>
         <source>Launch in Chromium</source>
         <translation>Uruchom w programie Chromium</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="799"/>
+        <location filename="../ui/mainwindow.ui" line="746"/>
         <source>Get PHP help</source>
         <translation>Uzyskaj pomoc PHP</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="804"/>
+        <location filename="../ui/mainwindow.ui" line="751"/>
         <source>Google Search</source>
         <translation>Szukaj w Google</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="809"/>
+        <location filename="../ui/mainwindow.ui" line="756"/>
         <source>Wikipedia Search</source>
         <translation>Szukaj w Wikipedii</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="814"/>
+        <location filename="../ui/mainwindow.ui" line="761"/>
         <source>Open file(s)</source>
         <translation>Otwórz plik(i)</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="819"/>
+        <location filename="../ui/mainwindow.ui" line="766"/>
         <source>Open file(s) in a new window</source>
         <translation>Otwórz plik(i) w nowym oknie</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="824"/>
+        <location filename="../ui/mainwindow.ui" line="771"/>
         <source>Modify Shortcut / Delete Command...</source>
         <translation>Zmodyfikuj skrót/Usuń polecenie...</translation>
     </message>
     <message>
-        <source>Preferences...</source>
-        <translation type="vanished">Preferencje...</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="834"/>
+        <location filename="../ui/mainwindow.ui" line="781"/>
         <source>&amp;Find...</source>
         <translation>&amp;Znajdź...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="837"/>
+        <location filename="../ui/mainwindow.ui" line="784"/>
         <source>Ctrl+F</source>
         <translation>Ctrl+F</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="842"/>
+        <location filename="../ui/mainwindow.ui" line="789"/>
         <source>Find &amp;Next</source>
-        <translation>Znajdź &amp;następny </translation>
+        <translation>Znajdź &amp;następny</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="845"/>
+        <location filename="../ui/mainwindow.ui" line="792"/>
         <source>F3</source>
         <translation>F3</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="850"/>
+        <location filename="../ui/mainwindow.ui" line="797"/>
         <source>Find &amp;Previous</source>
         <translation>Znajdź &amp;poprzedni</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="853"/>
+        <location filename="../ui/mainwindow.ui" line="800"/>
         <source>Shift+F3</source>
         <translation>Shift+F3</translation>
     </message>
     <message>
-        <source>Plain text</source>
-        <translation type="vanished">Zwykły tekst</translation>
-    </message>
-    <message>
-        <source>Replace...</source>
-        <translation type="vanished">Zamień...</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="866"/>
+        <location filename="../ui/mainwindow.ui" line="813"/>
         <source>Ctrl+H</source>
         <translation>Ctrl+H</translation>
     </message>
     <message>
-        <source>Reload file interpreted as...</source>
-        <translation type="vanished">Odśwież plik interpretowany jako...</translation>
-    </message>
-    <message>
-        <source>Convert to...</source>
-        <translation type="vanished">Konwertuj na format...</translation>
-    </message>
-    <message>
-        <source>Interpret as UTF-16BE (UCS-2 Big Endian)</source>
-        <translation type="vanished">Interpretuj jako UTF-16BE (UCS-2 Big Endian)</translation>
-    </message>
-    <message>
-        <source>Interpret as UTF-8 without BOM</source>
-        <translation type="vanished">Interpretuj jako UTF-8 bez BOM</translation>
-    </message>
-    <message>
-        <source>Interpret as UTF-8</source>
-        <translation type="vanished">Interpretuj jako UTF-8</translation>
-    </message>
-    <message>
-        <source>Interpret as UTF-16LE (UCS-2 Little Endian)</source>
-        <translation type="vanished">Interpretuj jako UTF-16LE (UCS-2 Little Endian)</translation>
-    </message>
-    <message>
-        <source>Default settings</source>
-        <translation type="vanished">Ustawienia domyślne</translation>
-    </message>
-    <message>
-        <source>Custom...</source>
-        <translation type="vanished">Niestandardowe...</translation>
-    </message>
-    <message>
-        <source>Interpret as...</source>
-        <translation type="vanished">Interpretuj jako...</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="925"/>
+        <location filename="../ui/mainwindow.ui" line="872"/>
         <source>Launch in Chrome</source>
         <translation>Uruchom w programie Chrome</translation>
     </message>
     <message>
-        <source>Open a New Window</source>
-        <translation type="vanished">Otwórz w nowym oknie</translation>
-    </message>
-    <message>
-        <source>Find in Files...</source>
-        <translation type="vanished">Znajdź w plikach...</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="938"/>
+        <location filename="../ui/mainwindow.ui" line="885"/>
         <source>Ctrl+Shift+F</source>
         <translation>Ctrl+Shift+F</translation>
     </message>
     <message>
-        <source>Delete Current Line</source>
-        <translation type="vanished">Usuń bieżącą linię</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="946"/>
+        <location filename="../ui/mainwindow.ui" line="893"/>
         <source>Delete the current line</source>
         <translation>Usuń bieżącą linię</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="949"/>
+        <location filename="../ui/mainwindow.ui" line="896"/>
         <source>Ctrl+L</source>
         <translation>Ctrl+L</translation>
     </message>
     <message>
-        <source>Duplicate Current Line</source>
-        <translation type="vanished">Powiel bieżącą linię</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="957"/>
+        <location filename="../ui/mainwindow.ui" line="904"/>
         <source>Duplicate the current line</source>
         <translation>Powiel bieżącą linię</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="960"/>
+        <location filename="../ui/mainwindow.ui" line="907"/>
         <source>Ctrl+D</source>
         <translation>Ctrl+D</translation>
     </message>
     <message>
-        <source>Move Line Up</source>
-        <translation type="vanished">Przesuń linię do góry</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="968"/>
+        <location filename="../ui/mainwindow.ui" line="915"/>
         <source>Move the current line up</source>
         <translation>Przesuń bieżącą linię do góry</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="971"/>
+        <location filename="../ui/mainwindow.ui" line="918"/>
         <source>Ctrl+Shift+Up</source>
         <translation>Ctrl+Shift+Up</translation>
     </message>
     <message>
-        <source>Move Line Down</source>
-        <translation type="vanished">Przesuń linię do dołu</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="979"/>
+        <location filename="../ui/mainwindow.ui" line="926"/>
         <source>Move the current line down</source>
         <translation>Przesuń bieżącą linię do dołu</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="982"/>
+        <location filename="../ui/mainwindow.ui" line="929"/>
         <source>Ctrl+Shift+Down</source>
         <translation>Ctrl+Shift+Down</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="987"/>
+        <location filename="../ui/mainwindow.ui" line="934"/>
         <source>&amp;Trim Trailing Space</source>
-        <translation>&amp;Usuń spacje na końcach linii</translation>
+        <translation>Usuń spacje &amp;na końcach linii</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="990"/>
+        <location filename="../ui/mainwindow.ui" line="937"/>
         <source>Trim Trailing Space</source>
         <translation>Usuń spacje na końcach linii</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="995"/>
+        <location filename="../ui/mainwindow.ui" line="942"/>
         <source>Trim &amp;Leading Space</source>
-        <translation>Usuń spacje na &amp;początkach linii</translation>
+        <translation>Usuń spacje na początkac&amp;h linii</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="998"/>
+        <location filename="../ui/mainwindow.ui" line="945"/>
         <source>Trim Leading Space</source>
         <translation>Usuń spacje na początkach linii</translation>
     </message>
     <message>
-        <source>Trim Leading and Trailing Space</source>
-        <translation type="vanished">Usuń spacje na początkach i końcach linii</translation>
-    </message>
-    <message>
-        <source>EOL to Space</source>
-        <translation type="vanished">Zamień znak końca linii na spację</translation>
-    </message>
-    <message>
-        <source>TAB to Space</source>
-        <translation type="vanished">Zamień tabulator na spację</translation>
-    </message>
-    <message>
-        <source>Space to TAB (All)</source>
-        <translation type="vanished">Zamień spacje na tabulatory (wszędzie)</translation>
-    </message>
-    <message>
-        <source>Space to TAB (Leading)</source>
-        <translation type="vanished">Zamień spacje na tabulatory (początkowe)</translation>
-    </message>
-    <message>
-        <source>Open Folder...</source>
-        <translation type="vanished">Otwórz katalog...</translation>
-    </message>
-    <message>
-        <source>Go to line...</source>
-        <translation type="vanished">Przejdź do linii...</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="1036"/>
+        <location filename="../ui/mainwindow.ui" line="983"/>
         <source>Ctrl+G</source>
         <translation>Ctrl+G</translation>
     </message>
     <message>
-        <source>Install Extension...</source>
-        <translation type="vanished">Zainstaluj rozszerzenie...</translation>
-    </message>
-    <message>
-        <source>Full Screen</source>
-        <translation type="vanished">Pełny ekran</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="1052"/>
+        <location filename="../ui/mainwindow.ui" line="999"/>
         <source>F11</source>
         <translation>F11</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="1060"/>
+        <location filename="../ui/mainwindow.ui" line="1007"/>
         <source>S&amp;how Spaces</source>
-        <translation>P&amp;okaż spacje</translation>
+        <translation>Pokaż &amp;spacje</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="1063"/>
+        <location filename="../ui/mainwindow.ui" line="1010"/>
         <source>Show Spaces</source>
         <translation>Pokaż spacje</translation>
     </message>
     <message>
-        <source>Enable Smart Indent</source>
-        <translation type="vanished">Włącz inteligentne wcięcie</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.cpp" line="357"/>
-        <location filename="../ui/mainwindow.cpp" line="641"/>
+        <location filename="../ui/mainwindow.cpp" line="695"/>
         <source>INS</source>
         <translation>WSTAW</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="385"/>
+        <location filename="../ui/mainwindow.cpp" line="388"/>
         <source>Error while trying to save this session. Please ensure the following directory is accessible:
 
 </source>
-        <translation>Błąd poczas próby zapisu sesji. Upewnij się, że następujący katalog jest dostępny:</translation>
+        <translation>Błąd poczas próby zapisu sesji. Upewnij się, że następujący katalog jest dostępny:
+
+</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="639"/>
+        <location filename="../ui/mainwindow.cpp" line="390"/>
+        <source>By choosing &quot;ignore&quot; your session won&apos;t be saved.</source>
+        <translation>Wybierając &quot;ignoruj&quot; twoja sesja nie zostanie zapisana.</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="548"/>
+        <source>The &apos;--line&apos; and &apos;--column&apos; arguments will be ignored since more than one file is opened.</source>
+        <translation>Argumenty &apos;--line&apos; i &apos;--column&apos; zostaną zignorowane, gdyż otwarty jest więcej niż jeden plik.</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="558"/>
+        <source>Invalid value for &apos;--line&apos; argument: %1</source>
+        <translation>Nieprawidłowa wartość dla argumentu &apos;--line&apos;: %1</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="567"/>
+        <source>Invalid value for &apos;--column&apos; argument: %1</source>
+        <translation>Nieprawidłowa wartość dla argumentu &apos;--column&apos;: %1</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="693"/>
         <source>OVR</source>
         <translation>NADPIS</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="767"/>
-        <source>Your changes to «%1» will be discarded.</source>
-        <translation>Twoje zmiany do %1 zostaną odrzucone.</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.cpp" line="768"/>
-        <source>Reload</source>
-        <translation>Odśwież</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.cpp" line="806"/>
+        <location filename="../ui/mainwindow.cpp" line="845"/>
         <source>Open</source>
         <translation>Otwórz</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="808"/>
+        <location filename="../ui/mainwindow.cpp" line="847"/>
         <source>All files (*)</source>
         <translation>Wszystkie pliki (*)</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="826"/>
+        <location filename="../ui/mainwindow.cpp" line="869"/>
         <source>Open Folder</source>
         <translation>Otwórz katalog</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="866"/>
-        <source>Do you want to save changes to «%1»?</source>
-        <translation>Czy chcesz zapisać zmiany do «%1»? </translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.cpp" line="867"/>
+        <location filename="../ui/mainwindow.cpp" line="908"/>
         <source>Don&apos;t Save</source>
         <translation>Nie zapisuj</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="870"/>
-        <source>Do you want to save changes to «%1» before closing?</source>
-        <translation>Czy chcesz zapisać zmiany do «%1» przed zamknięciem?</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.cpp" line="874"/>
+        <location filename="../ui/mainwindow.cpp" line="915"/>
         <source>If you don&apos;t save the changes you made, you&apos;ll lose them forever.</source>
         <translation>Jeśli nie zapiszesz dokonanych zmian, to utracisz je na zawsze.</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="974"/>
+        <location filename="../ui/mainwindow.cpp" line="1027"/>
         <source>The file on disk has changed since the last read.
 Do you want to save it anyway?</source>
         <translation>Plik na dysku został zmieniony od ostatniego odczytu.
 Czy chcesz go zapisać mimo to?</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="977"/>
+        <location filename="../ui/mainwindow.cpp" line="1030"/>
         <source>Saving the file might cause loss of external data.</source>
         <translation>Zapisanie pliku może spowodować utratę danych zewnętrznych.</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="996"/>
+        <location filename="../ui/mainwindow.cpp" line="1052"/>
         <source>Save as</source>
         <translation>Zapisz jako</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="998"/>
+        <location filename="../ui/mainwindow.cpp" line="1054"/>
         <source>Any file (*)</source>
         <translation>Wszystkie pliki (*)</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="1170"/>
-        <source>%1 chars, %2 lines</source>
-        <translation>%1 znaków, %2 linii</translation>
+        <location filename="../ui/mainwindow.cpp" line="907"/>
+        <source>Do you want to save changes to Â«%1Â»?</source>
+        <translation>Czy chcesz zapisać zmiany do  Â«%1Â»?</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="1181"/>
-        <source>Ln %1, col %2</source>
-        <translation>Linia %1, Kol %2</translation>
+        <location filename="../ui/mainwindow.cpp" line="911"/>
+        <source>Do you want to save changes to Â«%1Â» before closing?</source>
+        <translation>Czy chcesz zapisać zmiany do Â«%1Â» przed zamknięciem?</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="1185"/>
-        <source>Sel %1 (%2)</source>
-        <translation>Zazn %1 (%2) </translation>
+        <location filename="../ui/mainwindow.cpp" line="1235"/>
+        <source>Ln %1, Col %2</source>
+        <translation>Lin %1, Kol %2</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="1253"/>
+        <location filename="../ui/mainwindow.cpp" line="1236"/>
+        <source>    Sel %1 (%2)</source>
+        <translation>    Zazn %1 (%2)</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="1237"/>
+        <source>    %1 chars, %2 lines</source>
+        <translation>    %1 znaków, %2 linii</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="1375"/>
         <source>Windows</source>
         <translation>Windows</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="1256"/>
+        <location filename="../ui/mainwindow.cpp" line="1378"/>
         <source>UNIX / OS X</source>
         <translation>UNIX / OS X</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="1259"/>
+        <location filename="../ui/mainwindow.cpp" line="1381"/>
         <source>Old Mac</source>
         <translation>Stary MAC</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="1266"/>
+        <location filename="../ui/mainwindow.cpp" line="1388"/>
         <source>%1 w/o BOM</source>
         <translation>%1 bez BOM</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="1742"/>
+        <location filename="../ui/mainwindow.cpp" line="1873"/>
         <source>No recent files</source>
         <translation>Brak ostatnio używanych plików</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="1910"/>
+        <location filename="../ui/mainwindow.cpp" line="1970"/>
+        <source>The following files do not exist anymore. Do you want to open them anyway?
+</source>
+        <translation>Następujące pliki już nie istnieją. Czy chcesz otworzyć je mimo to?
+</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="2081"/>
         <source>Convert to:</source>
         <translation>Konwertuj na format:</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="1924"/>
+        <location filename="../ui/mainwindow.cpp" line="2099"/>
         <source>Reload as:</source>
         <translation>Odśwież jako:</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="1966"/>
+        <location filename="../ui/mainwindow.cpp" line="2146"/>
         <source>Interpret as:</source>
         <translation>Interpretuj jako:</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="1981"/>
+        <location filename="../ui/mainwindow.cpp" line="2161"/>
         <source>Run...</source>
         <translation>Uruchom...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="1993"/>
+        <location filename="../ui/mainwindow.cpp" line="2173"/>
         <source>Modify Run Commands</source>
-        <translation>Zmodyfikuj komendy uruchamiania</translation>
+        <translation>Modyfikuj komendy uruchamiania</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="2273"/>
+        <location filename="../ui/mainwindow.cpp" line="2297"/>
+        <source>The file &quot;%1&quot; does not exist. Do you want to re-create it?</source>
+        <translation>Plik &quot;%1&quot; nie istnieje. Czy chcesz go utworzyć?</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.cpp" line="2466"/>
         <source>Extension</source>
         <translation>Rozszerzenie</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="2318"/>
+        <location filename="../ui/mainwindow.cpp" line="2547"/>
         <source>Open Session...</source>
         <translation>Otwórz sesję...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="2320"/>
-        <location filename="../ui/mainwindow.cpp" line="2340"/>
+        <location filename="../ui/mainwindow.cpp" line="2549"/>
+        <location filename="../ui/mainwindow.cpp" line="2572"/>
         <source>Session file (*.xml);;Any file (*)</source>
         <translation>Plik sesji (*.xml);;Wszystkie pliki (*)</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="2338"/>
+        <location filename="../ui/mainwindow.cpp" line="2570"/>
         <source>Save Session as...</source>
         <translation>Zapisz sesję jako...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.cpp" line="2364"/>
+        <location filename="../ui/mainwindow.cpp" line="2596"/>
         <source>Error while trying to save this session. Please try a different file name.</source>
         <translation>Błąd podczas próby zapisu sesji. Proszę wybrać inną nazwę pliku.</translation>
     </message>
@@ -1545,7 +1561,7 @@ Czy chcesz go zapisać mimo to?</translation>
 <context>
     <name>NqqRun::RunDelegate</name>
     <message>
-        <location filename="../ui/nqqrun.cpp" line="231"/>
+        <location filename="../ui/nqqrun.cpp" line="234"/>
         <source>Open File</source>
         <translation>Otwórz plik</translation>
     </message>
@@ -1553,37 +1569,62 @@ Czy chcesz go zapisać mimo to?</translation>
 <context>
     <name>NqqRun::RunDialog</name>
     <message>
-        <location filename="../ui/nqqrun.cpp" line="263"/>
+        <location filename="../ui/nqqrun.cpp" line="266"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../ui/nqqrun.cpp" line="264"/>
+        <location filename="../ui/nqqrun.cpp" line="267"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../ui/nqqrun.cpp" line="265"/>
+        <location filename="../ui/nqqrun.cpp" line="268"/>
         <source>Save...</source>
         <translation>Zapisz...</translation>
     </message>
     <message>
-        <location filename="../ui/nqqrun.cpp" line="267"/>
-        <source>    &lt;h3&gt;Special placeholders&lt;/h3&gt;&lt;ul&gt;    &lt;li&gt;&lt;em&gt;%fullpath%&lt;/em&gt; - Full path of the currently active file.&lt;/li&gt;    &lt;li&gt;&lt;em&gt;%directory%&lt;/em&gt; - Directory of the currently active file.&lt;/li&gt;    &lt;li&gt;&lt;em&gt;%filename%&lt;/em&gt; - Name of the currently active file.&lt;/li&gt;    &lt;li&gt;&lt;em&gt;%selection%&lt;/em&gt; - Currently selected text.&lt;/li&gt;    &lt;/ul&gt;</source>
-        <translation>    &lt;h3&gt;Specjalne symbole zastępcze&lt;/h3&gt;&lt;ul&gt;    &lt;li&gt;&lt;em&gt;%fullpath%&lt;/em&gt; - Pełna ścieżka do aktualnie aktywnego pliku.&lt;/li&gt;    &lt;li&gt;&lt;em&gt;%directory%&lt;/em&gt; - Katalog aktualnie aktywnego pliku.&lt;/li&gt;    &lt;li&gt;&lt;em&gt;%filename%&lt;/em&gt; - Nazwa aktualnie aktywnego pliku.&lt;/li&gt;    &lt;li&gt;&lt;em&gt;%selection%&lt;/em&gt; - Aktualnie zaznaczony tekst.&lt;/li&gt;    &lt;/ul&gt;</translation>
+        <location filename="../ui/nqqrun.cpp" line="271"/>
+        <source>Special placeholders</source>
+        <translation>Specjalne symbole zastępcze</translation>
     </message>
     <message>
-        <location filename="../ui/nqqrun.cpp" line="312"/>
+        <location filename="../ui/nqqrun.cpp" line="272"/>
+        <source>Full URL of the currently active file.</source>
+        <translation>Pełny URL obecnie aktywnego pliku.</translation>
+    </message>
+    <message>
+        <location filename="../ui/nqqrun.cpp" line="273"/>
+        <source>Full path of the currently active file.</source>
+        <translation>Pełna ścieżka obecnie aktywnego pliku.</translation>
+    </message>
+    <message>
+        <location filename="../ui/nqqrun.cpp" line="274"/>
+        <source>Directory of the currently active file.</source>
+        <translation>Katalog obecnie aktywnego pliku.</translation>
+    </message>
+    <message>
+        <location filename="../ui/nqqrun.cpp" line="275"/>
+        <source>Name of the currently active file.</source>
+        <translation>Nazwa obecnie aktywnego pliku.</translation>
+    </message>
+    <message>
+        <location filename="../ui/nqqrun.cpp" line="276"/>
+        <source>Currently selected text.</source>
+        <translation>Obecnie zaznaczony tekst.</translation>
+    </message>
+    <message>
+        <location filename="../ui/nqqrun.cpp" line="316"/>
         <source>Choose the name to be displayed in the run menu.</source>
         <translation>Wybierz nazwę, która będzie wyświetlana w menu uruchamiania.</translation>
     </message>
     <message>
-        <location filename="../ui/nqqrun.cpp" line="313"/>
+        <location filename="../ui/nqqrun.cpp" line="317"/>
         <source>Command Name:</source>
         <translation>Nazwa polecenia:</translation>
     </message>
     <message>
-        <location filename="../ui/nqqrun.cpp" line="322"/>
+        <location filename="../ui/nqqrun.cpp" line="326"/>
         <source>Command saved...</source>
         <translation>Polecenie zapisane...</translation>
     </message>
@@ -1591,27 +1632,52 @@ Czy chcesz go zapisać mimo to?</translation>
 <context>
     <name>NqqRun::RunPreferences</name>
     <message>
-        <location filename="../ui/nqqrun.cpp" line="26"/>
+        <location filename="../ui/nqqrun.cpp" line="28"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../ui/nqqrun.cpp" line="27"/>
+        <location filename="../ui/nqqrun.cpp" line="29"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../ui/nqqrun.cpp" line="31"/>
-        <source>    &lt;h3&gt;Special placeholders&lt;/h3&gt;&lt;ul&gt;    &lt;li&gt;&lt;em&gt;%fullpath%&lt;/em&gt; - Full path of the currently active file.&lt;/li&gt;    &lt;li&gt;&lt;em&gt;%directory%&lt;/em&gt; - Directory of the currently active file.&lt;/li&gt;    &lt;li&gt;&lt;em&gt;%filename%&lt;/em&gt; - Name of the currently active file.&lt;/li&gt;    &lt;li&gt;&lt;em&gt;%selection%&lt;/em&gt; - Currently selected text.&lt;/li&gt;    &lt;/ul&gt;</source>
-        <translation>    &lt;h3&gt;Specjalne symbole zastępcze&lt;/h3&gt;&lt;ul&gt;    &lt;li&gt;&lt;em&gt;%fullpath%&lt;/em&gt; - Pełna ścieżka do aktualnie aktywnego pliku.&lt;/li&gt;    &lt;li&gt;&lt;em&gt;%directory%&lt;/em&gt; - Katalog aktualnie aktywnego pliku.&lt;/li&gt;    &lt;li&gt;&lt;em&gt;%filename%&lt;/em&gt; - Nazwa aktualnie aktywnego pliku.&lt;/li&gt;    &lt;li&gt;&lt;em&gt;%selection%&lt;/em&gt; - Aktualnie zaznaczony tekst.&lt;/li&gt;    &lt;/ul&gt;</translation>
+        <location filename="../ui/nqqrun.cpp" line="34"/>
+        <source>Special placeholders</source>
+        <translation>Specjalne symbole zastępcze</translation>
     </message>
     <message>
-        <location filename="../ui/nqqrun.cpp" line="67"/>
+        <location filename="../ui/nqqrun.cpp" line="35"/>
+        <source>Full URL of the currently active file.</source>
+        <translation>Pełny URL obecnie aktywnego pliku.</translation>
+    </message>
+    <message>
+        <location filename="../ui/nqqrun.cpp" line="36"/>
+        <source>Full path of the currently active file.</source>
+        <translation>Pełna ścieżka obecnie aktywnego pliku.</translation>
+    </message>
+    <message>
+        <location filename="../ui/nqqrun.cpp" line="37"/>
+        <source>Directory of the currently active file.</source>
+        <translation>Katalog obecnie aktywnego pliku.</translation>
+    </message>
+    <message>
+        <location filename="../ui/nqqrun.cpp" line="38"/>
+        <source>Name of the currently active file.</source>
+        <translation>Nazwa obecnie aktywnego pliku.</translation>
+    </message>
+    <message>
+        <location filename="../ui/nqqrun.cpp" line="39"/>
+        <source>Currently selected text.</source>
+        <translation>Obecnie zaznaczony tekst.</translation>
+    </message>
+    <message>
+        <location filename="../ui/nqqrun.cpp" line="70"/>
         <source>Text</source>
         <translation>Tekst</translation>
     </message>
     <message>
-        <location filename="../ui/nqqrun.cpp" line="67"/>
+        <location filename="../ui/nqqrun.cpp" line="70"/>
         <source>Command</source>
         <translation>Polecenie</translation>
     </message>
@@ -1619,75 +1685,237 @@ Czy chcesz go zapisać mimo to?</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../ui/frmpreferences.cpp" line="429"/>
+        <location filename="../ui/frmpreferences.cpp" line="497"/>
         <source>Restart required</source>
         <translation>Wymagany restart</translation>
     </message>
     <message>
-        <location filename="../ui/frmpreferences.cpp" line="430"/>
+        <location filename="../ui/frmpreferences.cpp" line="498"/>
         <source>You need to restart Notepadqq for the localization changes to take effect.</source>
         <translation>Musisz zrestartować Notepadqq, by były widoczne efekty zmiany lokalizacji.</translation>
     </message>
     <message>
-        <location filename="../ui/notepadqq.cpp" line="17"/>
+        <location filename="../ui/notepadqq.cpp" line="18"/>
         <source>Copyright © 2010-%1, Daniele Di Sarli</source>
         <translation>Copyright © 2010-%1, Daniele Di Sarli</translation>
     </message>
     <message>
-        <location filename="../ui/notepadqq.cpp" line="86"/>
+        <location filename="../ui/notepadqq.cpp" line="87"/>
         <source>Open a new window in an existing instance of %1.</source>
         <translation>Otwórz nowe okno w istniejącej instancji %1.</translation>
     </message>
     <message>
-        <location filename="../ui/notepadqq.cpp" line="91"/>
+        <location filename="../ui/notepadqq.cpp" line="92"/>
+        <source>Open file at specified line.</source>
+        <translation>Otwórz plik na wybranej linii.</translation>
+    </message>
+    <message>
+        <location filename="../ui/notepadqq.cpp" line="98"/>
+        <source>Open file at specified column.</source>
+        <translation>Otwórz plik na wybranej kolumnie.</translation>
+    </message>
+    <message>
+        <location filename="../ui/notepadqq.cpp" line="103"/>
+        <source>Allows Notepadqq to be run as root.</source>
+        <translation>Pozwala Notepadqq być uruchomionym jako root.</translation>
+    </message>
+    <message>
+        <location filename="../ui/notepadqq.cpp" line="107"/>
         <source>Files to open.</source>
         <translation>Pliki do otwarcia.</translation>
     </message>
     <message>
-        <location filename="../ui/notepadqq.cpp" line="118"/>
-        <source>You are using an old version of Qt (%1)</source>
-        <translation>Korzystasz ze starej wersji Qt (%1)</translation>
-    </message>
-    <message>
-        <location filename="../ui/notepadqq.cpp" line="120"/>
-        <source>Notepadqq will try to do its best, but &lt;b&gt;some things will not work properly&lt;/b&gt;.</source>
-        <translation>Notepadqq zrobi co w jego mocy, ale &lt;b&gt;niektóre rzeczy mogą nie działać poprawnie&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <location filename="../ui/notepadqq.cpp" line="121"/>
-        <source>Install a newer Qt version (&amp;ge; %1) from the official repositories of your distribution.&lt;br&gt;&lt;br&gt;If it&apos;s not available, download Qt (&amp;ge; %1) from %2 and install it to &quot;%3&quot; or to &quot;%4&quot;.</source>
-        <translation>Zainstaluj nowszą wersję Qt (&amp;ge; %1) z oficjalnych repozytoriów twojej dystrybucji.&lt;br&gt;&lt;br&gt;Jeśli nie jest dostępna, to pobierz Qt (&amp;ge; %1) z %2 i zainstaluj do &quot;%3&quot; lub do &quot;%4&quot;.</translation>
-    </message>
-    <message>
-        <location filename="../ui/notepadqq.cpp" line="135"/>
-        <source>Don&apos;t show me this warning again</source>
-        <translation>Nie pokazuj tego ostrzeżenia ponownie </translation>
-    </message>
-    <message>
-        <location filename="../ui/Sessions/sessions.cpp" line="127"/>
+        <location filename="../ui/Sessions/sessions.cpp" line="130"/>
         <source>Error reading session file</source>
         <translation>Błąd podczas odczytu pliku sesji</translation>
     </message>
-</context>
-<context>
-    <name>ReplaceInFilesWorker</name>
     <message>
-        <location filename="../ui/Search/replaceinfilesworker.cpp" line="40"/>
-        <source>Error reading %1</source>
-        <translation>Błąd podczas odczytu %1</translation>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="51"/>
+        <source>Confirm Replacement</source>
+        <translation>Potwierdź zamianę</translation>
     </message>
     <message>
-        <location filename="../ui/Search/replaceinfilesworker.cpp" line="84"/>
-        <source>Error writing %1</source>
-        <translation>Błąd podczas zapisu %1</translation>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="52"/>
+        <source>This will replace %1 selected matches with &quot;%2&quot;. Continue?</source>
+        <translation>%1 zaznaczonych dopasowań zostanie zastąpionych przez &quot;%2&quot;. Kontynuować?</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="143"/>
+        <source>Notepadqq supports most of the &lt;a href=&apos;http://perldoc.perl.org/perlre.html&apos;&gt;Perl Regular Expression&lt;/a&gt; syntax when &apos;Use Regular Expressions&apos; is checked.</source>
+        <translation>Notepadqq wspiera większość składni &lt;a href=&apos;http://perldoc.perl.org/perlre.html&apos;&gt;wyrażeń regularnych Perla&lt;/a&gt; kiedy &apos;Użyj wyrażeń regularnych&apos; jest zaznaczone.</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="144"/>
+        <source>Here is a quick reference:</source>
+        <translation>Oto krótkie wyjaśnienie:</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="146"/>
+        <source>Matches a word character</source>
+        <translation>Dopasowuje znak wyrazu</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="147"/>
+        <source>Matches a 0-9 digit</source>
+        <translation>Dopasowuje cyfrę 0-9</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="148"/>
+        <source>Matches any of a, b, or c</source>
+        <translation>Dopasowuje a, b lub c</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="149"/>
+        <source>Matches anything but a, b, or c</source>
+        <translation>Dopasowuje wszystko oprócz a, b czy c</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="150"/>
+        <source>Matches the beginning of a line</source>
+        <translation>Dopasowuje początek linii</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="151"/>
+        <source>Matches the end of a line</source>
+        <translation>Dopasowuje koniec linii</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="152"/>
+        <source>Matches &apos;abc&apos; and captures it as a group</source>
+        <translation>Dopasowuje &apos;abc&apos; i zapisuje to jako grupę</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="153"/>
+        <source>Use in a replace operation to refer to the n&apos;th capture group</source>
+        <translation>Używane w operacji zamiany jako odwołanie do n-tej zapisanej grupy</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/advancedsearchdock.cpp" line="706"/>
+        <source>Search in...</source>
+        <translation>Szukaj w...</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/searchinstance.cpp" line="27"/>
+        <source>&lt;b&gt;%1&lt;/b&gt; Results for:   &apos;&lt;b&gt;%2&lt;/b&gt;&apos;</source>
+        <translation>&lt;b&gt;%1&lt;/b&gt; Wyniki dla:   &apos;&lt;b&gt;%2&lt;/b&gt;&apos;</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/searchobjects.cpp" line="10"/>
+        <source>Current Document</source>
+        <translation>Bieżący dokument</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/searchobjects.cpp" line="11"/>
+        <source>All Documents</source>
+        <translation>Wszystkie dokumenty</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/searchobjects.cpp" line="12"/>
+        <source>File System</source>
+        <translation>System plików</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/searchobjects.cpp" line="13"/>
+        <source>Invalid</source>
+        <translation>Nieprawidłowy</translation>
+    </message>
+    <message>
+        <location filename="../ui/Sessions/backupservice.cpp" line="107"/>
+        <source>Notepadqq was not closed properly. Do you want to recover unsaved changes?</source>
+        <translation>Notepadqq nie został zamknięty poprawnie. Czy chcesz odzyskać niezapisane zmiany?</translation>
+    </message>
+    <message>
+        <location filename="../ui/docengine.cpp" line="111"/>
+        <source>The file &quot;%1&quot; you are trying to open is %2 MiB in size. Do you want to continue?</source>
+        <translation>Plik &quot;%1&quot;, który chcesz otworzyć ma %2 MiB wielkości. Czy chcesz kontynuować?</translation>
+    </message>
+    <message>
+        <location filename="../ui/docengine.cpp" line="125"/>
+        <source>Do you want to reload Â«%1Â»?</source>
+        <translation>Chcesz załadować ponownie Â«%1Â»?</translation>
+    </message>
+    <message>
+        <location filename="../ui/docengine.cpp" line="126"/>
+        <source>Any changes made by you to this document will be lost.</source>
+        <translation>Jakiekolwiek zmiany w tym dokumencie zostaną utracone.</translation>
+    </message>
+    <message>
+        <location filename="../ui/main.cpp" line="92"/>
+        <source>Notepadqq will ask for root privileges whenever they are needed if either &apos;kdesu&apos; or &apos;gksu&apos; are installed. Running Notepadqq as root is not recommended. Use --allow-root if you really want to.</source>
+        <translation>Notepadqq poprosi o uprawnienia roota, jeśli będą potrzebne i jeśli zainstalowano &apos;kdesu&apos; lub &apos;gksu&apos;. Używanie Notepadqq jako root nie jest wskazane. Użyj &apos;--allow-root&apos; jeśli naprawdę tego chcesz.</translation>
+    </message>
+    <message>
+        <location filename="../ui/stats.cpp" line="126"/>
+        <source>Do you want to help?</source>
+        <translation>Chcesz pomóc?</translation>
+    </message>
+    <message>
+        <location filename="../ui/stats.cpp" line="128"/>
+        <source>You can help to improve Notepadqq by allowing us to collect &lt;b&gt;anonymous statistics&lt;/b&gt;.</source>
+        <translation>Możesz pomóc poprawić Notepadqq pozwalając nam zebrać &lt;b&gt;anonimowe statystyki&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../ui/stats.cpp" line="129"/>
+        <source>What will we collect?</source>
+        <translation>Co będziemy zbierać?</translation>
+    </message>
+    <message>
+        <location filename="../ui/stats.cpp" line="130"/>
+        <source>We will collect information such as the version of Qt, the version of the OS, or the number of extensions.&lt;br&gt;You don&apos;t have to trust us: Notepadqq is open source, so you can %1check by yourself%2 :)</source>
+        <translation>Zbierzemy takie informacje jak wersja Qt, wersja systemu operacyjnego czy liczbę rozszerzeń.&lt;br&gt;Nie musisz nam ufać: Notepadqq jest open source, więc możesz %1sprawdzić sam%2 :)</translation>
+    </message>
+    <message>
+        <location filename="../ui/stats.cpp" line="137"/>
+        <source>Okay, I agree</source>
+        <translation>Zgadzam się</translation>
+    </message>
+    <message>
+        <location filename="../ui/stats.cpp" line="138"/>
+        <source>No</source>
+        <translation>Nie</translation>
     </message>
 </context>
 <context>
-    <name>SearchInFilesWorker</name>
+    <name>SearchInstance</name>
     <message>
-        <location filename="../ui/Search/searchinfilesworker.cpp" line="66"/>
-        <source>Error reading %1</source>
-        <translation>Błąd podczas zapisu %1</translation>
+        <location filename="../ui/Search/searchinstance.cpp" line="115"/>
+        <source>current document</source>
+        <translation>bieżący dokument</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/searchinstance.cpp" line="117"/>
+        <source>open documents</source>
+        <translation>otwarte dokumenty</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/searchinstance.cpp" line="125"/>
+        <source>Copy Line to Clipboard</source>
+        <translation>Skopiuj linię do schowka</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/searchinstance.cpp" line="133"/>
+        <source>Open Document</source>
+        <translation>Otwórz dokument</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/searchinstance.cpp" line="142"/>
+        <source>Open Folder in File Browser</source>
+        <translation>Otwórz folder w wyszukiwarce plików</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/searchinstance.cpp" line="155"/>
+        <source>Search Results in: %1</source>
+        <translation>Szukaj wyników w: %1</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/searchinstance.cpp" line="231"/>
+        <source>Calculating...</source>
+        <translation>Obliczanie...</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/searchinstance.cpp" line="388"/>
+        <source>Search in progress [%1/%2 finished]</source>
+        <translation>Wyszukiwanie w trakcie [ukończono %1/%2]</translation>
     </message>
 </context>
 <context>
@@ -1706,27 +1934,27 @@ Czy chcesz go zapisać mimo to?</translation>
 <context>
     <name>frmAbout</name>
     <message>
-        <location filename="../ui/frmabout.ui" line="17"/>
+        <location filename="../ui/frmabout.ui" line="20"/>
         <source>Notepadqq</source>
         <translation>Notepadqq</translation>
     </message>
     <message>
-        <location filename="../ui/frmabout.ui" line="39"/>
+        <location filename="../ui/frmabout.ui" line="42"/>
         <source>Close</source>
         <translation>Zamknij</translation>
     </message>
     <message>
-        <location filename="../ui/frmabout.ui" line="108"/>
+        <location filename="../ui/frmabout.ui" line="114"/>
         <source>License</source>
         <translation>Licencja</translation>
     </message>
     <message>
-        <location filename="../ui/frmabout.cpp" line="23"/>
+        <location filename="../ui/frmabout.cpp" line="25"/>
         <source>Contributors:</source>
         <translation>Współtwórcy:</translation>
     </message>
     <message>
-        <location filename="../ui/frmabout.cpp" line="23"/>
+        <location filename="../ui/frmabout.cpp" line="25"/>
         <source>GitHub Contributors</source>
         <translation>Współtwórcy z GitHuba</translation>
     </message>
@@ -1820,124 +2048,194 @@ Czy chcesz go zapisać mimo to?</translation>
     </message>
     <message>
         <location filename="../ui/frmpreferences.ui" line="81"/>
+        <source>Toolbar</source>
+        <translation>Pasek narzędzi</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="86"/>
         <source>Extensions</source>
         <translation>Rozszerzenia</translation>
     </message>
     <message>
-        <location filename="../ui/frmpreferences.ui" line="105"/>
-        <source>Check Qt version at startup</source>
-        <translation>Sprawdzaj wersję Qt przy starcie</translation>
+        <location filename="../ui/frmpreferences.ui" line="110"/>
+        <source>Collect and transmit anonymous statistics to improve Notepadqq</source>
+        <translation>Zbieraj i przesyłaj anonimowe statystyki w celu poprawy Notepadqq</translation>
     </message>
     <message>
-        <location filename="../ui/frmpreferences.ui" line="112"/>
+        <location filename="../ui/frmpreferences.ui" line="117"/>
         <source>Warn when the indentation doesn&apos;t match the settings</source>
         <translation>Ostrzegaj, gdy wcięcie nie pasuje do ustawień</translation>
     </message>
     <message>
-        <location filename="../ui/frmpreferences.ui" line="119"/>
+        <location filename="../ui/frmpreferences.ui" line="124"/>
         <source>Remember open tabs when closing Notepadqq</source>
         <translation>Pamiętaj otwierane karty przy zamykaniu Notepadqq</translation>
     </message>
     <message>
-        <location filename="../ui/frmpreferences.ui" line="128"/>
+        <location filename="../ui/frmpreferences.ui" line="133"/>
+        <source>This option allows Notepadqq to recover your documents after a crash even if they were not explicitely saved.</source>
+        <translation>Ta opcja pozwala Notepadqq na odzyskanie dokumentów po awarii, nawet jeśli nie zostały zapisane.</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="136"/>
+        <source>Backup open documents every</source>
+        <translation>Rób kopie zapasowe otwartych dokumentów co</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="143"/>
+        <source> seconds</source>
+        <translation> sekund</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="171"/>
+        <source>Exit Notepadqq when closing the last Tab</source>
+        <translation>Zamknij Notepadqq po zamknięciu ostatniej karty</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="180"/>
         <source>Localization:</source>
         <translation>Lokalizacja:</translation>
     </message>
     <message>
-        <location filename="../ui/frmpreferences.ui" line="185"/>
+        <location filename="../ui/frmpreferences.ui" line="237"/>
         <source>Color scheme:</source>
         <translation>Schemat kolorów:</translation>
     </message>
     <message>
-        <location filename="../ui/frmpreferences.ui" line="217"/>
+        <location filename="../ui/frmpreferences.ui" line="269"/>
         <source>Override Font Family</source>
         <translation>Zmień rodzinę czcionki</translation>
     </message>
     <message>
-        <location filename="../ui/frmpreferences.ui" line="240"/>
+        <location filename="../ui/frmpreferences.ui" line="292"/>
         <source>Override Font Size</source>
         <translation>Zmień rozmiar czcionki</translation>
     </message>
     <message>
-        <location filename="../ui/frmpreferences.ui" line="269"/>
+        <location filename="../ui/frmpreferences.ui" line="321"/>
         <source>Override Line Height</source>
         <translation>Zmień wysokość wiersza</translation>
     </message>
     <message>
-        <location filename="../ui/frmpreferences.ui" line="285"/>
+        <location filename="../ui/frmpreferences.ui" line="337"/>
         <source>em</source>
         <translation>em</translation>
     </message>
     <message>
-        <location filename="../ui/frmpreferences.ui" line="306"/>
+        <location filename="../ui/frmpreferences.ui" line="358"/>
         <source>Preview</source>
         <translation>Podgląd</translation>
     </message>
     <message>
-        <location filename="../ui/frmpreferences.ui" line="389"/>
+        <location filename="../ui/frmpreferences.ui" line="441"/>
         <source>Tab size:</source>
         <translation>Wielkość tabulatora:</translation>
     </message>
     <message>
-        <location filename="../ui/frmpreferences.ui" line="402"/>
+        <location filename="../ui/frmpreferences.ui" line="454"/>
         <source>Use spaces instead of tabs</source>
         <translation>Używaj spacji zamiast tabulatorów</translation>
     </message>
     <message>
-        <location filename="../ui/frmpreferences.ui" line="426"/>
+        <location filename="../ui/frmpreferences.ui" line="478"/>
         <source>Use default settings</source>
         <translation>Używaj domyślnych ustawień</translation>
     </message>
     <message>
-        <location filename="../ui/frmpreferences.ui" line="462"/>
+        <location filename="../ui/frmpreferences.ui" line="514"/>
         <source>Search as I type</source>
         <translation>Wyszukuj, gdy piszę</translation>
     </message>
     <message>
-        <location filename="../ui/frmpreferences.ui" line="517"/>
+        <location filename="../ui/frmpreferences.ui" line="521"/>
+        <source>Save search history</source>
+        <translation>Zapisz historię wyszukiwania</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="569"/>
+        <source>Add</source>
+        <translation>Dodaj</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="580"/>
+        <source>Remove</source>
+        <translation>Usuń</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="609"/>
+        <source>Move Up</source>
+        <translation>Przesuń w górę</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="620"/>
+        <source>Move Down</source>
+        <translation>Przesuń w dół</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="650"/>
+        <source>Reset to Default</source>
+        <translation>Ustaw domyślne</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.ui" line="697"/>
         <source>Node.js runtime</source>
         <translation>Środowisko uruchomieniowe Node.js</translation>
     </message>
     <message>
-        <location filename="../ui/frmpreferences.ui" line="523"/>
+        <location filename="../ui/frmpreferences.ui" line="703"/>
         <source>Supported Node versions: 0.10, 0.11, 0.12</source>
         <translation>Wspierane wersje Node: 0.10, 0.11, 0.12</translation>
     </message>
     <message>
-        <location filename="../ui/frmpreferences.ui" line="530"/>
+        <location filename="../ui/frmpreferences.ui" line="710"/>
         <source>Node.js path:</source>
         <translation>Ścieżka do Node.js:</translation>
     </message>
     <message>
-        <location filename="../ui/frmpreferences.ui" line="542"/>
-        <location filename="../ui/frmpreferences.ui" line="563"/>
+        <location filename="../ui/frmpreferences.ui" line="722"/>
+        <location filename="../ui/frmpreferences.ui" line="743"/>
         <source>Browse...</source>
         <translation>Przeglądaj...</translation>
     </message>
     <message>
-        <location filename="../ui/frmpreferences.ui" line="551"/>
+        <location filename="../ui/frmpreferences.ui" line="731"/>
         <source>NPM path:</source>
         <translation>Ścieżka do NPM:</translation>
     </message>
     <message>
-        <location filename="../ui/frmpreferences.ui" line="572"/>
+        <location filename="../ui/frmpreferences.ui" line="752"/>
         <source>WARNING: support for extensions is EXPERIMENTAL.</source>
         <translation>UWAGA: wsparcie dla rozszerzeń jest EKSPERYMENTALNE.</translation>
     </message>
     <message>
-        <location filename="../ui/frmpreferences.cpp" line="324"/>
+        <location filename="../ui/frmpreferences.cpp" line="277"/>
+        <source>Reset Selected</source>
+        <translation>Zresetuj zaznaczone</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.cpp" line="278"/>
+        <source>Reset All</source>
+        <translation>Zresetuj wszystkie</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.cpp" line="375"/>
         <source>Keyboard shortcut conflict</source>
         <translation>Konflikt skrótu klawiaturowego</translation>
     </message>
     <message>
-        <location filename="../ui/frmpreferences.cpp" line="325"/>
+        <location filename="../ui/frmpreferences.cpp" line="376"/>
         <source>Two or more actions share the same shortcut. These conflicts must be resolved before your changes can be saved.</source>
         <translation>Ten sam skrót klawiaturowy jest przypisany do dwóch lub więcej akcji. Te konflikty muszą być rozwiązane przed zapisaniem zmian.</translation>
     </message>
     <message>
-        <location filename="../ui/frmpreferences.cpp" line="436"/>
+        <location filename="../ui/frmpreferences.cpp" line="504"/>
         <source>Browse</source>
         <translation>Przeglądaj</translation>
+    </message>
+    <message>
+        <location filename="../ui/frmpreferences.cpp" line="590"/>
+        <source>Would you like to clear the existing history now?</source>
+        <translation>Czy chciałbyś teraz wyczyścić historię?</translation>
     </message>
 </context>
 <context>
@@ -1958,175 +2256,100 @@ Czy chcesz go zapisać mimo to?</translation>
         <translation>Zamień na</translation>
     </message>
     <message>
-        <location filename="../ui/Search/frmsearchreplace.ui" line="76"/>
-        <location filename="../ui/Search/frmsearchreplace.cpp" line="572"/>
-        <source>Look in</source>
-        <translation>Szukaj w</translation>
-    </message>
-    <message>
-        <location filename="../ui/Search/frmsearchreplace.ui" line="89"/>
-        <source>Filter</source>
-        <translation>Filtruj</translation>
-    </message>
-    <message>
-        <location filename="../ui/Search/frmsearchreplace.ui" line="150"/>
-        <source>...</source>
-        <translation>...</translation>
-    </message>
-    <message>
-        <location filename="../ui/Search/frmsearchreplace.ui" line="195"/>
-        <source>Include subdirectories</source>
-        <translation>Uwzględnij podkatalogi</translation>
-    </message>
-    <message>
-        <location filename="../ui/Search/frmsearchreplace.ui" line="202"/>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="110"/>
         <source>Show advanced options</source>
         <translation>Pokaż opcje zaawansowane</translation>
     </message>
     <message>
-        <location filename="../ui/Search/frmsearchreplace.ui" line="209"/>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="117"/>
         <source>Advanced</source>
         <translation>Zaawansowane</translation>
     </message>
     <message>
-        <location filename="../ui/Search/frmsearchreplace.ui" line="215"/>
-        <source>Search plain text</source>
-        <translation>Wyszukiwanie zwykłego tekstu</translation>
-    </message>
-    <message>
-        <location filename="../ui/Search/frmsearchreplace.ui" line="241"/>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="149"/>
         <source>Match whole word only</source>
-        <translation>Znajdź tylko całe wyrazy </translation>
+        <translation>Dopasuj tylko całe wyrazy</translation>
     </message>
     <message>
-        <location filename="../ui/Search/frmsearchreplace.ui" line="248"/>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="156"/>
         <source>Match case</source>
         <translation>Uwzględnij wielkość liter</translation>
     </message>
     <message>
-        <location filename="../ui/Search/frmsearchreplace.ui" line="255"/>
-        <source>Search with special characters (\n, \r, \t, \0, \u..., \x...)</source>
-        <translation>Wyszukiwanie ze znakami specjalnymi (\n, \r, \t, \0, \u..., \x...)</translation>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="123"/>
+        <source>Search &amp;plain text</source>
+        <translation>Szukaj &amp;zwykłego tekstu</translation>
     </message>
     <message>
-        <location filename="../ui/Search/frmsearchreplace.ui" line="262"/>
-        <source>Search with regular expressions</source>
-        <translation>Wyszukiwanie z wyrażeniami regularnymi</translation>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="163"/>
+        <source>Search &amp;with special characters (\n, \r, \t, \0, \u..., \x...)</source>
+        <translation>Szukaj &amp;ze specjalnymi znakami (\n, \r, \t, \0, \u..., \x...)</translation>
     </message>
     <message>
-        <location filename="../ui/Search/frmsearchreplace.ui" line="290"/>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="170"/>
+        <source>Search with &amp;regular expressions</source>
+        <translation>Szukaj z &amp;wyrażeniami regularnymi</translation>
+    </message>
+    <message>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="198"/>
         <source>Find ⇩</source>
         <translation>Znajdź ⇩</translation>
     </message>
     <message>
-        <location filename="../ui/Search/frmsearchreplace.ui" line="300"/>
-        <location filename="../ui/Search/frmsearchreplace.cpp" line="432"/>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="208"/>
+        <location filename="../ui/Search/frmsearchreplace.cpp" line="290"/>
         <source>Select all</source>
         <translation>Zaznacz wszystko</translation>
     </message>
     <message>
-        <location filename="../ui/Search/frmsearchreplace.ui" line="310"/>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="218"/>
         <source>Replace ⇧</source>
         <translation>Zamień ⇧</translation>
     </message>
     <message>
-        <location filename="../ui/Search/frmsearchreplace.ui" line="320"/>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="228"/>
         <source>Replace ⇩</source>
         <translation>Zamień ⇩</translation>
     </message>
     <message>
-        <location filename="../ui/Search/frmsearchreplace.ui" line="330"/>
-        <location filename="../ui/Search/frmsearchreplace.ui" line="383"/>
-        <location filename="../ui/Search/frmsearchreplace.cpp" line="420"/>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="238"/>
+        <location filename="../ui/Search/frmsearchreplace.cpp" line="278"/>
         <source>Replace all</source>
         <translation>Zamień wszystko</translation>
     </message>
     <message>
-        <location filename="../ui/Search/frmsearchreplace.ui" line="347"/>
-        <source>Find all</source>
-        <translation>Znajdź wszystko</translation>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="334"/>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="337"/>
+        <source>Advanced Search</source>
+        <translation>Wyszukiwanie zaawansowane</translation>
     </message>
     <message>
-        <location filename="../ui/Search/frmsearchreplace.ui" line="357"/>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="255"/>
         <source>Find ⇧</source>
         <translation>Znajdź ⇧</translation>
     </message>
     <message>
-        <location filename="../ui/Search/frmsearchreplace.ui" line="396"/>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="284"/>
         <source>Toolbar</source>
         <translation>Pasek narzędzi</translation>
     </message>
     <message>
-        <location filename="../ui/Search/frmsearchreplace.ui" line="430"/>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="318"/>
         <source>&amp;Replace</source>
         <translation>&amp;Zamień</translation>
     </message>
     <message>
-        <location filename="../ui/Search/frmsearchreplace.ui" line="438"/>
+        <location filename="../ui/Search/frmsearchreplace.ui" line="326"/>
         <source>&amp;Find</source>
         <translation>&amp;Znajdź</translation>
     </message>
     <message>
-        <location filename="../ui/Search/frmsearchreplace.ui" line="446"/>
-        <location filename="../ui/Search/frmsearchreplace.ui" line="449"/>
-        <source>Find in files</source>
-        <translation>Znajdź w plikach</translation>
-    </message>
-    <message>
-        <location filename="../ui/Search/frmsearchreplace.cpp" line="306"/>
-        <source>Searching...</source>
-        <translation>Wyszukiwanie...</translation>
-    </message>
-    <message>
-        <location filename="../ui/Search/frmsearchreplace.cpp" line="214"/>
-        <location filename="../ui/Search/frmsearchreplace.cpp" line="244"/>
-        <source>Error</source>
-        <translation>Błąd</translation>
-    </message>
-    <message>
-        <location filename="../ui/Search/frmsearchreplace.cpp" line="232"/>
-        <location filename="../ui/Search/frmsearchreplace.cpp" line="236"/>
-        <location filename="../ui/Search/frmsearchreplace.cpp" line="285"/>
-        <source>Replace in files</source>
-        <translation>Zamień w plikach</translation>
-    </message>
-    <message>
-        <location filename="../ui/Search/frmsearchreplace.cpp" line="286"/>
-        <source>Are you sure you want to replace all occurrences in %1 for file types %2?</source>
-        <translation>Czy jesteś pewny(a), że chcesz zamienić wszystkie wystąpienia w %1 dla typów plików %2? </translation>
-    </message>
-    <message>
-        <location filename="../ui/Search/frmsearchreplace.cpp" line="266"/>
-        <source>Replacing...</source>
-        <translation>Zamienianie...</translation>
-    </message>
-    <message>
-        <location filename="../ui/Search/frmsearchreplace.cpp" line="233"/>
-        <source>%1 occurrences replaced in %2 files.</source>
-        <translation>%1 wystąpień zamienionych w %2 plikach.</translation>
-    </message>
-    <message>
-        <location filename="../ui/Search/frmsearchreplace.cpp" line="237"/>
-        <source>%1 occurrences replaced in %2 files, but the replacement has been canceled before it could finish.</source>
-        <translation>%1 wystąpień zamienionych w %2 plikach, ale zamiana została anulowana przed jej ukończeniem.</translation>
-    </message>
-    <message>
-        <location filename="../ui/Search/frmsearchreplace.cpp" line="253"/>
-        <source>Replacing in </source>
-        <translation>Zamienianie w</translation>
-    </message>
-    <message>
-        <location filename="../ui/Search/frmsearchreplace.cpp" line="255"/>
-        <source>Searching in </source>
-        <translation>Wyszukiwanie w</translation>
-    </message>
-    <message>
-        <location filename="../ui/Search/frmsearchreplace.cpp" line="420"/>
+        <location filename="../ui/Search/frmsearchreplace.cpp" line="278"/>
         <source>%1 occurrences have been replaced.</source>
         <translation>%1 wystąpień zostało zamienionych.</translation>
     </message>
     <message>
-        <location filename="../ui/Search/frmsearchreplace.cpp" line="432"/>
+        <location filename="../ui/Search/frmsearchreplace.cpp" line="290"/>
         <source>No results found</source>
         <translation>Brak wyników</translation>
     </message>


### PR DESCRIPTION
Updated Polish translation file after running `lupdate -no-obsolete src/ui/ui.pro -ts src/translations/notepadqq_pl.ts` in forked repo as suggested [here](https://github.com/notepadqq/notepadqq/wiki/Translate-Notepadqq).

Please do not merge yet.

I didn't know what to do with phrases with `&` (in MainWindow), that can be triggered with a shortcut `ALT+<letter>`. Should I make it so the shortcuts in translation are the same as in the original text? Or should I just pick whatever I think suiting (1st/2nd letters mostly) but so the shortcuts are not duplicated?
In case of $1, what should I do if my translation doesn't have the letter necessary? E.g. for "&File" the translation is "&Plik" which doesn't have 'f'.
In case of $2, can the letters duplicate but in different submenus? So can I make one shortcut with letter 'p' in "File" menu and also one in "Edit" menu?

I'll update this PR after I know what to do.