### PR TITLE
Fixed a typo in a few files

### DIFF
--- a/src/translations/notepadqq_de.ts
+++ b/src/translations/notepadqq_de.ts
@@ -2081,7 +2081,7 @@ Wollen Sie dennoch speichern?</translation>
     </message>
     <message>
         <location filename="../ui/frmpreferences.ui" line="140"/>
-        <source>This option allows Notepadqq to recover your documents after a crash even if they were not explicitely saved.</source>
+        <source>This option allows Notepadqq to recover your documents after a crash even if they were not explicitly saved.</source>
         <translation>Hilft dabei Dokumente nach einem Absturz wieder herzustellen, auch ohne diese vorher explizit zu sichern.</translation>
     </message>
     <message>

--- a/src/translations/notepadqq_hu.ts
+++ b/src/translations/notepadqq_hu.ts
@@ -2075,7 +2075,7 @@ A Notepadqq rootként való futtatása nem ajánlott. Ha mindenképpen szükség
     </message>
     <message>
         <location filename="../ui/frmpreferences.ui" line="133"/>
-        <source>This option allows Notepadqq to recover your documents after a crash even if they were not explicitely saved.</source>
+        <source>This option allows Notepadqq to recover your documents after a crash even if they were not explicitly saved.</source>
         <translation>Ez az opció lehetővé teszi a Notepadqq számára, hogy egy összeomlást követően helyreállítsa a dokumentumokat, még akkor is, ha azok nem lettek elmentetve.</translation>
     </message>
     <message>

--- a/src/translations/notepadqq_pl.ts
+++ b/src/translations/notepadqq_pl.ts
@@ -2073,7 +2073,7 @@ Czy chcesz go zapisać mimo to?</translation>
     </message>
     <message>
         <location filename="../ui/frmpreferences.ui" line="133"/>
-        <source>This option allows Notepadqq to recover your documents after a crash even if they were not explicitely saved.</source>
+        <source>This option allows Notepadqq to recover your documents after a crash even if they were not explicitly saved.</source>
         <translation>Ta opcja pozwala Notepadqq na odzyskanie dokumentów po awarii, nawet jeśli nie zostały zapisane.</translation>
     </message>
     <message>

--- a/src/translations/notepadqq_uk.ts
+++ b/src/translations/notepadqq_uk.ts
@@ -2079,7 +2079,7 @@ Do you want to save it anyway?</source>
     </message>
     <message>
         <location filename="../ui/frmpreferences.ui" line="140"/>
-        <source>This option allows Notepadqq to recover your documents after a crash even if they were not explicitely saved.</source>
+        <source>This option allows Notepadqq to recover your documents after a crash even if they were not explicitly saved.</source>
         <translation>Ця опція дозволяє Notepadqq відновити ваші документи після аварії, навіть якщо їх не було збережено.</translation>
     </message>
     <message>

--- a/src/translations/notepadqq_zh.ts
+++ b/src/translations/notepadqq_zh.ts
@@ -2054,7 +2054,7 @@ Do you want to save it anyway?</source>
     </message>
     <message>
         <location filename="../ui/frmpreferences.ui" line="133"/>
-        <source>This option allows Notepadqq to recover your documents after a crash even if they were not explicitely saved.</source>
+        <source>This option allows Notepadqq to recover your documents after a crash even if they were not explicitly saved.</source>
         <translation>该选项允许Notepadqq在崩溃后恢复文档，即使它们没有被明确保存。</translation>
     </message>
     <message>

--- a/src/ui/Sessions/sessions.cpp
+++ b/src/ui/Sessions/sessions.cpp
@@ -453,7 +453,7 @@ void loadSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
                 editor->setCustomIndentationMode(tab.useTabs, tab.tabSize);
             }
 
-            // loadDocuments() explicitely calls setFocus() so we'll have to undo that.
+            // loadDocuments() explicitly calls setFocus() so we'll have to undo that.
             editor->clearFocus();
         } // end for
 

--- a/src/ui/frmpreferences.ui
+++ b/src/ui/frmpreferences.ui
@@ -130,7 +130,7 @@
            <item>
             <widget class="QCheckBox" name="chkAutosave">
              <property name="toolTip">
-              <string>This option allows Notepadqq to recover your documents after a crash even if they were not explicitely saved.</string>
+              <string>This option allows Notepadqq to recover your documents after a crash even if they were not explicitly saved.</string>
              </property>
              <property name="text">
               <string>Backup open documents every</string>


### PR DESCRIPTION
"explicitely" -> "explicitly"

Searched it with `egrep -rnw . -ie "explicitely"`.