### PR TITLE
Auto-detect TSX files as TypeScript

### DIFF
--- a/src/editor/Languages.json
+++ b/src/editor/Languages.json
@@ -601,7 +601,8 @@
     "mode":"javascript",
     "mime":"application/typescript",
     "fileExtensions":[
-      "ts"
+      "ts",
+	    "tsx"
     ]
   },
   "jinja2":{

--- a/src/editor/Languages.json
+++ b/src/editor/Languages.json
@@ -602,7 +602,7 @@
     "mime":"application/typescript",
     "fileExtensions":[
       "ts",
-	    "tsx"
+      "tsx"
     ]
   },
   "jinja2":{


### PR DESCRIPTION
This pull request is tied to the Issue #753 which I created. The intent is for .tsx files to be auto-detected as TypeScript. 

Working with projects that have many .ts and .tsx it can be quite inconsistent to have the .tsx files open as plain text and no syntax highlighting while the .ts files do.

This change would seem especially fitting since the "jsx" extension is already associated with JavaScript, but the "tsx" is not associated with TypeScript.