### PR TITLE
Feat: Use uchardet to improve encoding detection

### DIFF
--- a/.travis/macos-script.sh
+++ b/.travis/macos-script.sh
@@ -4,6 +4,7 @@ compile()
 {
     brew install qt
     brew install uchardet
+
     export PATH="/usr/local/opt/qt/bin:$PATH"
     export PKG_CONFIG_PATH="/usr/local/opt/qt/lib/pkgconfig"
 

--- a/.travis/macos-script.sh
+++ b/.travis/macos-script.sh
@@ -3,7 +3,7 @@
 compile()
 {
     brew install qt
-    uchardet
+    brew install uchardet
     export PATH="/usr/local/opt/qt/bin:$PATH"
     export PKG_CONFIG_PATH="/usr/local/opt/qt/lib/pkgconfig"
 

--- a/.travis/macos-script.sh
+++ b/.travis/macos-script.sh
@@ -3,6 +3,7 @@
 compile()
 {
     brew install qt
+    uchardet
     export PATH="/usr/local/opt/qt/bin:$PATH"
     export PKG_CONFIG_PATH="/usr/local/opt/qt/lib/pkgconfig"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get -qq update && apt-get --no-install-recommends -y install \
     pkg-config \
     qtbase5-dev \
     qttools5-dev-tools \
-    qtwebengine5-dev
+    qtwebengine5-dev \
+    libuchardet-dev
 
 WORKDIR /build/
 CMD bash

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Build it yourself
 | libqt5websockets5-dev | libqt5websockets5 |
 | libqt5svg5-dev        | libqt5svg5        |
 | qttools5-dev-tools    | coreutils         |
+| libuchardet-dev       | libuchardet       |
 
 #### Get the source
 
@@ -37,11 +38,11 @@ Build it yourself
     
 If you encounter errors make sure to have the necessary libraries installed. For Ubuntu you can do that using apt-get:
 
-    notepadqq$ sudo apt-get install qt5-default qttools5-dev-tools qtwebengine5-dev libqt5websockets5-dev libqt5svg5 libqt5svg5-dev
+    notepadqq$ sudo apt-get install qt5-default qttools5-dev-tools qtwebengine5-dev libqt5websockets5-dev libqt5svg5 libqt5svg5-dev libuchardet-dev
 
 For CentOS:
 
-    notepadqq$ sudo yum install -y qt5-qtbase-devel qt5-qttools-devel qt5-qtwebengine-devel qt5-qtwebsockets-devel qt5-qtsvg-devel
+    notepadqq$ sudo yum install -y qt5-qtbase-devel qt5-qttools-devel qt5-qtwebengine-devel qt5-qtwebsockets-devel qt5-qtsvg-devel uchardet
     
 #### Install
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -50,6 +50,7 @@ parts:
       - libqt5websockets5-dev
       - libqt5svg5-dev
       - qttools5-dev-tools
+      - libuchardet-dev
     stage-packages: 
       - adwaita-icon-theme-full
       - bamfdaemon

--- a/src/ui/docengine.cpp
+++ b/src/ui/docengine.cpp
@@ -14,7 +14,7 @@
 #include <QTextCodec>
 #include <QTextStream>
 
-#include <uchardet/uchardet.h>
+#include <uchardet.h>
 
 DocEngine::DocEngine(TopEditorContainer *topEditorContainer, QObject *parent) :
     QObject(parent),

--- a/src/ui/ui.pro
+++ b/src/ui/ui.pro
@@ -5,8 +5,8 @@
 #-------------------------------------------------
 
 QT       += core gui svg widgets printsupport network webenginewidgets webchannel websockets
-LIBS     += -luchardet
-CONFIG += c++14
+CONFIG += c++14 link_pkgconfig
+PKGCONFIG += uchardet
 
 !macx: TARGET = notepadqq-bin
 macx: TARGET = notepadqq

--- a/src/ui/ui.pro
+++ b/src/ui/ui.pro
@@ -5,7 +5,7 @@
 #-------------------------------------------------
 
 QT       += core gui svg widgets printsupport network webenginewidgets webchannel websockets
-
+LIBS     += -luchardet
 CONFIG += c++14
 
 !macx: TARGET = notepadqq-bin


### PR DESCRIPTION
I tested this against uchardet's multiple test files and it appears to detect each and every one of them properly.  It also happens to greatly simplify the decoding process overall.  So this should fix #730 

The problem here is with distribution.  I'm sure uchardet is probably available on most distributions.  The issue I'm having here is qmake's poor dependency tracking with anything that's... well... not QT.

I know it didn't make sense before, but if we're going to start using other libraries alongside QT (which we should, it makes things a lot easier), we should probably rethink our current build system.  I tend to prefer CMake, but I'm okay with anything that has better library dependency handling.