### PR TITLE
Revert "chore: automate translation inclusions for qmake (#766)"

### DIFF
--- a/src/ui/ui.pro
+++ b/src/ui/ui.pro
@@ -42,6 +42,12 @@ isEmpty(DESTDIR) {
     }
 }
 
+isEmpty(LRELEASE) {
+    !macx:!haiku: LRELEASE = qtchooser -run-tool=lrelease -qt=5
+    haiku: LRELEASE = lrelease
+    macx: LRELEASE = lrelease
+}
+
 !macx {
     APPDATADIR = "$$DESTDIR/../appdata"
     BINDIR = "$$DESTDIR/../bin"
@@ -167,20 +173,39 @@ RESOURCES += \
 
 ICON = ../../images/notepadqq.icns
 
-# Automated translation building (.ts -> .qm)
-# Source translation files (.ts) are obtained from ../translations/
-TRANSLATIONS = $$files("../translations/*.ts")
-qtPrepareTool(LRELEASE, lrelease)
-for (tsfile, TRANSLATIONS) {
-    qmfile = $$shadowed($$tsfile)
-    qmfile ~= s,.ts$,.qm,
-    qmdir = $$dirname(qmfile)
-    !exists($$qmdir) {
-        mkpath($$qmdir)|error("Failed to create directory: $$qmdir")
-    }
-    command = $$LRELEASE -removeidentical $$tsfile -qm $$qmfile
-    QMAKE_CLEAN += $$qmfile
-}
+TRANSLATIONS = \
+    ../translations/notepadqq_de.ts \
+    ../translations/notepadqq_es.ts \
+    ../translations/notepadqq_fr.ts \
+    ../translations/notepadqq_hu.ts \
+    ../translations/notepadqq_it.ts \
+    ../translations/notepadqq_ja.ts \
+    ../translations/notepadqq_pl.ts \
+    ../translations/notepadqq_pt.ts \
+    ../translations/notepadqq_ru.ts \
+    ../translations/notepadqq_sl.ts \
+    ../translations/notepadqq_sv.ts \
+    ../translations/notepadqq_uk.ts \
+    ../translations/notepadqq_zh.ts 
+
+QMAKE_CLEAN += \
+    ../translations/notepadqq_de.qm \
+    ../translations/notepadqq_es.qm \
+    ../translations/notepadqq_fr.qm \
+    ../translations/notepadqq_hu.qm \
+    ../translations/notepadqq_it.qm \
+    ../translations/notepadqq_ja.qm \
+    ../translations/notepadqq_pl.qm \
+    ../translations/notepadqq_pt.qm \
+    ../translations/notepadqq_ru.qm \
+    ../translations/notepadqq_sl.qm \
+    ../translations/notepadqq_sv.qm \
+    ../translations/notepadqq_uk.qm \
+    ../translations/notepadqq_zh.qm
+
+
+# Build translations so that qmake doesn't complain about missing files in resources.qrc
+system($${LRELEASE} \"$${CURRFILE}\")
 
 ### EXTRA TARGETS ###
 


### PR DESCRIPTION
This reverts commit d3c127f27926a5ef9006caf0aff9740cf1406ed3.