### PR TITLE
fix: Don't rely on `which` return values for verifying binary existence

### DIFF
--- a/src/ui/docengine.cpp
+++ b/src/ui/docengine.cpp
@@ -624,24 +624,26 @@ void DocEngine::unmonitorDocument(const QString &fileName)
 
 QString DocEngine::getAvailableSudoProgram() const
 {
-    QProcess p;
-
-    p.start("which kdesu");
-    if (p.waitForFinished(10) && p.exitStatus() == QProcess::NormalExit && p.exitCode() == 0)
-        return "kdesu";
-
-    p.start("which gksu");
-    if (p.waitForFinished(10) && p.exitStatus() == QProcess::NormalExit && p.exitCode() == 0)
-        return "gksu";
-
-    p.start("which pkexec");
-    if (p.waitForFinished(10) && p.exitStatus() == QProcess::NormalExit && p.exitCode() == 0)
-        return "pkexec";
-
-    return "";
+#ifdef __linux__
+    const QStringList sudoPrograms {"gksu", "kdesu", "pkexec"};
+    QString envPath = qEnvironmentVariable("PATH");
+    if (!envPath.isEmpty()) {
+        QStringList pathList = envPath.split(':', QString::SkipEmptyParts);
+        for (const auto& path : pathList) {
+            QDir dir(path);
+            for (const auto& executable : sudoPrograms) {
+                if (dir.exists(executable)) {
+                    return dir.absoluteFilePath(executable);
+                }
+            }
+        }
+    }
+#endif
+    return {};
 }
 
-bool DocEngine::trySudoSave(QString sudoProgram, QUrl outFileName, Editor* editor) {
+bool DocEngine::trySudoSave(QString sudoProgram, QUrl outFileName, Editor* editor)
+{
     if(sudoProgram.isEmpty())
         return false;
 
@@ -651,27 +653,21 @@ bool DocEngine::trySudoSave(QString sudoProgram, QUrl outFileName, Editor* edito
             .toLocalFile();
 
     QFile file(filePath);
-
     if (!write(&file, editor))
         return false;
 
+    QString sudoBinaryName = QFileInfo(sudoProgram).baseName();
+    QStringList arguments;
+    if (sudoBinaryName == "kdesu") {
+        arguments = QStringList({"--noignorebutton", "-n", "-c"});
+    } else if (sudoBinaryName == "gksu") {
+        arguments = QStringList({"-S", "-m", tr("Notepadqq asks permission to overwrite the following file:\n\n%1")
+            .arg(outFileName.toLocalFile())});
+    }
+    arguments.append({"cp", filePath, outFileName.toLocalFile()});
+    
     QProcess p;
-
-    if (sudoProgram == "kdesu")
-        p.start("kdesu", QStringList()
-                << "--noignorebutton"
-                << "-n"
-                << "-c" << "cp" << filePath << outFileName.toLocalFile());
-    else if (sudoProgram == "gksu")
-        p.start("gksu", QStringList()
-                << "-S" << "-m" << tr("Notepadqq asks permission to overwrite the following file:\n\n%1")
-                .arg(outFileName.toLocalFile())
-                << "cp" << filePath << outFileName.toLocalFile());
-    else if (sudoProgram == "pkexec")
-        p.start("pkexec", QStringList() << "cp" << filePath << outFileName.toLocalFile());
-    else
-        return false;
-
+    p.start(sudoProgram, arguments);
 
     p.waitForFinished(-1);
     file.remove();

--- a/src/ui/docengine.cpp
+++ b/src/ui/docengine.cpp
@@ -626,7 +626,7 @@ QString DocEngine::getAvailableSudoProgram() const
 {
 #ifdef __linux__
     const QStringList sudoPrograms{"gksu", "kdesu", "pkexec"};
-    QString envPath = qEnvironmentVariable("PATH");
+    QString envPath = QString::fromLocal8Bit(qgetenv("PATH"));
     if (!envPath.isEmpty()) {
         QStringList pathList = envPath.split(':', QString::SkipEmptyParts);
         for (const auto& path : pathList) {

--- a/src/ui/docengine.cpp
+++ b/src/ui/docengine.cpp
@@ -624,9 +624,9 @@ void DocEngine::unmonitorDocument(const QString &fileName)
 
 QString DocEngine::getAvailableSudoProgram() const
 {
-    //NOTE: Don't rely on `which` for this information.  Some slower hard
-    //drives were exceeding the 10ms execution limit and failing to
-    //find any sudo program at all.
+    // NOTE: Don't rely on `which` for this information.  Some slower hard
+    // drives were exceeding the 10ms execution limit and failing to
+    // find any sudo program at all.
     static QString sudoProgram;
 #ifdef __linux__
     if (sudoProgram.isEmpty()) {

--- a/src/ui/docengine.cpp
+++ b/src/ui/docengine.cpp
@@ -625,7 +625,7 @@ void DocEngine::unmonitorDocument(const QString &fileName)
 QString DocEngine::getAvailableSudoProgram() const
 {
 #ifdef __linux__
-    const QStringList sudoPrograms {"gksu", "kdesu", "pkexec"};
+    const QStringList sudoPrograms{"gksu", "kdesu", "pkexec"};
     QString envPath = qEnvironmentVariable("PATH");
     if (!envPath.isEmpty()) {
         QStringList pathList = envPath.split(':', QString::SkipEmptyParts);
@@ -661,11 +661,12 @@ bool DocEngine::trySudoSave(QString sudoProgram, QUrl outFileName, Editor* edito
     if (sudoBinaryName == "kdesu") {
         arguments = QStringList({"--noignorebutton", "-n", "-c"});
     } else if (sudoBinaryName == "gksu") {
-        arguments = QStringList({"-S", "-m", tr("Notepadqq asks permission to overwrite the following file:\n\n%1")
-            .arg(outFileName.toLocalFile())});
+        arguments = QStringList({"-S",
+            "-m",
+            tr("Notepadqq asks permission to overwrite the following file:\n\n%1").arg(outFileName.toLocalFile())});
     }
     arguments.append({"cp", filePath, outFileName.toLocalFile()});
-    
+
     QProcess p;
     p.start(sudoProgram, arguments);
 


### PR DESCRIPTION
This changes around a few things where we aren't relying on the return values of a 3rd party program in order to verify whether a binary exists.

The new method works by:
* Grabbing the **PATH** environment variable
* Creating a QDir object for each directory in the envvar
* Checking against a const list of known gui-sudo programs

It also returns the full path of the binary as well, just as a safety precaution.

It should (hopefully) fix the issue in #812, but there's really no way to tell without the user giving it a try.

I don't particularly think that utility functions like this belong in docengine, but there's not really a better place to put it currently.