### PR TITLE
fix: Apply saved session zoom level to right view

### DIFF
--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -78,6 +78,7 @@ public:
 
     DocEngine*  getDocEngine() const;
     void generateRunMenu();
+    void configurePostSessionUserInterface();
 public slots:
     void refreshEditorUiInfo(Editor *editor);
     void refreshEditorUiCursorInfo(QMap<QString, QVariant> data);

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -160,6 +160,7 @@ int main(int argc, char *argv[])
 
         if (settings.General.getRememberTabsOnExit()) {
             Sessions::loadSession(wnd->getDocEngine(), wnd->topEditorContainer(), PersistentCache::cacheSessionPath());
+            wnd->configurePostSessionUserInterface();
         }
 
         wnd->openCommandLineProvidedUrls(QDir::currentPath(), QApplication::arguments());

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2181,6 +2181,18 @@ void MainWindow::generateRunMenu()
     connect(a, &QAction::triggered, this, &MainWindow::modifyRunCommands);
 }
 
+/**
+ * @brief Configure any user interface after loading session
+ */
+void MainWindow::configurePostSessionUserInterface()
+{
+    // Restore zoom after load session
+    const qreal zoom = m_settings.General.getZoom();
+    for (int i = 0; i < m_topEditorContainer->count(); i++) {
+        m_topEditorContainer->tabWidget(i)->setZoomFactor(zoom);
+    }
+}
+
 void MainWindow::modifyRunCommands()
 {
     NqqRun::RunPreferences p;


### PR DESCRIPTION
Main window is created before loadSession where zoom setting is
restored, this will cause zoom setting not be set to right view.

This is to fix #838