### PR TITLE
Implemented feature request #756, by adding the -Show line numbers- o…

### DIFF
--- a/src/editor/app.js
+++ b/src/editor/app.js
@@ -412,6 +412,11 @@ UiDriver.registerEventHandler("C_CMD_SET_FONT", function (msg, data, prevReturn)
     }
 });
 
+UiDriver.registerEventHandler("C_CMD_SET_LINE_NUMBERS_VISIBLE", function (msg, data, prevReturn) {
+    editor.setOption("lineNumbers", data);
+    editor.refresh();
+});
+
 UiDriver.registerEventHandler("C_CMD_SET_OVERWRITE", function(msg, data, prevReturn) {
     editor.toggleOverwrite(data);
 });
@@ -687,7 +692,7 @@ UiDriver.registerEventHandler("C_CMD_GET_DOCUMENT_INFO", function(msg, data, pre
 
 $(document).ready(function () {
     editor = CodeMirror($(".editor")[0], {
-        lineNumbers: true,
+        lineNumbers: _showLineNumbers,
         mode: { name: "" },
         highlightSelectionMatches: {style: "selectedHighlight", wordsOnly: true, delay: 25},
         styleSelectedText: true,

--- a/src/editor/app.js
+++ b/src/editor/app.js
@@ -692,7 +692,7 @@ UiDriver.registerEventHandler("C_CMD_GET_DOCUMENT_INFO", function(msg, data, pre
 
 $(document).ready(function () {
     editor = CodeMirror($(".editor")[0], {
-        lineNumbers: _showLineNumbers,
+        lineNumbers: true,
         mode: { name: "" },
         highlightSelectionMatches: {style: "selectedHighlight", wordsOnly: true, delay: 25},
         styleSelectedText: true,

--- a/src/editor/init.js
+++ b/src/editor/init.js
@@ -6,7 +6,6 @@
 
 var _initialized = false;
 var _defaultTheme = "";
-var _showLineNumbers = true;
 
 function addStylesheet(path) {
     var link = document.createElement("link");
@@ -35,11 +34,6 @@ function init()
     var themeName = getParameterByName("themeName");
     if (themePath !== "") {
         addStylesheet(themePath);
-    }
-
-    var showLineNumbers = getParameterByName("showLineNumbers");
-    if (showLineNumbers === "false") {
-        _showLineNumbers = false;
     }
     
     _defaultTheme = themeName === "" ? "default" : themeName;

--- a/src/editor/init.js
+++ b/src/editor/init.js
@@ -6,6 +6,7 @@
 
 var _initialized = false;
 var _defaultTheme = "";
+var _showLineNumbers = true;
 
 function addStylesheet(path) {
     var link = document.createElement("link");
@@ -34,6 +35,11 @@ function init()
     var themeName = getParameterByName("themeName");
     if (themePath !== "") {
         addStylesheet(themePath);
+    }
+
+    var showLineNumbers = getParameterByName("showLineNumbers");
+    if (showLineNumbers === "false") {
+        _showLineNumbers = false;
     }
     
     _defaultTheme = themeName === "" ? "default" : themeName;

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -24,19 +24,17 @@ namespace EditorNS
     {
 
         QString themeName = NqqSettings::getInstance().Appearance.getColorScheme();
-        
-        bool showLineNumbers = NqqSettings::getInstance().Appearance.getShowLineNumbers();
 
-        fullConstructor(themeFromName(themeName), showLineNumbers);
+        fullConstructor(themeFromName(themeName));
     }
 
-    Editor::Editor(const Theme &theme, bool showLineNumbers, QWidget *parent) :
+    Editor::Editor(const Theme &theme, QWidget *parent) :
         QWidget(parent)
     {
-        fullConstructor(theme, showLineNumbers);
+        fullConstructor(theme);
     }
 
-    void Editor::fullConstructor(const Theme &theme, bool showLineNumbers)
+    void Editor::fullConstructor(const Theme &theme)
     {
         m_jsToCppProxy = new JsToCppProxy(this);
         connect(m_jsToCppProxy,
@@ -49,12 +47,6 @@ namespace EditorNS
         QUrlQuery query;
         query.addQueryItem("themePath", theme.path);
         query.addQueryItem("themeName", theme.name);
-
-        if (showLineNumbers) {
-            query.addQueryItem("showLineNumbers", "true");
-        } else {
-            query.addQueryItem("showLineNumbers", "false");
-        }
 
         QUrl url = QUrl("file://" + Notepadqq::editorPath());
         url.setQuery(query);

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -48,8 +48,7 @@ namespace EditorNS
         QUrlQuery query;
         query.addQueryItem("themePath", theme.path);
         query.addQueryItem("themeName", theme.name);
-        if (showLineNumbers)
-        {
+        if (showLineNumbers) {
             query.addQueryItem("showLineNumbers", "true");
         } else {
             query.addQueryItem("showLineNumbers", "false");

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -48,6 +48,7 @@ namespace EditorNS
         QUrlQuery query;
         query.addQueryItem("themePath", theme.path);
         query.addQueryItem("themeName", theme.name);
+        
         if (showLineNumbers) {
             query.addQueryItem("showLineNumbers", "true");
         } else {

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -24,17 +24,18 @@ namespace EditorNS
     {
 
         QString themeName = NqqSettings::getInstance().Appearance.getColorScheme();
+        bool showLineNumbers = NqqSettings::getInstance().Appearance.getShowLineNumbers();
 
-        fullConstructor(themeFromName(themeName));
+        fullConstructor(themeFromName(themeName), showLineNumbers);
     }
 
-    Editor::Editor(const Theme &theme, QWidget *parent) :
+    Editor::Editor(const Theme &theme, bool showLineNumbers, QWidget *parent) :
         QWidget(parent)
     {
-        fullConstructor(theme);
+        fullConstructor(theme, showLineNumbers);
     }
 
-    void Editor::fullConstructor(const Theme &theme)
+    void Editor::fullConstructor(const Theme &theme, bool showLineNumbers)
     {
         m_jsToCppProxy = new JsToCppProxy(this);
         connect(m_jsToCppProxy,
@@ -47,6 +48,12 @@ namespace EditorNS
         QUrlQuery query;
         query.addQueryItem("themePath", theme.path);
         query.addQueryItem("themeName", theme.name);
+        if (showLineNumbers)
+        {
+            query.addQueryItem("showLineNumbers", "true");
+        } else {
+            query.addQueryItem("showLineNumbers", "false");
+        }
 
         QUrl url = QUrl("file://" + Notepadqq::editorPath());
         url.setQuery(query);
@@ -648,6 +655,11 @@ namespace EditorNS
         tmap.insert("size", QString::number(fontSize));
         tmap.insert("lineHeight", QString::number(lineHeight,'f',2));
         asyncSendMessageWithResultP("C_CMD_SET_FONT", tmap);
+    }
+
+    void Editor::setLineNumbersVisible(bool visible)
+    {
+        asyncSendMessageWithResultP("C_CMD_SET_LINE_NUMBERS_VISIBLE", visible);
     }
 
     QTextCodec *Editor::codec() const

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -24,6 +24,7 @@ namespace EditorNS
     {
 
         QString themeName = NqqSettings::getInstance().Appearance.getColorScheme();
+        
         bool showLineNumbers = NqqSettings::getInstance().Appearance.getShowLineNumbers();
 
         fullConstructor(themeFromName(themeName), showLineNumbers);
@@ -48,7 +49,7 @@ namespace EditorNS
         QUrlQuery query;
         query.addQueryItem("themePath", theme.path);
         query.addQueryItem("themeName", theme.name);
-        
+
         if (showLineNumbers) {
             query.addQueryItem("showLineNumbers", "true");
         } else {

--- a/src/ui/frmpreferences.cpp
+++ b/src/ui/frmpreferences.cpp
@@ -106,8 +106,11 @@ void frmPreferences::updatePreviewEditorFont()
     const QString font = ui->cmbFontFamilies->isEnabled() ? ui->cmbFontFamilies->currentFont().family() : "";
     const int size = ui->spnFontSize->isEnabled() ? ui->spnFontSize->value() : 0;
     const double lineHeight = ui->spnLineHeight->isEnabled() ? ui->spnLineHeight->value() : 0;
+    const bool lineNumbersVisible = ui->chkShowLineNumbers->isChecked();
 
     m_previewEditor->setFont(font, size, lineHeight);
+
+    m_previewEditor->setLineNumbersVisible(lineNumbersVisible);
 
     // Re-setting language also updates the position of text selection. If not done, selected text
     // would often glitch out when changing the font causes the position of text characters to change.
@@ -213,6 +216,11 @@ void frmPreferences::loadAppearanceTab()
         ui->chkOverrideLineHeight->setChecked(true);
         ui->spnLineHeight->setValue(lineHeight);
     }
+
+    const bool showLineNumbers = m_settings.Appearance.getShowLineNumbers();
+    if (showLineNumbers) {
+        ui->chkShowLineNumbers->setChecked(true);
+    }
 }
 
 void frmPreferences::saveAppearanceTab()
@@ -222,10 +230,12 @@ void frmPreferences::saveAppearanceTab()
     const QString fontFamily = ui->cmbFontFamilies->isEnabled() ? ui->cmbFontFamilies->currentFont().family() : "";
     const int fontSize = ui->spnFontSize->isEnabled() ? ui->spnFontSize->value() : 0;
     const double lineHeight = ui->spnLineHeight->isEnabled() ? ui->spnLineHeight->value() : 0;
+    const bool showLineNumbers = ui->chkShowLineNumbers->isChecked();
 
     m_settings.Appearance.setOverrideFontFamily(fontFamily);
     m_settings.Appearance.setOverrideFontSize(fontSize);
     m_settings.Appearance.setOverrideLineHeight(lineHeight);
+    m_settings.Appearance.setShowLineNumbers(showLineNumbers);
 }
 
 void frmPreferences::loadTranslations()
@@ -404,6 +414,7 @@ bool frmPreferences::applySettings()
     const QString fontFamily = ui->cmbFontFamilies->isEnabled() ? ui->cmbFontFamilies->currentFont().family() : "";
     const int fontSize = ui->spnFontSize->isEnabled() ? ui->spnFontSize->value() : 0;
     const double lineHeight = ui->spnLineHeight->isEnabled() ? ui->spnLineHeight->value() : 0;
+    const bool lineNumbersVisible = ui->chkShowLineNumbers->isChecked();
 
     // Apply changes to currently opened editors
     for (MainWindow *w : MainWindow::instances()) {
@@ -416,6 +427,9 @@ bool frmPreferences::applySettings()
 
             // Set font override
             editor->setFont(fontFamily, fontSize, lineHeight);
+
+            // Set line numbers visibility
+            editor->setLineNumbersVisible(lineNumbersVisible);
 
             // Reset language-dependent settings (e.g. tab settings)
             editor->setLanguage(editor->getLanguage());
@@ -568,6 +582,11 @@ void frmPreferences::on_chkOverrideLineHeight_toggled(bool checked)
 }
 
 void frmPreferences::on_spnLineHeight_valueChanged(double /*arg1*/)
+{
+    updatePreviewEditorFont();
+}
+
+void frmPreferences::on_chkShowLineNumbers_toggled(bool checked)
 {
     updatePreviewEditorFont();
 }

--- a/src/ui/frmpreferences.cpp
+++ b/src/ui/frmpreferences.cpp
@@ -42,6 +42,10 @@ frmPreferences::frmPreferences(TopEditorContainer *topEditorContainer, QWidget *
                               R"(})" "\n"
                               );
 
+    // Update the preview editor so that the editor's current settings are applied and shown properly
+    // in the editor preview
+    updatePreviewEditorFont();
+
     // Select first item in treeWidget
     ui->treeWidget->setCurrentItem(ui->treeWidget->topLevelItem(s_lastSelectedTab));
 

--- a/src/ui/frmpreferences.ui
+++ b/src/ui/frmpreferences.ui
@@ -577,7 +577,7 @@
                 </property>
                 <property name="icon">
                  <iconset theme="go-next">
-                  <normaloff>../../../../../.designer/backup</normaloff>../../../../../.designer/backup</iconset>
+                  <normaloff>.</normaloff>.</iconset>
                 </property>
                </widget>
               </item>
@@ -588,7 +588,7 @@
                 </property>
                 <property name="icon">
                  <iconset theme="go-previous">
-                  <normaloff>../../../../../.designer/backup</normaloff>../../../../../.designer/backup</iconset>
+                  <normaloff>.</normaloff>.</iconset>
                 </property>
                </widget>
               </item>
@@ -617,7 +617,7 @@
                 </property>
                 <property name="icon">
                  <iconset theme="go-up">
-                  <normaloff>../../../../../.designer/backup</normaloff>../../../../../.designer/backup</iconset>
+                  <normaloff>.</normaloff>.</iconset>
                 </property>
                </widget>
               </item>
@@ -628,7 +628,7 @@
                 </property>
                 <property name="icon">
                  <iconset theme="go-down">
-                  <normaloff>../../../../../.designer/backup</normaloff>../../../../../.designer/backup</iconset>
+                  <normaloff>.</normaloff>.</iconset>
                 </property>
                </widget>
               </item>
@@ -658,7 +658,7 @@
              </property>
              <property name="icon">
               <iconset theme="edit-undo">
-               <normaloff>../../../../../.designer/backup</normaloff>../../../../../.designer/backup</iconset>
+               <normaloff>.</normaloff>.</iconset>
              </property>
             </widget>
            </item>
@@ -815,7 +815,7 @@
   </layout>
  </widget>
  <resources>
-  <include location="../CLionProjects/notepadqq/src/ui/resources.qrc"/>
+  <include location="resources.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/src/ui/frmpreferences.ui
+++ b/src/ui/frmpreferences.ui
@@ -14,7 +14,7 @@
    <string>Preferences</string>
   </property>
   <property name="windowIcon">
-   <iconset resource="resources.qrc">
+   <iconset resource="../CLionProjects/notepadqq/src/ui/resources.qrc">
     <normaloff>:/icons/notepadqq/scalable/notepadqq.svg</normaloff>:/icons/notepadqq/scalable/notepadqq.svg</iconset>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -91,7 +91,7 @@
      <item>
       <widget class="QStackedWidget" name="stackedWidget">
        <property name="currentIndex">
-        <number>0</number>
+        <number>1</number>
        </property>
        <widget class="QWidget" name="pageGeneral">
         <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -350,6 +350,13 @@
              </property>
             </widget>
            </item>
+           <item row="3" column="0">
+            <widget class="QCheckBox" name="chkShowLineNumbers">
+             <property name="text">
+              <string>Show line numbers</string>
+             </property>
+            </widget>
+           </item>
           </layout>
          </item>
          <item>
@@ -570,7 +577,7 @@
                 </property>
                 <property name="icon">
                  <iconset theme="go-next">
-                  <normaloff>.</normaloff>.</iconset>
+                  <normaloff>../../../../../.designer/backup</normaloff>../../../../../.designer/backup</iconset>
                 </property>
                </widget>
               </item>
@@ -581,7 +588,7 @@
                 </property>
                 <property name="icon">
                  <iconset theme="go-previous">
-                  <normaloff>.</normaloff>.</iconset>
+                  <normaloff>../../../../../.designer/backup</normaloff>../../../../../.designer/backup</iconset>
                 </property>
                </widget>
               </item>
@@ -610,7 +617,7 @@
                 </property>
                 <property name="icon">
                  <iconset theme="go-up">
-                  <normaloff>.</normaloff>.</iconset>
+                  <normaloff>../../../../../.designer/backup</normaloff>../../../../../.designer/backup</iconset>
                 </property>
                </widget>
               </item>
@@ -621,7 +628,7 @@
                 </property>
                 <property name="icon">
                  <iconset theme="go-down">
-                  <normaloff>.</normaloff>.</iconset>
+                  <normaloff>../../../../../.designer/backup</normaloff>../../../../../.designer/backup</iconset>
                 </property>
                </widget>
               </item>
@@ -651,7 +658,7 @@
              </property>
              <property name="icon">
               <iconset theme="edit-undo">
-               <normaloff>.</normaloff>.</iconset>
+               <normaloff>../../../../../.designer/backup</normaloff>../../../../../.designer/backup</iconset>
              </property>
             </widget>
            </item>
@@ -686,8 +693,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>362</width>
-              <height>205</height>
+              <width>565</width>
+              <height>390</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -808,7 +815,7 @@
   </layout>
  </widget>
  <resources>
-  <include location="resources.qrc"/>
+  <include location="../CLionProjects/notepadqq/src/ui/resources.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/src/ui/frmpreferences.ui
+++ b/src/ui/frmpreferences.ui
@@ -14,7 +14,7 @@
    <string>Preferences</string>
   </property>
   <property name="windowIcon">
-   <iconset resource="../CLionProjects/notepadqq/src/ui/resources.qrc">
+   <iconset resource="resources.qrc">
     <normaloff>:/icons/notepadqq/scalable/notepadqq.svg</normaloff>:/icons/notepadqq/scalable/notepadqq.svg</iconset>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_4">

--- a/src/ui/include/EditorNS/editor.h
+++ b/src/ui/include/EditorNS/editor.h
@@ -82,7 +82,7 @@ namespace EditorNS
             }
         };
 
-        explicit Editor(const Theme &theme, QWidget *parent = 0);
+        explicit Editor(const Theme &theme, bool showLineNumbers, QWidget *parent = 0);
         explicit Editor(QWidget *parent = 0);
 
         /**
@@ -264,6 +264,13 @@ namespace EditorNS
          */
         void setFont(QString fontFamily, int fontSize, double lineHeight);
 
+        /**
+         * @brief Toggles line numbers on/off in the editor
+         * @param visible when true, the line numbers will be visible,
+         * when false the line numbers will be hidden.
+         */
+        void setLineNumbersVisible(bool visible);
+
         QTextCodec *codec() const;
 
         /**
@@ -342,7 +349,7 @@ namespace EditorNS
         inline void waitAsyncLoad();
         QString jsStringEscape(QString str) const;
 
-        void fullConstructor(const Theme &theme);
+        void fullConstructor(const Theme &theme, bool showLineNumbers);
 
         QPromise<void> setIndentationMode(const bool useTabs, const int size);
         QPromise<void> setIndentationMode(const Language*);

--- a/src/ui/include/EditorNS/editor.h
+++ b/src/ui/include/EditorNS/editor.h
@@ -82,7 +82,7 @@ namespace EditorNS
             }
         };
 
-        explicit Editor(const Theme &theme, bool showLineNumbers, QWidget *parent = 0);
+        explicit Editor(const Theme &theme, QWidget *parent = 0);
         explicit Editor(QWidget *parent = 0);
 
         /**
@@ -349,7 +349,7 @@ namespace EditorNS
         inline void waitAsyncLoad();
         QString jsStringEscape(QString str) const;
 
-        void fullConstructor(const Theme &theme, bool showLineNumbers);
+        void fullConstructor(const Theme &theme);
 
         QPromise<void> setIndentationMode(const bool useTabs, const int size);
         QPromise<void> setIndentationMode(const Language*);

--- a/src/ui/include/frmpreferences.h
+++ b/src/ui/include/frmpreferences.h
@@ -44,6 +44,7 @@ private slots:
     void on_cmbFontFamilies_currentFontChanged(const QFont &f);
     void on_chkOverrideLineHeight_toggled(bool checked);
     void on_spnLineHeight_valueChanged(double arg1);
+    void on_chkShowLineNumbers_toggled(bool checked);
 
     void on_buttonBox_clicked(QAbstractButton *button);
 

--- a/src/ui/include/nqqsettings.h
+++ b/src/ui/include/nqqsettings.h
@@ -97,6 +97,7 @@ public:
         NQQ_SETTING(OverrideFontFamily, QString,    "")
         NQQ_SETTING(OverrideFontSize,   int,        0)
         NQQ_SETTING(OverrideLineHeight, double,     0)
+        NQQ_SETTING(ShowLineNumbers, bool, true)
     END_CATEGORY(Appearance)
 
     BEGIN_CATEGORY(Search)

--- a/src/ui/include/nqqsettings.h
+++ b/src/ui/include/nqqsettings.h
@@ -97,7 +97,7 @@ public:
         NQQ_SETTING(OverrideFontFamily, QString,    "")
         NQQ_SETTING(OverrideFontSize,   int,        0)
         NQQ_SETTING(OverrideLineHeight, double,     0)
-        NQQ_SETTING(ShowLineNumbers, bool, true)
+        NQQ_SETTING(ShowLineNumbers, bool,       true)
     END_CATEGORY(Appearance)
 
     BEGIN_CATEGORY(Search)

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1220,6 +1220,7 @@ void MainWindow::on_editorAdded(EditorTabWidget *tabWidget, int tab)
     editor->setFont(m_settings.Appearance.getOverrideFontFamily(),
                     m_settings.Appearance.getOverrideFontSize(),
                     m_settings.Appearance.getOverrideLineHeight());
+    editor->setLineNumbersVisible(m_settings.Appearance.getShowLineNumbers());
     editor->setSmartIndent(m_settings.General.getSmartIndentation());
     editor->setMathEnabled(ui->actionMath_Rendering->isChecked());
 }


### PR DESCRIPTION
…ption inside the Preferences->Appearance Tab. The line numbers on the left side of the editor can now be turned on or off, according to the user's personal needs/preferences.