### PR TITLE
Faster startup [DO NOT MERGE] fixes #836

### DIFF
--- a/src/ui/Sessions/sessions.cpp
+++ b/src/ui/Sessions/sessions.cpp
@@ -381,7 +381,7 @@ void loadSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
     for (const auto& view : views) {
         // Each new view must be created if it does not yet exist.
         EditorTabWidget* tabW = editorContainer->tabWidget(viewCounter);
-        int activeIndex = 0;
+        QSharedPointer<Editor> activeEditor;
 
         if (!tabW)
             tabW = editorContainer->addTabWidget();
@@ -402,77 +402,106 @@ void loadSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
             if (!fileExists && !cacheFileExists)
                 continue;
 
-            docEngine->getDocumentLoader()
+            auto loadedDocs = docEngine->getDocumentLoader()
                 .setUrl(loadUrl)
                 .setTabWidget(tabW)
                 .setRememberLastDir(false)
                 .setFileSizeWarning(DocEngine::FileSizeActionYesToAll)
-                .execute()
-                .wait(); // FIXME Transform to async
+                .executeInBackground();
 
-            int idx = tabW->findOpenEditorByUrl(loadUrl);
-
-            if (idx == -1)
+            if (loadedDocs.length() == 0) {
+                // For some reason it hasn't been loaded
                 continue;
-
-            // DocEngine sets the editor's fileName to loadUrl since this is where the file
-            // was loaded from. Since loadUrl could point to a cached file we reset it here.
-            auto editor = tabW->editor(idx);
-
-            if (cacheFileExists) {
-                editor->markDirty();
-                editor->setLanguageFromFilePath();
-                // Since we loaded from cache we want to unmonitor the cache file.
-                docEngine->unmonitorDocument(editor);
             }
 
+            // We need to set the correct title as soon as possible, otherwise
+            // the UI will jump around changing the width of the tabs while they
+            // are loading.
+            auto loadingEditor = loadedDocs.first().first;
+            QString tabText;
             if (tab.filePath.isEmpty()) {
-                editor->setFilePath(QUrl());
-                tabW->setTabText(idx, docEngine->getNewDocumentName());
+                tabText = docEngine->getNewDocumentName();
             } else {
-                editor->setFilePath(fileUrl);
-                if(fileExists)
-                    docEngine->monitorDocument(editor);
+                tabText = tabW->generateTabTitleForUrl(QUrl(tab.filePath));
+            }
+            tabW->setTabText(loadingEditor.data(), tabText);
+
+            if (tab.active) {
+                activeEditor = loadingEditor;
             }
 
-            // If we're loading an existing file from cache we want to inform the user whether
-            // the file has changed since Nqq was last closed. For this we can compare the
-            // file's last modification date.
-            if (fileExists && cacheFileExists && tab.lastModified != 0) {
-                auto lastModified = fileInfo.lastModified().toMSecsSinceEpoch();
+            // FIXME The active editor should have priority when loading!!
+            // FIXME Test with no session
+            // FIXME Test with command line parameters
 
-                if (lastModified > tab.lastModified) {
-                    editor->setFileOnDiskChanged(true);
+            loadedDocs.first().second.then([=](QSharedPointer<Editor> editor){
+
+                int idx = tabW->indexOf(editor);
+
+                // DocEngine sets the editor's fileName to loadUrl since this is where the file
+                // was loaded from. Since loadUrl could point to a cached file we reset it here.
+                if (cacheFileExists) {
+                    editor->markDirty();
+                    editor->setLanguageFromFilePath();
+                    // Since we loaded from cache we want to unmonitor the cache file.
+                    docEngine->unmonitorDocument(editor);
                 }
-            }
 
-            // If the orig. file does not exist but *should* exist, we inform the user of its removal.
-            if (!fileExists && !fileUrl.isEmpty()) {
-                editor->setFileOnDiskChanged(true);
-                emit docEngine->fileOnDiskChanged(tabW, idx, true);
-            }
+                if (tab.filePath.isEmpty()) {
+                    editor->setFilePath(QUrl());
+                    //tabW->setTabText(editor.data(), docEngine->getNewDocumentName()); // FIXME
+                    tabW->setTabText(idx, tabText);
+                } else {
+                    editor->setFilePath(fileUrl);
+                    if(fileExists)
+                        docEngine->monitorDocument(editor);
+                }
 
-            if(tab.active) activeIndex = idx;
+                // If we're loading an existing file from cache we want to inform the user whether
+                // the file has changed since Nqq was last closed. For this we can compare the
+                // file's last modification date.
+                if (fileExists && cacheFileExists && tab.lastModified != 0) {
+                    auto lastModified = fileInfo.lastModified().toMSecsSinceEpoch();
 
-            if(!tab.language.isEmpty()) editor->setLanguage(tab.language);
+                    if (lastModified > tab.lastModified) {
+                        editor->setFileOnDiskChanged(true);
+                    }
+                }
 
-            editor->setCursorPosition(tab.cursorX, tab.cursorY);
-            editor->setScrollPosition(tab.scrollX, tab.scrollY);
+                // If the orig. file does not exist but *should* exist, we inform the user of its removal.
+                if (!fileExists && !fileUrl.isEmpty()) {
+                    editor->setFileOnDiskChanged(true);
+                    emit docEngine->fileOnDiskChanged(tabW, idx, true);
+                }
 
-            if (tab.customIndent) {
-                editor->setCustomIndentationMode(tab.useTabs, tab.tabSize);
-            }
+                if(!tab.language.isEmpty()) editor->setLanguage(tab.language);
 
-            // loadDocuments() explicitly calls setFocus() so we'll have to undo that.
-            editor->clearFocus();
+                editor->setCursorPosition(tab.cursorX, tab.cursorY);
+                editor->setScrollPosition(tab.scrollX, tab.scrollY);
+
+                if (tab.customIndent) {
+                    editor->setCustomIndentationMode(tab.useTabs, tab.tabSize);
+                }
+
+                // loadDocuments() explicitly calls setFocus() so we'll have to undo that.
+                editor->clearFocus();
+
+                if (tab.active) {
+                    // We need to trigger a final call to MainWindow::refreshEditorUiInfo to display the correct info
+                    // on start-up. The easiest way is to emit a cleanChanged() event.
+                    editor->isCleanP().then([=](bool isClean){ emit editor->cleanChanged(isClean); });
+                }
+
+            });
         } // end for
 
         // In case a new tabwidget was created but no tabs were actually added to it,
         // we'll attempt to re-use the widget for the next view.
-        if (tabW->count() == 0)
+        if (tabW->count() == 0) {
             viewCounter--;
-        else // Otherwise we finish by making the right tab the currently open one.
-            tabW->setCurrentIndex(activeIndex);
+        } else { // Otherwise we finish by making the right tab the currently open one.
+            tabW->setCurrentIndex(tabW->indexOf(activeEditor));
+        }
 
     } // end for
 
@@ -484,10 +513,6 @@ void loadSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
     EditorTabWidget* firstTabW = editorContainer->tabWidget(0);
     auto currEd = firstTabW->currentEditor();
     currEd->setFocus();
-
-    // We need to trigger a final call to MainWindow::refreshEditorUiInfo to display the correct info
-    // on start-up. The easiest way is to emit a cleanChanged() event.
-    currEd->isCleanP().then([=](bool isClean){ emit currEd->cleanChanged(isClean); });
 
     // If the last tabwidget still has no tabs in it at this point, we'll have to delete it.
     EditorTabWidget* lastTabW = editorContainer->tabWidget( editorContainer->count() -1);

--- a/src/ui/Sessions/sessions.cpp
+++ b/src/ui/Sessions/sessions.cpp
@@ -38,6 +38,9 @@
  *
  * */
 
+// Some shorthand names
+constexpr int ALL_MAXIMUM_PRIORITY = DocEngine::DocumentLoader::ALL_MAXIMUM_PRIORITY;
+constexpr int ALL_MINIMUM_PRIORITY = DocEngine::DocumentLoader::ALL_MINIMUM_PRIORITY;
 
 struct TabData {
     QString filePath;
@@ -407,6 +410,7 @@ void loadSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
                 .setTabWidget(tabW)
                 .setRememberLastDir(false)
                 .setFileSizeWarning(DocEngine::FileSizeActionYesToAll)
+                .setPriorityIdx(tab.active ? ALL_MAXIMUM_PRIORITY : ALL_MINIMUM_PRIORITY)
                 .executeInBackground();
 
             if (loadedDocs.length() == 0) {
@@ -429,10 +433,6 @@ void loadSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
             if (tab.active) {
                 activeEditor = loadingEditor;
             }
-
-            // FIXME The active editor should have priority when loading!!
-            // FIXME Test with no session
-            // FIXME Test with command line parameters
 
             loadedDocs.first().second.then([=](QSharedPointer<Editor> editor){
 

--- a/src/ui/docengine.cpp
+++ b/src/ui/docengine.cpp
@@ -359,6 +359,9 @@ QList<std::pair<QSharedPointer<Editor>, QPromise<QSharedPointer<Editor>>>> DocEn
 
 QPromise<void> DocEngine::loadDocuments(const DocEngine::DocumentLoader& docLoader)
 {
+    // FIXME Unify with loadDocumentsInBackground by calling
+    // loadDocumentsInBackground() and waiting on the result promises.
+
     const auto& fileNames = docLoader.urls;
     const auto& rememberLastSelectedDir = docLoader.rememberLastDir;
     const auto& reloadAction = docLoader.reloadAction;
@@ -479,11 +482,12 @@ QPromise<void> DocEngine::loadDocuments(const DocEngine::DocumentLoader& docLoad
                 msgBox.setDefaultButton(QMessageBox::Retry);
                 msgBox.setIcon(QMessageBox::Critical);
                 int ret = msgBox.exec();
-                if(ret == QMessageBox::Abort) {
+                if (ret == QMessageBox::Abort) {
                     tabWidget->removeTab(tabIndex);
                     return _break;
                 } else if(ret == QMessageBox::Retry) {
                     // Retry
+                    readResult = this->read(&file, editor, codec, bom).wait(); // FIXME To async!
                 } else if(ret == QMessageBox::Ignore) {
                     tabWidget->removeTab(tabIndex);
                     return _continue;

--- a/src/ui/docengine.cpp
+++ b/src/ui/docengine.cpp
@@ -312,36 +312,39 @@ QList<std::pair<QSharedPointer<Editor>, QPromise<QSharedPointer<Editor>>>> DocEn
                     }
                 }
 
-                // In case of reload, restore cursor, scroll position, language
                 if (isAlreadyOpen) {
+                    // In case of reload, restore cursor, scroll position, language
                     editor->setScrollPosition(scrollPosition);
                     editor->setCursorPosition(cursorPosition);
                     editor->setLanguage(language);
-                }
 
-                if (!file.exists()) {
-                    // If it's a file that doesn't exists,
-                    // set it as if it has changed. This way, if someone
-                    // creates that file from outside of notepadqq,
-                    // when the user tries to save over it he gets a warning.
-                    editor->setFileOnDiskChanged(true);
-                    editor->markDirty();
-                }
-
-                file.close();
-                if (isAlreadyOpen) {
                     editor->setFileOnDiskChanged(false);
-                } else {
-                    editor->setFilePath(url);
-                    tabWidget->setTabToolTip(tabIndex, fi.absoluteFilePath());
-                    editor->setLanguageFromFilePath();
-                }
 
-                this->monitorDocument(editor);
+                    if (!file.exists()) {
+                        // If it's a file that doesn't exists,
+                        // set it as if it has changed. This way, if someone
+                        // creates that file from outside of notepadqq,
+                        // when the user tries to save over it he gets a warning.
+                        editor->setFileOnDiskChanged(true);
+                        editor->markDirty();
+                    }
 
-                if (isAlreadyOpen) {
+                    this->monitorDocument(editor);
+
                     emit this->documentReloaded(tabWidget, tabIndex);
+
                 } else {
+
+                    if (docLoader.manualEditorInitialization == nullptr) {
+                        editor->setFilePath(url);
+                        tabWidget->setTabToolTip(tabIndex, fi.absoluteFilePath());
+                        editor->setLanguageFromFilePath();
+
+                        this->monitorDocument(editor);
+                    } else {
+                        docLoader.manualEditorInitialization(editor, fileNames[i]);
+                    }
+
                     emit this->documentLoaded(tabWidget, tabIndex, false, rememberLastSelectedDir);
                 }
 

--- a/src/ui/docengine.cpp
+++ b/src/ui/docengine.cpp
@@ -225,7 +225,7 @@ QList<std::pair<QSharedPointer<Editor>, QPromise<QSharedPointer<Editor>>>> DocEn
         auto editor = tabWidget->editor(tabIndex);
         editor->isLoading = true;
 
-        // Once we are here, we can NOT remove the tab
+        // Once we are here, we can NOT remove the tab we've just added
 
         // If there was only a new empty tab opened, remove it
         if (tabWidget->count() == 2) {
@@ -291,15 +291,10 @@ QList<std::pair<QSharedPointer<Editor>, QPromise<QSharedPointer<Editor>>>> DocEn
                         msgBox.setWindowTitle(QCoreApplication::applicationName());
                         msgBox.setText(tr("Error trying to open \"%1\"").arg(fi.fileName()));
                         msgBox.setDetailedText(file.errorString());
-                        //msgBox.setStandardButtons(QMessageBox::Abort | QMessageBox::Retry | QMessageBox::Ignore);
                         msgBox.setStandardButtons(QMessageBox::Retry | QMessageBox::Ignore);
                         msgBox.setDefaultButton(QMessageBox::Retry);
                         msgBox.setIcon(QMessageBox::Critical);
                         int ret = msgBox.exec();
-                        /*if(ret == QMessageBox::Abort) {
-                            tabWidget->removeTab(tabIndex);
-                            return _break; // stop whole loading process
-                        } else*/
                         if(ret == QMessageBox::Retry) {
                             // Retry
                             readResult = this->read(&file, editor, codec, bom).wait();

--- a/src/ui/docengine.cpp
+++ b/src/ui/docengine.cpp
@@ -153,7 +153,7 @@ QList<std::pair<QSharedPointer<Editor>, QPromise<QSharedPointer<Editor>>>> DocEn
 
     QList<std::pair<QSharedPointer<Editor>, QPromise<QSharedPointer<Editor>>>> loadedEditors;
 
-    //bool isFirstDocument = true;
+    bool isFirstDocument = true;
 
     for (int i = 0; i < fileNames.count(); i++) {
         const QUrl& url = fileNames[i];
@@ -179,10 +179,10 @@ QList<std::pair<QSharedPointer<Editor>, QPromise<QSharedPointer<Editor>>>> DocEn
             EditorTabWidget *tabW = static_cast<EditorTabWidget *>
                                     (m_topEditorContainer->widget(openPos.first));
 
-            /*if (isFirstDocument) {
+            if (isFirstDocument) {
                 isFirstDocument = false;
                 tabW->setCurrentIndex(openPos.second);
-            }*/
+            }
 
             emit this->documentLoaded(tabW, openPos.second, true, rememberLastSelectedDir);
             continue;
@@ -234,6 +234,12 @@ QList<std::pair<QSharedPointer<Editor>, QPromise<QSharedPointer<Editor>>>> DocEn
                 tabWidget->removeTab(0);
                 tabIndex--;
             }
+        }
+
+        if (isFirstDocument) {
+            isFirstDocument = false;
+            tabWidget->setCurrentIndex(tabIndex);
+            tabWidget->editor(tabIndex)->setFocus();
         }
 
         auto continuationP = QPromise<QSharedPointer<Editor>>([=](auto resolve, auto reject)
@@ -332,12 +338,6 @@ QList<std::pair<QSharedPointer<Editor>, QPromise<QSharedPointer<Editor>>>> DocEn
                 }
 
                 this->monitorDocument(editor);
-
-                /*if (isFirstDocument) {
-                    isFirstDocument = false;
-                    tabWidget->setCurrentIndex(tabIndex);
-                    tabWidget->editor(tabIndex)->setFocus();
-                }*/
 
                 if (isAlreadyOpen) {
                     emit this->documentReloaded(tabWidget, tabIndex);

--- a/src/ui/docengine.cpp
+++ b/src/ui/docengine.cpp
@@ -238,7 +238,20 @@ QList<std::pair<QSharedPointer<Editor>, QPromise<QSharedPointer<Editor>>>> DocEn
 
         auto continuationP = QPromise<QSharedPointer<Editor>>([=](auto resolve, auto reject)
         {
-            QTimer::singleShot(0, [=]()
+            // Compute the ms of delay based on the priority for this URL.
+            constexpr int min_priority_delay = 100;
+            int delay_ms = 0;
+            if (docLoader.priorityIdx >= 0) {
+                delay_ms = docLoader.priorityIdx == i ? 0 : min_priority_delay;
+            } else if (docLoader.priorityIdx == DocumentLoader::ALL_MAXIMUM_PRIORITY) {
+                delay_ms = 0;
+            } else if (docLoader.priorityIdx == DocumentLoader::ALL_MINIMUM_PRIORITY) {
+                delay_ms = min_priority_delay;
+            } else {
+                Q_ASSERT(false); // Should never get here
+            }
+
+            QTimer::singleShot(delay_ms, [=]()
             {
                 // In case of a reload, save cursor, scroll position, language
                 QPair<int, int> scrollPosition;

--- a/src/ui/docengine.cpp
+++ b/src/ui/docengine.cpp
@@ -136,6 +136,216 @@ int showReloadDialog(const QString docName) {
     return msgBox.exec();
 }
 
+QList<std::pair<QSharedPointer<Editor>, QPromise<QSharedPointer<Editor>>>> DocEngine::loadDocumentsInBackground(const DocEngine::DocumentLoader& docLoader)
+{
+    const auto& fileNames = docLoader.urls;
+    const auto& rememberLastSelectedDir = docLoader.rememberLastDir;
+    const auto& reloadAction = docLoader.reloadAction;
+    const auto& codec = docLoader.textCodec;
+    const auto& bom = docLoader.bom;
+    auto fileSizeAction = std::make_shared<FileSizeAction>(docLoader.fileSizeAction);
+
+    if (fileNames.empty())
+        return QList<std::pair<QSharedPointer<Editor>, QPromise<QSharedPointer<Editor>>>>();
+
+    if (rememberLastSelectedDir)
+        NqqSettings::getInstance().General.setLastSelectedDir(QFileInfo(fileNames[0].toLocalFile()).absolutePath());
+
+    QList<std::pair<QSharedPointer<Editor>, QPromise<QSharedPointer<Editor>>>> loadedEditors;
+
+    //bool isFirstDocument = true;
+
+    for (int i = 0; i < fileNames.count(); i++) {
+        const QUrl& url = fileNames[i];
+
+        if (url.isEmpty())
+            continue;
+
+        if (!url.isLocalFile()) {
+            QMessageBox msgBox;
+            msgBox.setWindowTitle(QCoreApplication::applicationName());
+            msgBox.setText(tr("Protocol not supported for file \"%1\".").arg(url.toDisplayString()));
+            msgBox.exec();
+            continue;
+        }
+
+        QString localFileName = url.toLocalFile();
+        QFileInfo fi(localFileName);
+
+        const QPair<int, int> openPos = findOpenEditorByUrl(url);
+        const bool isAlreadyOpen = openPos.first > -1; //'true' when we're reloading a tab
+
+        if(isAlreadyOpen && reloadAction == ReloadActionDont) {
+            EditorTabWidget *tabW = static_cast<EditorTabWidget *>
+                                    (m_topEditorContainer->widget(openPos.first));
+
+            /*if (isFirstDocument) {
+                isFirstDocument = false;
+                tabW->setCurrentIndex(openPos.second);
+            }*/
+
+            emit this->documentLoaded(tabW, openPos.second, true, rememberLastSelectedDir);
+            continue;
+        }
+
+        const int warnAtSize = NqqSettings::getInstance().General.getWarnIfFileLargerThan() * 1024 * 1024;
+        const auto fileSize = fi.size();
+
+        // Only warn if warnAtSize is at least 1. Otherwise the warning is disabled.
+        const bool fileTooLarge = warnAtSize > 0 && fileSize > warnAtSize;
+        if (*fileSizeAction!=FileSizeActionYesToAll && fileTooLarge) {
+            if (*fileSizeAction==FileSizeActionNoToAll)
+                continue;
+
+            int ret = showFileSizeDialog(fi.fileName(), fileSize, fileNames.size() > 1);
+
+            switch(ret) {
+            case QMessageBox::YesToAll:
+                *fileSizeAction = FileSizeActionYesToAll;
+                break;
+            case QMessageBox::Yes:
+                break;
+            case QMessageBox::NoToAll:
+                *fileSizeAction = FileSizeActionNoToAll;
+                continue;
+            case QMessageBox::No:
+                continue;
+            }
+        }
+
+        auto* tabWidget = docLoader.tabWidget;
+        int tabIndex;
+        if (isAlreadyOpen) {
+            tabWidget = m_topEditorContainer->tabWidget(openPos.first);
+            tabIndex = openPos.second;
+        } else {
+            tabIndex = tabWidget->addEditorTab(false, fi.fileName());
+        }
+
+        auto editor = tabWidget->editor(tabIndex);
+        editor->isLoading = true;
+
+        // Once we are here, we can NOT remove the tab
+
+        // If there was only a new empty tab opened, remove it
+        if (tabWidget->count() == 2) {
+            auto victim = tabWidget->editor(0);
+            if (!victim->isLoading && victim->filePath().isEmpty() && victim->isClean()) {
+                tabWidget->removeTab(0);
+                tabIndex--;
+            }
+        }
+
+        auto continuationP = QPromise<QSharedPointer<Editor>>([=](auto resolve, auto reject)
+        {
+            QTimer::singleShot(0, [=]()
+            {
+                // In case of a reload, save cursor, scroll position, language
+                QPair<int, int> scrollPosition;
+                QPair<int, int> cursorPosition;
+                const EditorNS::Language* language;
+                if (isAlreadyOpen) {
+                    scrollPosition = editor->scrollPosition();
+                    cursorPosition = editor->cursorPosition();
+                    language = editor->getLanguage();
+                }
+
+                if (isAlreadyOpen && reloadAction == DocEngine::ReloadActionAsk && !editor->isClean()) {
+                    EditorTabWidget *tabW = static_cast<EditorTabWidget *>
+                                            (m_topEditorContainer->widget(openPos.first));
+                    tabW->setCurrentIndex(openPos.second);
+
+                    int retVal = showReloadDialog(fi.fileName());
+                    if (retVal == QMessageBox::Cancel) {
+                        resolve(editor);
+                        return;
+                    }
+                }
+
+                QFile file(localFileName);
+                if (file.exists()) {
+                    QPromise<void> readResult = this->read(&file, editor, codec, bom).wait();
+
+                    while (readResult.isRejected()) {
+                        // Handle error
+                        QMessageBox msgBox;
+                        msgBox.setWindowTitle(QCoreApplication::applicationName());
+                        msgBox.setText(tr("Error trying to open \"%1\"").arg(fi.fileName()));
+                        msgBox.setDetailedText(file.errorString());
+                        //msgBox.setStandardButtons(QMessageBox::Abort | QMessageBox::Retry | QMessageBox::Ignore);
+                        msgBox.setStandardButtons(QMessageBox::Retry | QMessageBox::Ignore);
+                        msgBox.setDefaultButton(QMessageBox::Retry);
+                        msgBox.setIcon(QMessageBox::Critical);
+                        int ret = msgBox.exec();
+                        /*if(ret == QMessageBox::Abort) {
+                            tabWidget->removeTab(tabIndex);
+                            return _break; // stop whole loading process
+                        } else*/
+                        if(ret == QMessageBox::Retry) {
+                            // Retry
+                            readResult = this->read(&file, editor, codec, bom).wait();
+                        } else if(ret == QMessageBox::Ignore) {
+                            //tabWidget->removeTab(tabIndex);
+                            //reject(QSharedPointer<Editor>());
+                            resolve(editor);
+                            return;
+                        }
+                    }
+                }
+
+                // In case of reload, restore cursor, scroll position, language
+                if (isAlreadyOpen) {
+                    editor->setScrollPosition(scrollPosition);
+                    editor->setCursorPosition(cursorPosition);
+                    editor->setLanguage(language);
+                }
+
+                if (!file.exists()) {
+                    // If it's a file that doesn't exists,
+                    // set it as if it has changed. This way, if someone
+                    // creates that file from outside of notepadqq,
+                    // when the user tries to save over it he gets a warning.
+                    editor->setFileOnDiskChanged(true);
+                    editor->markDirty();
+                }
+
+                file.close();
+                if (isAlreadyOpen) {
+                    editor->setFileOnDiskChanged(false);
+                } else {
+                    editor->setFilePath(url);
+                    tabWidget->setTabToolTip(tabIndex, fi.absoluteFilePath());
+                    editor->setLanguageFromFilePath();
+                }
+
+                this->monitorDocument(editor);
+
+                /*if (isFirstDocument) {
+                    isFirstDocument = false;
+                    tabWidget->setCurrentIndex(tabIndex);
+                    tabWidget->editor(tabIndex)->setFocus();
+                }*/
+
+                if (isAlreadyOpen) {
+                    emit this->documentReloaded(tabWidget, tabIndex);
+                } else {
+                    emit this->documentLoaded(tabWidget, tabIndex, false, rememberLastSelectedDir);
+                }
+
+                resolve(editor);
+            });
+
+        }).then([](QSharedPointer<Editor> editor){
+            editor->isLoading = false;
+            return editor;
+        });
+
+        loadedEditors.append(std::make_pair(editor, continuationP));
+    }
+
+    return loadedEditors;
+}
+
 QPromise<void> DocEngine::loadDocuments(const DocEngine::DocumentLoader& docLoader)
 {
     const auto& fileNames = docLoader.urls;
@@ -442,6 +652,7 @@ QPromise<void> DocEngine::loadDocuments(const DocEngine::DocumentLoader& docLoad
         if (isAlreadyOpen) {
             editor->setScrollPosition(scrollPosition);
             editor->setCursorPosition(cursorPosition);
+            editor->setLanguage(language);
         }
 
         if (!file.exists()) {

--- a/src/ui/editortabwidget.cpp
+++ b/src/ui/editortabwidget.cpp
@@ -78,6 +78,15 @@ void EditorTabWidget::disconnectEditorSignals(Editor *editor)
                this, &EditorTabWidget::on_fileNameChanged);
 }
 
+int EditorTabWidget::indexOf(QSharedPointer<Editor> editor) const
+{
+    return indexOf(editor.data());
+}
+
+int EditorTabWidget::indexOf(QWidget *widget) const
+{
+    return QTabWidget::indexOf(widget);
+}
 
 QString EditorTabWidget::tabText(Editor* editor) const
 {
@@ -329,15 +338,9 @@ void EditorTabWidget::mouseReleaseEvent(QMouseEvent *ev)
     QTabWidget::mouseReleaseEvent(ev);
 }
 
-void EditorTabWidget::on_fileNameChanged(const QUrl & /*oldFileName*/, const QUrl &newFileName)
+QString EditorTabWidget::generateTabTitleForUrl(const QUrl &filename) const
 {
-    Editor *editor = dynamic_cast<Editor *>(sender());
-    if (!editor)
-        return;
-
-    int index = indexOf(editor);
-
-    QString fileName = QFileInfo(newFileName.toDisplayString(QUrl::RemoveScheme |
+    QString fileName = QFileInfo(filename.toDisplayString(QUrl::RemoveScheme |
                                                    QUrl::RemovePassword |
                                                    QUrl::RemoveUserInfo |
                                                    QUrl::RemovePort |
@@ -346,11 +349,21 @@ void EditorTabWidget::on_fileNameChanged(const QUrl & /*oldFileName*/, const QUr
                                                    QUrl::RemoveFragment |
                                                    QUrl::PreferLocalFile
                                                    )).fileName();
+    return fileName;
+}
+
+void EditorTabWidget::on_fileNameChanged(const QUrl & /*oldFileName*/, const QUrl &newFileName)
+{
+    Editor *editor = dynamic_cast<Editor *>(sender());
+    if (!editor)
+        return;
+
+    int index = indexOf(editor);
 
     QString fullFileName = newFileName.toDisplayString(QUrl::PreferLocalFile |
                                                        QUrl::RemovePassword);
 
-    setTabText(index, fileName);
+    setTabText(index, generateTabTitleForUrl(newFileName));
     setTabToolTip(index, fullFileName);
 }
 

--- a/src/ui/include/EditorNS/editor.h
+++ b/src/ui/include/EditorNS/editor.h
@@ -129,6 +129,13 @@ namespace EditorNS
         };
 
         /**
+         * @brief Just a flag that is used for marking editors that are still loading,
+         * meaning for example that the Editor has been created but we still need
+         * to load the file contents or setup the syntax highlighting.
+         */
+        bool isLoading = false;
+
+        /**
              * @brief Adds a new Editor to the internal buffer used by getNewEditor().
              *        You might want to call this method e.g. as soon as the application
              *        starts (so that an Editor is ready as soon as it gets required),

--- a/src/ui/include/docengine.h
+++ b/src/ui/include/docengine.h
@@ -77,6 +77,11 @@ public:
             return docEngine.loadDocuments(*this);
         }
 
+        QList<std::pair<QSharedPointer<Editor>, QPromise<QSharedPointer<Editor>>>> executeInBackground() {
+            Q_ASSERT(tabWidget != nullptr);
+            return docEngine.loadDocumentsInBackground(*this);
+        }
+
         // See here for the arguments' default values
         QList<QUrl> urls;
         EditorTabWidget* tabWidget      = nullptr;
@@ -173,6 +178,14 @@ private:
      * @param docLoader Contains parameters for document loading. See DocumentLoader class for info.
      */
     QPromise<void> loadDocuments(const DocumentLoader& docLoader);
+
+    /**
+     * @brief Loads documents in background. Experimental API that needs to be integrated
+     * into DocumentLoader.
+     * @param docLoader
+     * @return
+     */
+    QList<std::pair<QSharedPointer<Editor>, QPromise<QSharedPointer<Editor>>>> loadDocumentsInBackground(const DocumentLoader& docLoader);
 
     void monitorDocument(const QString &fileName);
     void unmonitorDocument(const QString &fileName);

--- a/src/ui/include/docengine.h
+++ b/src/ui/include/docengine.h
@@ -69,6 +69,12 @@ public:
         // Determines how already opened documents should be treated.
         DocumentLoader& setReloadAction(ReloadAction reload) { reloadAction = reload; return *this; }
 
+        // Index of the URL that must be loaded with highest priority, for example because
+        // it will be the one with user focus. With constants ALL_MINIMUM_PRIORITY and
+        // ALL_MAXIMUM_PRIORITY, all URLs will be loaded with the same low or high priority.
+        // This parameter has effect only for background executions (i.e. executeInBackground()).
+        DocumentLoader& setPriorityIdx(int idx) { priorityIdx = idx; return *this; }
+
         /**
          * @brief execute Runs the load operation.
          */
@@ -82,6 +88,9 @@ public:
             return docEngine.loadDocumentsInBackground(*this);
         }
 
+        static constexpr int ALL_MINIMUM_PRIORITY = -1;
+        static constexpr int ALL_MAXIMUM_PRIORITY = -2;
+
         // See here for the arguments' default values
         QList<QUrl> urls;
         EditorTabWidget* tabWidget      = nullptr;
@@ -90,6 +99,7 @@ public:
         bool rememberLastDir            = true;
         bool bom                        = false;
         FileSizeAction fileSizeAction   = FileSizeActionAsk;
+        int priorityIdx                 = ALL_MAXIMUM_PRIORITY;
 
     private:
         friend class DocEngine;

--- a/src/ui/include/docengine.h
+++ b/src/ui/include/docengine.h
@@ -75,6 +75,25 @@ public:
         // This parameter has effect only for background executions (i.e. executeInBackground()).
         DocumentLoader& setPriorityIdx(int idx) { priorityIdx = idx; return *this; }
 
+        // Set whether, after an Editor has been created and his content has been loaded,
+        // the document loader should take care of things like assigning a file path to the
+        // editor, setting the syntax highlighting, enabling monitoring and so on.
+        // If not nullptr, runs the specified function to allow manual initialization instead
+        // of the internal one. Note that, in case of a document reload, the internal
+        // initialization is used regardless of this parameter. Similarly, this parameter
+        // is ignored for non-background executions (i.e. execute()).
+        // This is useful for example in case of loading tabs from a session, where in some
+        // cases a fake file path (different from the data source) must be assigned to the
+        // Editor during its loading.
+        //
+        // If this function is called, it will be called asynchronously. However, the function
+        // itself must be synchronous so that the DocumentLoader knows when to emit the
+        // DocumentLoaded event.
+        DocumentLoader& setManualEditorInitialization(
+                std::function<void(QSharedPointer<Editor> editor, const QUrl& url)> f) {
+            manualEditorInitialization = f; return *this;
+        }
+
         /**
          * @brief execute Runs the load operation.
          */
@@ -100,6 +119,7 @@ public:
         bool bom                        = false;
         FileSizeAction fileSizeAction   = FileSizeActionAsk;
         int priorityIdx                 = ALL_MAXIMUM_PRIORITY;
+        std::function<void(QSharedPointer<Editor> editor, const QUrl& url)> manualEditorInitialization = nullptr;
 
     private:
         friend class DocEngine;

--- a/src/ui/include/editortabwidget.h
+++ b/src/ui/include/editortabwidget.h
@@ -19,6 +19,9 @@ public:
     explicit EditorTabWidget(QWidget *parent = 0);
     ~EditorTabWidget();
 
+    int indexOf(QSharedPointer<Editor> editor) const;
+    int indexOf(QWidget *widget) const;
+
     int addEditorTab(bool setFocus, const QString &title);
     /**
      * @brief Add a new document, moving it from another EditorTabWidget
@@ -67,6 +70,8 @@ public:
     void setTabText(int index, const QString& text);
 
     int formerTabIndex();
+
+    QString generateTabTitleForUrl(const QUrl &filename) const;
 
 private:
 

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -174,7 +174,11 @@ int main(int argc, char *argv[])
     qDebug() << QString("Started in " + QString::number(__aet_elapsed / 1000 / 1000) + "msec").toStdString().c_str();
 #endif
 
-    Stats::init();
+    // Initialize stats, but delay so that we are sure that
+    // any dialog will open on top of MainWindow without blocking it.
+    QTimer::singleShot(0, [](){
+        Stats::init();
+    });
 
     auto retVal = a.exec();
 


### PR DESCRIPTION
Dramatically improve Notepadqq startup time by loading tabs in the background.

- [x] Basic functionality for session loading
- [x] Active editors should have priority during loading
- [x] Fix filename flickering
- [x] Test loading in the case of no preexisting session to load
- [ ] Implement background loading for command line parameters (separate PR?)
- [x] Code cleanup