### PR TITLE
Update AppData file

### DIFF
--- a/support_files/notepadqq.appdata.xml
+++ b/support_files/notepadqq.appdata.xml
@@ -29,6 +29,7 @@
     <binary>notepadqq</binary>
   </provides>
   <releases>
+    <release version="2.0.0~beta" date="2019-10-08" type="development"/>
     <release version="1.9.99" date="2019-08-30" type="development"/>
     <release version="1.4.8" date="2018-05-10"/>
   </releases>


### PR DESCRIPTION
 - Update `<releases>`

Why `2.0.0~beta` (_tilde_) instead of `2.0.0-beta` _(hyphen-minus_)? Because of this:
```
$ flatpak run org.freedesktop.appstream-glib vercmp 1.9.99 2.0.0~beta
1.9.99 < 2.0.0~beta
$ flatpak run org.freedesktop.appstream-glib vercmp 2.0.0~beta 2.0.0
2.0.0~beta < 2.0.0
$ flatpak run org.freedesktop.appstream-glib vercmp 2.0.0-beta 2.0.0
2.0.0-beta > 2.0.0
```
```
$ rpmdev-vercmp 1.9.99 2.0.0~beta
1.9.99 < 2.0.0~beta
$ rpmdev-vercmp 2.0.0~beta 2.0.0
2.0.0~beta < 2.0.0
$ rpmdev-vercmp 2.0.0-beta 2.0.0
2.0.0-beta > 2.0.0
```