### PR TITLE
Fix typo in original for it/ja translation files

### DIFF
--- a/src/translations/notepadqq_it.ts
+++ b/src/translations/notepadqq_it.ts
@@ -2072,7 +2072,7 @@ Vuoi salvare comunque?</translation>
     </message>
     <message>
         <location filename="../ui/frmpreferences.ui" line="133"/>
-        <source>This option allows Notepadqq to recover your documents after a crash even if they were not explicitely saved.</source>
+        <source>This option allows Notepadqq to recover your documents after a crash even if they were not explicitly saved.</source>
         <translation>Questa opzione permette a Notepadqq di ripristinare i tuoi documenti dopo un crash anche se non sono stati esplicitamente salvati.</translation>
     </message>
     <message>

--- a/src/translations/notepadqq_ja.ts
+++ b/src/translations/notepadqq_ja.ts
@@ -2074,7 +2074,7 @@ Do you want to save it anyway?</source>
     </message>
     <message>
         <location filename="../ui/frmpreferences.ui" line="133"/>
-        <source>This option allows Notepadqq to recover your documents after a crash even if they were not explicitely saved.</source>
+        <source>This option allows Notepadqq to recover your documents after a crash even if they were not explicitly saved.</source>
         <translation>このオプションは、Notepadqq がクラッシュした際にドキュメントを保存していなかった場合でも、ドキュメントの復元を可能にします。</translation>
     </message>
     <message>


### PR DESCRIPTION
The typo was corrected in the original and most translations, but these two missed the train