### PR TITLE
Remove deprecated Encodig= line from desktop launcher

### DIFF
--- a/support_files/shortcuts/notepadqq.desktop
+++ b/support_files/shortcuts/notepadqq.desktop
@@ -1,6 +1,5 @@
 [Desktop Entry]
 Version=1.1
-Encoding=UTF-8
 Name=Notepadqq
 Name[de_DE]=Notepadqq
 Name[fr]=Notepadqq


### PR DESCRIPTION
This entry line is deprecated on the latest freedesktop standards.

See: https://specifications.freedesktop.org/desktop-entry-spec/latest/apc.html