### PR TITLE
Fix special placeholders for running commands

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2247,8 +2247,8 @@ void MainWindow::runCommand()
         QString cmd = command;
         if (!url.isEmpty()) {
             cmd.replace("\%url\%", url.toString(QUrl::None));
-            cmd.replace("\%path\%", url.path(QUrl::FullyEncoded));
-            cmd.replace("\%filename\%", url.fileName(QUrl::FullyEncoded));
+            cmd.replace("\%path\%", url.path(QUrl::FullyDecoded));
+            cmd.replace("\%filename\%", url.fileName(QUrl::FullyDecoded));
             cmd.replace("\%directory\%", QFileInfo(url.toLocalFile()).absolutePath());
         }
         if (!selection.first().isEmpty()) {


### PR DESCRIPTION
Special placeholders were meant to be used in commands; however, the path and filename placeholders pointed to nonexistent files if they contained any spaces because spaces were returned as "%20". By decoding the placeholders, spaces are returned normally.