### PR TITLE
QtWebEngine settings for AppImage builds

### DIFF
--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -28,6 +28,11 @@ void loadExtensions();
 
 int main(int argc, char *argv[])
 {
+#ifdef APPIMAGE_BUILD
+    qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--disable-gpu --no-sandbox");
+    QApplication::setAttribute(Qt::AA_UseOpenGLES);
+#endif
+
     QTranslator translator;
 #ifdef QT_DEBUG
     QElapsedTimer __aet_timer;


### PR DESCRIPTION
Otherwise the editor page will remain blank. Only relevant if you want to bundle it as an AppImage.
See https://github.com/probonopd/linuxdeployqt/issues/554#issuecomment-1285876053
