### PR TITLE
Use bash to setup git hooks

### DIFF
--- a/build-tools/setup-hooks.sh
+++ b/build-tools/setup-hooks.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 echo -n "Setting up git hooks..."
 # All of our hooks for convenience go here

--- a/build-tools/setup-hooks.sh
+++ b/build-tools/setup-hooks.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 echo -n "Setting up git hooks..."
 # All of our hooks for convenience go here


### PR DESCRIPTION
Fixes the following errors on Debian, where /bin/sh is not bash:

    ./setup-hooks.sh: 2: Bad substitution