### PR TITLE
added some null pointer checks to avoid crashes

### DIFF
--- a/src/ui/Sessions/backupservice.cpp
+++ b/src/ui/Sessions/backupservice.cpp
@@ -79,12 +79,21 @@ void BackupService::executeBackup() {
 
 bool BackupService::writeBackup(MainWindow* wnd)
 {
+    if (wnd == nullptr) {
+        return false;
+    }
+
     // Save this MainWindow as a session inside the autosave path.
     // MainWindow's address is used to have a unique path name.
     const auto& backupPath = PersistentCache::backupDirPath();
     const auto ptrToInt = reinterpret_cast<uintptr_t>(wnd);
     const QString cachePath = backupPath + QString("/window_%1").arg(ptrToInt);
     const QString sessPath = backupPath + QString("/window_%1/window.xml").arg(ptrToInt);
+
+    TopEditorContainer *topEdCon = wnd->topEditorContainer();
+    if (topEdCon == nullptr) {
+        return false;
+    }
 
     return Sessions::saveSession(wnd->getDocEngine(), wnd->topEditorContainer(), sessPath, cachePath);
 }

--- a/src/ui/Sessions/sessions.cpp
+++ b/src/ui/Sessions/sessions.cpp
@@ -257,6 +257,10 @@ namespace Sessions {
 
 bool saveSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QString sessionPath, QString cacheDirPath)
 {
+    if (editorContainer == nullptr) {
+        return false;
+    }
+
     const bool cacheModifiedFiles = !cacheDirPath.isEmpty();
 
     QDir cacheDir;
@@ -282,6 +286,11 @@ bool saveSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
     const int tabWidgetsCount = editorContainer->count();
     for (int i = 0; i < tabWidgetsCount; i++) {
         EditorTabWidget *tabWidget = editorContainer->tabWidget(i);
+
+        if (tabWidget == nullptr) {
+            continue;
+        }
+
         const int tabCount = tabWidget->count();
 
         viewData.push_back( ViewData() );


### PR DESCRIPTION
I wanted to start adding some line operation features, but engaged in solving the annoying crashes. It seems that these simple null pointer checks avoids the crashes. But maybe to completely solve the issue, we need to fix timer and backup service objects life cycles in the future.