### PR TITLE
adding the transpose-line feature

### DIFF
--- a/src/editor/app.js
+++ b/src/editor/app.js
@@ -529,6 +529,22 @@ UiDriver.registerEventHandler("C_CMD_MOVE_LINE_DOWN", function(msg, data, prevRe
     
 });
 
+UiDriver.registerEventHandler("C_CMD_TRANSPOSE_LINE", function(msg, data, prevReturn) {
+
+    var cur = editor.getCursor();
+
+    if (cur.line > 0) {
+        var line = editor.getLine(cur.line) + '\n' + editor.getLine(cur.line - 1);
+        var from = { line: cur.line - 1, ch: 0          };
+        var to   = { line: cur.line,     ch: line.length};
+
+        editor.replaceRange(line, from, to);
+        editor.setCursor(cur.line, cur.ch );
+    }
+    else {
+        return false;
+    }
+});
 
 UiDriver.registerEventHandler("C_CMD_DELETE_LINE", function(msg, data, prevReturn) {
     editor.execCommand("deleteLine");

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -178,6 +178,7 @@ private slots:
     void on_actionDuplicate_Line_triggered();
     void on_actionMove_Line_Up_triggered();
     void on_actionMove_Line_Down_triggered();
+    void on_actionTranspose_Line_triggered();
     void on_actionTrim_Trailing_Space_triggered();
     void on_actionTrim_Leading_Space_triggered();
     void on_actionTrim_Leading_and_Trailing_Space_triggered();

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2468,6 +2468,11 @@ void MainWindow::on_actionMove_Line_Down_triggered()
     currentEditor()->sendMessage("C_CMD_MOVE_LINE_DOWN");
 }
 
+void MainWindow::on_actionTranspose_Line_triggered()
+{
+    currentEditor()->sendMessage("C_CMD_TRANSPOSE_LINE");
+}
+
 void MainWindow::on_actionTrim_Trailing_Space_triggered()
 {
     currentEditor()->sendMessage("C_CMD_TRIM_TRAILING_SPACE");

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -123,6 +123,7 @@
      <addaction name="actionDelete_Line"/>
      <addaction name="actionMove_Line_Up"/>
      <addaction name="actionMove_Line_Down"/>
+     <addaction name="actionTranspose_Line"/>
     </widget>
     <widget class="QMenu" name="menuBlank_Operations">
      <property name="title">
@@ -937,6 +938,17 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+Down</string>
+   </property>
+  </action>
+  <action name="actionTranspose_Line">
+   <property name="text">
+    <string>&amp;Transpose Line</string>
+   </property>
+   <property name="toolTip">
+    <string>Transpose the current line with the line above</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+T</string>
    </property>
   </action>
   <action name="actionTrim_Trailing_Space">


### PR DESCRIPTION
Notepad++ has a line-operation feature named "Transpose Line" which transposes the current line with the above one, I found the name of this feature from it's source code because at the time of this writing, it is not mentioned in the menus. I put this feature in the line operation menu with the shortcut key ctrl+shift+T, the shortcut for it in the notepad++ is ctrl+t but that shortcut in notepadqq is already taken up for toggling the tabs... 

I think later we should organize and group the line operations and commands of it in the source code by some standard, because right now it may looks a little unorganized 🤔.