### PR TITLE
adding the RTL/LTR dir change feature

### DIFF
--- a/src/editor/app.js
+++ b/src/editor/app.js
@@ -146,6 +146,14 @@ UiDriver.registerEventHandler("C_CMD_SET_CURSOR", function(msg, data, prevReturn
     editor.setCursor(line, ch);
 });
 
+UiDriver.registerEventHandler("C_CMD_SET_RTL", function(msg, data, prevReturn) {
+    editor.setOption("direction", "rtl");
+});
+
+UiDriver.registerEventHandler("C_CMD_SET_LTR", function(msg, data, prevReturn) {
+    editor.setOption("direction", "ltr");
+});
+
 UiDriver.registerEventHandler("C_FUN_GET_SCROLL_POS", function(msg, data, prevReturn) {
     var scroll = editor.getScrollInfo();
     return [scroll.left, scroll.top];

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -110,6 +110,8 @@ private slots:
     void on_cursorActivity(QMap<QString, QVariant> data);
     void on_actionDelete_triggered();
     void on_actionSelect_All_triggered();
+    void on_actionSet_RTL_triggered();
+    void on_actionSet_LTR_triggered();
     void on_actionAbout_Notepadqq_triggered();
     void on_actionAbout_Qt_triggered();
     void on_actionUndo_triggered();

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1413,6 +1413,16 @@ void MainWindow::on_actionSelect_All_triggered()
     currentEditor()->sendMessage("C_CMD_SELECT_ALL");
 }
 
+void MainWindow::on_actionSet_RTL_triggered()
+{
+    currentEditor()->sendMessage("C_CMD_SET_RTL");
+}
+
+void MainWindow::on_actionSet_LTR_triggered()
+{
+    currentEditor()->sendMessage("C_CMD_SET_LTR");
+}
+
 void MainWindow::on_actionAbout_Notepadqq_triggered()
 {
     frmAbout *_about;

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -1102,7 +1102,7 @@
       <string>Change Layout Direction to Left-to-Right</string>
     </property>
     <property name="shortcut">
-      <string>Ctrl+Alt+Shift+R</string>
+      <string>Ctrl+Alt+Shift+L</string>
     </property>
   </action>
  </widget>

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -1085,7 +1085,7 @@
   </action>
   <action name="actionSet_RTL">
     <property name="text">
-      <string>Set &amp;RTL</string>
+      <string>Text Direction &amp;RTL</string>
     </property>
     <property name="toolTip">
       <string>Change Layout Direction to Right-to-Left</string>
@@ -1096,7 +1096,7 @@
   </action>
   <action name="actionSet_LTR">
     <property name="text">
-      <string>Set &amp;LTR</string>
+      <string>Text Direction &amp;LTR</string>
     </property>
     <property name="toolTip">
       <string>Change Layout Direction to Left-to-Right</string>

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -209,6 +209,8 @@
     <addaction name="actionMath_Rendering"/>
     <addaction name="actionToggle_To_Former_Tab"/>
     <addaction name="separator"/>
+    <addaction name="actionSet_RTL"/>
+    <addaction name="actionSet_LTR"/>
     <addaction name="separator"/>
     <addaction name="actionFull_Screen"/>
    </widget>
@@ -1080,6 +1082,28 @@
    <property name="shortcut">
     <string>Ctrl+T</string>
    </property>
+  </action>
+  <action name="actionSet_RTL">
+    <property name="text">
+      <string>Set &amp;RTL</string>
+    </property>
+    <property name="toolTip">
+      <string>Change Layout Direction to Right-to-Left</string>
+    </property>
+    <property name="shortcut">
+      <string>Ctrl+Alt+Shift+R</string>
+    </property>
+  </action>
+  <action name="actionSet_LTR">
+    <property name="text">
+      <string>Set &amp;LTR</string>
+    </property>
+    <property name="toolTip">
+      <string>Change Layout Direction to Left-to-Right</string>
+    </property>
+    <property name="shortcut">
+      <string>Ctrl+Alt+Shift+R</string>
+    </property>
   </action>
  </widget>
  <layoutdefault spacing="6" margin="11"/>


### PR DESCRIPTION
In notepad++, they used ctrl+alt+R/L for the shortcut keys, but I had problem with ctrl+alt+L, because it was used for xflock4 on Ubuntu/xfce4 on my PC. So decided to use a rare shortcut: ctrl+alt+shift+R/L, we can change it in the present and future if it was necessary. 🤔

The place of it in the menu is like Notepad++. I tested the feature and so far is working well.