### PR TITLE
removing QRandomGenerator::global() seeding to avoid crash for Qt6

### DIFF
--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -38,8 +38,15 @@ int main(int argc, char *argv[])
     printerrln("WARNING: Notepadqq is running in DEBUG mode.");
 #endif
 
-    // Initialize random number generator
-    QRandomGenerator::global()->seed(QDateTime::currentDateTimeUtc().time().msec() + QRandomGenerator::global()->generate());
+    // according to https://doc.qt.io/qt-6/qrandomgenerator.html:
+    // "The global generator is securely seeded by the operating
+    // system's cryptographic random number generator... It is not
+    // necessary to seed the global generator manually."
+    //
+    // "Note: It is not permitted to seed the global or system
+    // generators. Attempting to do so will result in a fatal error."
+    //
+    // QRandomGenerator::global()->seed(QDateTime::currentDateTimeUtc().time().msec() + QRandomGenerator::global()->generate());
 
 #if QT_VERSION > QT_VERSION_CHECK(5, 6, 0)
     SingleApplication::setAttribute(Qt::AA_EnableHighDpiScaling);


### PR DESCRIPTION
QRandomGenerator::global() seeding caused a runtime crash for Qt6. For more info about why this kind of global seeding is deprecated and should not be used for newer Qts read this:

https://doc.qt.io/qt-6/qrandomgenerator.html

