### PR TITLE
fix: show hidden files in file dialogs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ set(NQQ_APP_SOURCES
     src/ui/Sessions/sessions.cpp
     src/ui/Sessions/persistentcache.cpp
     src/ui/nqqsettings.cpp
+    src/ui/nqqfiledialog.cpp
     src/ui/nqqrun.cpp
     src/ui/Search/filesearcher.cpp
     src/ui/Search/filereplacer.cpp
@@ -147,6 +148,7 @@ set(NQQ_APP_HEADERS
     src/ui/include/Sessions/sessions.h
     src/ui/include/Sessions/persistentcache.h
     src/ui/include/nqqsettings.h
+    src/ui/include/nqqfiledialog.h
     src/ui/include/nqqrun.h
     src/ui/include/Search/filesearcher.h
     src/ui/include/Search/searchobjects.h

--- a/src/ui-tests/tst_notepadqqtest.cpp
+++ b/src/ui-tests/tst_notepadqqtest.cpp
@@ -2,8 +2,14 @@
 #include "include/editoruicontroller.h"
 #include "include/mainwindow.h"
 #include "include/notepadqq.h"
+#include "include/nqqfiledialog.h"
+#include "include/nqqsettings.h"
 
 #include <QCloseEvent>
+#include <QDir>
+#include <QFile>
+#include <QFileDialog>
+#include <QFileSystemModel>
 #include <QPointer>
 #include <QSettings>
 #include <QString>
@@ -22,6 +28,10 @@ private Q_SLOTS:
     void editorPathIsHtml();
     void acceptedCloseDisconnectsEditorUiController();
     void directWindowDeletionDestroysEditorUiControllerFirst();
+    void hiddenFilesSettingDrivesDialogFilter();
+    void showingHiddenFilesGivesUpTheNativeDialog();
+    void entryFiltersRevealDotFiles();
+    void forcedQtDialogActuallyListsHiddenEntries();
 
 private:
     QTemporaryDir m_settingsDirectory;
@@ -107,6 +117,117 @@ void NotepadqqTest::directWindowDeletionDestroysEditorUiControllerFirst()
     delete window;
 
     QCOMPARE(destructionOrder, QStringList({"controller", "window"}));
+}
+
+// Restores the file dialog settings whatever the test does with them.
+class FileDialogSettingsGuard {
+public:
+    FileDialogSettingsGuard()
+        : m_native(NqqSettings::getInstance().General.getUseNativeFilePicker())
+        , m_hidden(NqqSettings::getInstance().General.getShowHiddenFiles())
+    {
+    }
+    ~FileDialogSettingsGuard()
+    {
+        NqqSettings::getInstance().General.setUseNativeFilePicker(m_native);
+        NqqSettings::getInstance().General.setShowHiddenFiles(m_hidden);
+    }
+
+private:
+    const bool m_native;
+    const bool m_hidden;
+};
+
+// The dialog filter must gain QDir::Hidden only when the user asked for hidden files.
+void NotepadqqTest::hiddenFilesSettingDrivesDialogFilter()
+{
+    FileDialogSettingsGuard guard;
+    NqqSettings::getInstance().General.setUseNativeFilePicker(false);
+
+    NqqSettings::getInstance().General.setShowHiddenFiles(false);
+    QFileDialog withoutHidden;
+    NqqFileDialog::applySettings(withoutHidden);
+    QVERIFY(!withoutHidden.filter().testFlag(QDir::Hidden));
+
+    NqqSettings::getInstance().General.setShowHiddenFiles(true);
+    QFileDialog withHidden;
+    NqqFileDialog::applySettings(withHidden);
+    QVERIFY(withHidden.filter().testFlag(QDir::Hidden));
+}
+
+// A native dialog ignores QDir::Hidden, so asking for hidden files has to force Qt's own dialog.
+void NotepadqqTest::showingHiddenFilesGivesUpTheNativeDialog()
+{
+    FileDialogSettingsGuard guard;
+    NqqSettings::getInstance().General.setUseNativeFilePicker(true);
+
+    NqqSettings::getInstance().General.setShowHiddenFiles(false);
+    QFileDialog nativeDialog;
+    NqqFileDialog::applySettings(nativeDialog);
+    QVERIFY(!nativeDialog.testOption(QFileDialog::DontUseNativeDialog));
+
+    NqqSettings::getInstance().General.setShowHiddenFiles(true);
+    QFileDialog forcedQtDialog;
+    NqqFileDialog::applySettings(forcedQtDialog);
+    QVERIFY(forcedQtDialog.testOption(QFileDialog::DontUseNativeDialog));
+    QVERIFY(forcedQtDialog.filter().testFlag(QDir::Hidden));
+}
+
+// "Open Folder" enumerates the directory itself: dot files must follow the same setting.
+void NotepadqqTest::entryFiltersRevealDotFiles()
+{
+    FileDialogSettingsGuard guard;
+
+    QTemporaryDir directory;
+    QVERIFY(directory.isValid());
+    for (const QString& name : {QStringLiteral("visible.txt"), QStringLiteral(".hidden.txt")}) {
+        QFile file(QDir(directory.path()).filePath(name));
+        QVERIFY(file.open(QIODevice::WriteOnly));
+        file.close();
+    }
+
+    NqqSettings::getInstance().General.setShowHiddenFiles(false);
+    QCOMPARE(QDir(directory.path()).entryList(QStringList(), NqqFileDialog::entryFilters(QDir::Files)),
+        QStringList({"visible.txt"}));
+
+    NqqSettings::getInstance().General.setShowHiddenFiles(true);
+    QCOMPARE(QDir(directory.path()).entryList(QStringList(), NqqFileDialog::entryFilters(QDir::Files)),
+        QStringList({".hidden.txt", "visible.txt"}));
+}
+
+// QFileDialog::setFilter() only reaches the file system model once the widgets exist, so assert
+// on the model that actually populates the list rather than on the dialog options.
+void NotepadqqTest::forcedQtDialogActuallyListsHiddenEntries()
+{
+    FileDialogSettingsGuard guard;
+    NqqSettings::getInstance().General.setUseNativeFilePicker(true);
+    NqqSettings::getInstance().General.setShowHiddenFiles(true);
+
+    QTemporaryDir directory;
+    QVERIFY(directory.isValid());
+    QFile hidden(QDir(directory.path()).filePath(".hidden.txt"));
+    QVERIFY(hidden.open(QIODevice::WriteOnly));
+    hidden.close();
+
+    QFileDialog dialog;
+    dialog.setAcceptMode(QFileDialog::AcceptOpen);
+    dialog.setFileMode(QFileDialog::ExistingFiles);
+    dialog.setDirectory(directory.path());
+    NqqFileDialog::applySettings(dialog);
+
+    // Builds the widget hierarchy without ever putting the dialog on screen.
+    dialog.setAttribute(Qt::WA_DontShowOnScreen);
+    dialog.show();
+
+    auto* model = dialog.findChild<QFileSystemModel*>();
+    QVERIFY(model);
+    QVERIFY(model->filter().testFlag(QDir::Hidden));
+
+    const QModelIndex root = model->index(directory.path());
+    QTRY_COMPARE(model->rowCount(root), 1);
+    QCOMPARE(model->index(0, 0, root).data(Qt::DisplayRole).toString(), QStringLiteral(".hidden.txt"));
+
+    dialog.hide();
 }
 
 QTEST_MAIN(NotepadqqTest)

--- a/src/ui/Search/advancedsearchdock.cpp
+++ b/src/ui/Search/advancedsearchdock.cpp
@@ -5,6 +5,7 @@
 #include "include/Search/searchstring.h"
 #include "include/iconprovider.h"
 #include "include/mainwindow.h"
+#include "include/nqqfiledialog.h"
 #include "include/nqqsettings.h"
 
 #include <QApplication>
@@ -750,7 +751,7 @@ AdvancedSearchDock::AdvancedSearchDock(MainWindow* mainWindow)
             defaultDir = NqqSettings::getInstance().General.getLastSelectedDir();
         }
 
-        QString dir = QFileDialog::getExistingDirectory(QApplication::activeWindow(),
+        QString dir = NqqFileDialog::getExistingDirectory(QApplication::activeWindow(),
             QObject::tr("Search in..."),
             defaultDir,
             QFileDialog::ShowDirsOnly | QFileDialog::ReadOnly | QFileDialog::DontResolveSymlinks);

--- a/src/ui/documentcontroller.cpp
+++ b/src/ui/documentcontroller.cpp
@@ -13,6 +13,7 @@
 #include "include/iconprovider.h"
 #include "include/mainwindow.h"
 #include "include/notepadqq.h"
+#include "include/nqqfiledialog.h"
 #include "include/nqqsettings.h"
 #include "include/topeditorcontainer.h"
 #include "ui_mainwindow.h"
@@ -145,7 +146,7 @@ void DocumentController::openDroppedUrls(QList<QUrl> urls, EditorNS::Editor* sou
         const QFileInfo fileInfo(path);
         if (fileInfo.isDir()) {
             urls.clear();
-            for (const QFileInfo& entry : QDir(path).entryInfoList(QDir::Files))
+            for (const QFileInfo& entry : QDir(path).entryInfoList(NqqFileDialog::entryFilters(QDir::Files)))
                 urls.push_back(QUrl::fromLocalFile(entry.filePath()));
         }
     }
@@ -162,10 +163,8 @@ void DocumentController::openFiles()
     BackupServicePauser backupServicePauser;
     backupServicePauser.pause();
 
-    const auto dialogOption =
-        m_settings.General.getUseNativeFilePicker() ? QFileDialog::Options() : QFileDialog::DontUseNativeDialog;
-    const QList<QUrl> fileNames = QFileDialog::getOpenFileUrls(
-        &m_window, m_window.tr("Open"), defaultUrl, m_window.tr("All files (*)"), nullptr, dialogOption);
+    const QList<QUrl> fileNames =
+        NqqFileDialog::getOpenFileUrls(&m_window, m_window.tr("Open"), defaultUrl, m_window.tr("All files (*)"));
     if (fileNames.isEmpty())
         return;
 
@@ -181,16 +180,14 @@ void DocumentController::openFolder()
     BackupServicePauser backupServicePauser;
     backupServicePauser.pause();
 
-    const auto dialogOption =
-        m_settings.General.getUseNativeFilePicker() ? QFileDialog::Options() : QFileDialog::DontUseNativeDialog;
-    const QString folder = QFileDialog::getExistingDirectory(
-        &m_window, m_window.tr("Open Folder"), defaultUrl.toLocalFile(), dialogOption);
+    const QString folder =
+        NqqFileDialog::getExistingDirectory(&m_window, m_window.tr("Open Folder"), defaultUrl.toLocalFile());
     if (folder.isEmpty())
         return;
 
     QList<QUrl> fileNames;
-    for (const QString& file : QDir(folder).entryList(QStringList(), QDir::Files)) {
-        if (!file.startsWith('.') && !file.endsWith('~'))
+    for (const QString& file : QDir(folder).entryList(QStringList(), NqqFileDialog::entryFilters(QDir::Files))) {
+        if (!file.endsWith('~'))
             fileNames.append(stringToUrl(file, folder));
     }
     if (fileNames.isEmpty())
@@ -376,14 +373,10 @@ int DocumentController::saveAs(EditorTabWidget* tabWidget, int tab, bool copy)
     BackupServicePauser backupServicePauser;
     backupServicePauser.pause();
 
-    const auto dialogOption =
-        m_settings.General.getUseNativeFilePicker() ? QFileDialog::Options() : QFileDialog::DontUseNativeDialog;
-    const QString filename = QFileDialog::getSaveFileName(&m_window,
+    const QString filename = NqqFileDialog::getSaveFileName(&m_window,
         m_window.tr("Save as"),
         saveDialogDefaultFileName(tabWidget, tab).toLocalFile(),
-        m_window.tr("Any file (*)"),
-        nullptr,
-        dialogOption);
+        m_window.tr("Any file (*)"));
     if (filename.isEmpty())
         return DocEngine::saveFileResult_Canceled;
 
@@ -648,14 +641,8 @@ void DocumentController::loadSession()
     backupServicePauser.pause();
 
     const QString recentFolder = QUrl::fromLocalFile(m_settings.General.getLastSelectedSessionDir()).toLocalFile();
-    const auto dialogOption =
-        m_settings.General.getUseNativeFilePicker() ? QFileDialog::Options() : QFileDialog::DontUseNativeDialog;
-    const QString filePath = QFileDialog::getOpenFileName(&m_window,
-        m_window.tr("Open Session..."),
-        recentFolder,
-        m_window.tr("Session file (*.xml);;Any file (*)"),
-        nullptr,
-        dialogOption);
+    const QString filePath = NqqFileDialog::getOpenFileName(
+        &m_window, m_window.tr("Open Session..."), recentFolder, m_window.tr("Session file (*.xml);;Any file (*)"));
     if (filePath.isEmpty())
         return;
 
@@ -674,7 +661,7 @@ void DocumentController::saveSession()
     dialog.setFileMode(QFileDialog::AnyFile);
     dialog.setDefaultSuffix("xml");
     dialog.setAcceptMode(QFileDialog::AcceptSave);
-    dialog.setOption(QFileDialog::DontUseNativeDialog, !m_settings.General.getUseNativeFilePicker());
+    NqqFileDialog::applySettings(dialog);
     if (!dialog.exec() || dialog.selectedFiles().isEmpty())
         return;
 

--- a/src/ui/frmpreferences.cpp
+++ b/src/ui/frmpreferences.cpp
@@ -6,11 +6,11 @@
 #include "include/keygrabber.h"
 #include "include/mainwindow.h"
 #include "include/notepadqq.h"
+#include "include/nqqfiledialog.h"
 #include "include/stats.h"
 #include "ui_frmpreferences.h"
 
 #include <QDialogButtonBox>
-#include <QFileDialog>
 #include <QInputDialog>
 #include <QSortFilterProxyModel>
 #include <QToolBar>
@@ -63,6 +63,8 @@ frmPreferences::frmPreferences(TopEditorContainer* topEditorContainer, QWidget* 
     ui->chkWarnForDifferentIndentation->setChecked(m_settings.General.getWarnForDifferentIndentation());
     ui->chkRememberSession->setChecked(m_settings.General.getRememberTabsOnExit());
     ui->chkExitOnLastTabClose->setChecked(m_settings.General.getExitOnLastTabClose());
+    ui->chkUseNativeFilePicker->setChecked(m_settings.General.getUseNativeFilePicker());
+    ui->chkShowHiddenFiles->setChecked(m_settings.General.getShowHiddenFiles());
 
     ui->chkAutosave->setChecked(m_settings.General.getAutosaveInterval() > 0);
     ui->sbAutosaveInterval->setValue(m_settings.General.getAutosaveInterval());
@@ -397,6 +399,8 @@ bool frmPreferences::applySettings()
     m_settings.General.setWarnForDifferentIndentation(ui->chkWarnForDifferentIndentation->isChecked());
     m_settings.General.setRememberTabsOnExit(ui->chkRememberSession->isChecked());
     m_settings.General.setExitOnLastTabClose(ui->chkExitOnLastTabClose->isChecked());
+    m_settings.General.setUseNativeFilePicker(ui->chkUseNativeFilePicker->isChecked());
+    m_settings.General.setShowHiddenFiles(ui->chkShowHiddenFiles->isChecked());
 
     const int autosaveInSeconds = ui->chkAutosave->isChecked() ? ui->sbAutosaveInterval->value() : 0;
     m_settings.General.setAutosaveInterval(autosaveInSeconds);
@@ -509,7 +513,7 @@ void frmPreferences::on_localizationComboBox_activated(int /*index*/)
 
 bool frmPreferences::extensionBrowseRuntime(QLineEdit* lineEdit)
 {
-    QString fn = QFileDialog::getOpenFileName(this, tr("Browse"), lineEdit->text());
+    QString fn = NqqFileDialog::getOpenFileName(this, tr("Browse"), lineEdit->text());
     if (fn.isNull())
         return false;
     lineEdit->setText(fn);

--- a/src/ui/frmpreferences.ui
+++ b/src/ui/frmpreferences.ui
@@ -173,6 +173,26 @@
           </widget>
          </item>
          <item>
+          <widget class="QCheckBox" name="chkUseNativeFilePicker">
+           <property name="toolTip">
+            <string>Use the file dialog provided by your desktop environment instead of the one built into Notepadqq.</string>
+           </property>
+           <property name="text">
+            <string>Use the native file dialog</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="chkShowHiddenFiles">
+           <property name="toolTip">
+            <string>The native file dialog cannot be asked to reveal hidden files, so enabling this option makes Notepadqq use its own file dialog.</string>
+           </property>
+           <property name="text">
+            <string>Show hidden files in file dialogs</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <layout class="QFormLayout" name="formLayout">
            <item row="1" column="0">
             <widget class="QLabel" name="localizationLabel">

--- a/src/ui/include/nqqfiledialog.h
+++ b/src/ui/include/nqqfiledialog.h
@@ -1,0 +1,79 @@
+#ifndef NQQFILEDIALOG_H
+#define NQQFILEDIALOG_H
+
+#include <QDir>
+#include <QFileDialog>
+#include <QList>
+#include <QString>
+#include <QUrl>
+
+class QWidget;
+
+/**
+ * @brief File dialogs that consistently apply Notepadqq's dialog settings.
+ *
+ * Every dialog is driven by two settings: General/UseNativeFilePicker and
+ * General/ShowHiddenFiles.
+ *
+ * Qt cannot ask a platform dialog (GTK, KDE, xdg-desktop-portal) to reveal hidden entries:
+ * QFileDialog::setFilter() only ever reaches the widget-based dialog, and the GTK theme
+ * plugin never forwards QDir::Hidden to gtk_file_chooser_set_show_hidden(). So when the user
+ * asks for hidden files we fall back to Qt's own dialog, the only one we can control.
+ *
+ * The getXXX() functions mirror the QFileDialog static functions of the same name, with those
+ * settings already applied. Prefer them over the Qt ones: the static functions give no access
+ * to the dialog they build, and therefore no way to set the hidden files filter.
+ */
+namespace NqqFileDialog {
+
+/**
+ * @brief Applies the UseNativeFilePicker and ShowHiddenFiles settings to a dialog.
+ * @param dialog A dialog whose file mode and options have already been set. Calling this
+ *        earlier would let those setters discard the hidden files filter.
+ */
+void applySettings(QFileDialog& dialog);
+
+/**
+ * @brief Adds QDir::Hidden to the given filters when the user asked to see hidden files.
+ *
+ * For the places where we enumerate a directory ourselves instead of going through a dialog.
+ *
+ * @param baseFilters The filters the caller would have used.
+ * @return The filters to pass to QDir.
+ */
+QDir::Filters entryFilters(QDir::Filters baseFilters);
+
+/**
+ * @brief Asks the user for one or more existing files.
+ * @param dir Starting location. As in Qt, a URL pointing at a file opens its parent directory
+ *        and preselects the file.
+ * @return The selected URLs, empty if the user cancelled.
+ */
+QList<QUrl> getOpenFileUrls(QWidget* parent, const QString& caption, const QUrl& dir, const QString& filter);
+
+/**
+ * @brief Asks the user for a single existing file.
+ * @return The selected path, a null string if the user cancelled.
+ */
+QString getOpenFileName(QWidget* parent,
+    const QString& caption,
+    const QString& dir = QString(),
+    const QString& filter = QString());
+
+/**
+ * @brief Asks the user where to save a file.
+ * @param dir Starting location, whose file name part becomes the proposed name.
+ * @return The chosen path, a null string if the user cancelled.
+ */
+QString getSaveFileName(QWidget* parent, const QString& caption, const QString& dir, const QString& filter);
+
+/**
+ * @brief Asks the user for an existing directory.
+ * @return The selected path, a null string if the user cancelled.
+ */
+QString getExistingDirectory(
+    QWidget* parent, const QString& caption, const QString& dir, QFileDialog::Options options = QFileDialog::Options());
+
+} // namespace NqqFileDialog
+
+#endif // NQQFILEDIALOG_H

--- a/src/ui/include/nqqsettings.h
+++ b/src/ui/include/nqqsettings.h
@@ -112,6 +112,8 @@ public:
     NQQ_SETTING(SmartIndentation, bool, true)
     NQQ_SETTING(MathRendering, bool, true)
     NQQ_SETTING(UseNativeFilePicker, bool, true)
+    // Forces the non-native dialog when enabled: a platform file picker ignores QDir::Hidden.
+    NQQ_SETTING(ShowHiddenFiles, bool, true)
     NQQ_SETTING(EditorEngine, QString, "auto")
     END_CATEGORY(General)
 

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -12,13 +12,13 @@
 #include "include/frmabout.h"
 #include "include/frmpreferences.h"
 #include "include/notepadqq.h"
+#include "include/nqqfiledialog.h"
 #include "include/nqqrun.h"
 #include "include/windowuicontroller.h"
 #include "ui_mainwindow.h"
 
 #include <QClipboard>
 #include <QDesktopServices>
-#include <QFileDialog>
 #include <QInputDialog>
 #include <QLineEdit>
 #include <QMessageBox>
@@ -1025,7 +1025,7 @@ void MainWindow::on_actionInstall_Extension_triggered()
     BackupServicePauser bsp;
     bsp.pause();
 
-    QString file = QFileDialog::getOpenFileName(this, tr("Extension"), QString(), "Notepadqq extensions (*.nqqext)");
+    QString file = NqqFileDialog::getOpenFileName(this, tr("Extension"), QString(), "Notepadqq extensions (*.nqqext)");
     if (!file.isNull()) {
         Extensions::InstallExtension* installExt = new Extensions::InstallExtension(file, this);
         installExt->exec();

--- a/src/ui/nqqfiledialog.cpp
+++ b/src/ui/nqqfiledialog.cpp
@@ -1,0 +1,118 @@
+#include "include/nqqfiledialog.h"
+
+#include "include/nqqsettings.h"
+
+#include <QFileInfo>
+
+namespace NqqFileDialog {
+
+namespace {
+
+// Reproduces what the static QFileDialog functions do with their "dir" argument: a path pointing
+// at a file selects that file inside its own directory, anything else is a starting directory.
+void applyInitialLocation(QFileDialog& dialog, const QUrl& location)
+{
+    if (location.isEmpty())
+        return;
+
+    if (!location.isLocalFile()) {
+        dialog.setDirectoryUrl(location);
+        return;
+    }
+
+    const QFileInfo info(location.toLocalFile());
+    if (info.isDir()) {
+        dialog.setDirectory(info.absoluteFilePath());
+        return;
+    }
+
+    dialog.setDirectory(info.absolutePath());
+    if (!info.fileName().isEmpty())
+        dialog.selectFile(info.fileName());
+}
+
+bool showHiddenFiles()
+{ return NqqSettings::getInstance().General.getShowHiddenFiles(); }
+
+} // namespace
+
+void applySettings(QFileDialog& dialog)
+{
+    const bool showHidden = showHiddenFiles();
+
+    // A platform dialog silently ignores the QDir::Hidden filter below, so honouring the
+    // setting means giving up the native one.
+    const bool useNative = NqqSettings::getInstance().General.getUseNativeFilePicker() && !showHidden;
+    dialog.setOption(QFileDialog::DontUseNativeDialog, !useNative);
+
+    if (showHidden)
+        dialog.setFilter(dialog.filter() | QDir::Hidden);
+}
+
+QDir::Filters entryFilters(QDir::Filters baseFilters)
+{ return showHiddenFiles() ? (baseFilters | QDir::Hidden) : baseFilters; }
+
+QList<QUrl> getOpenFileUrls(QWidget* parent, const QString& caption, const QUrl& dir, const QString& filter)
+{
+    QFileDialog dialog(parent, caption);
+    dialog.setAcceptMode(QFileDialog::AcceptOpen);
+    dialog.setFileMode(QFileDialog::ExistingFiles);
+    if (!filter.isEmpty())
+        dialog.setNameFilter(filter);
+    applyInitialLocation(dialog, dir);
+    applySettings(dialog);
+
+    if (dialog.exec() != QDialog::Accepted)
+        return {};
+
+    return dialog.selectedUrls();
+}
+
+QString getOpenFileName(QWidget* parent, const QString& caption, const QString& dir, const QString& filter)
+{
+    QFileDialog dialog(parent, caption);
+    dialog.setAcceptMode(QFileDialog::AcceptOpen);
+    dialog.setFileMode(QFileDialog::ExistingFile);
+    if (!filter.isEmpty())
+        dialog.setNameFilter(filter);
+    applyInitialLocation(dialog, QUrl::fromLocalFile(dir));
+    applySettings(dialog);
+
+    if (dialog.exec() != QDialog::Accepted || dialog.selectedFiles().isEmpty())
+        return QString();
+
+    return dialog.selectedFiles().first();
+}
+
+QString getSaveFileName(QWidget* parent, const QString& caption, const QString& dir, const QString& filter)
+{
+    QFileDialog dialog(parent, caption);
+    dialog.setAcceptMode(QFileDialog::AcceptSave);
+    dialog.setFileMode(QFileDialog::AnyFile);
+    if (!filter.isEmpty())
+        dialog.setNameFilter(filter);
+    applyInitialLocation(dialog, QUrl::fromLocalFile(dir));
+    applySettings(dialog);
+
+    if (dialog.exec() != QDialog::Accepted || dialog.selectedFiles().isEmpty())
+        return QString();
+
+    return dialog.selectedFiles().first();
+}
+
+QString getExistingDirectory(QWidget* parent, const QString& caption, const QString& dir, QFileDialog::Options options)
+{
+    QFileDialog dialog(parent, caption);
+    dialog.setAcceptMode(QFileDialog::AcceptOpen);
+    dialog.setFileMode(QFileDialog::Directory);
+    dialog.setOptions(options);
+    applyInitialLocation(dialog, QUrl::fromLocalFile(dir));
+    applySettings(dialog);
+
+    if (dialog.exec() != QDialog::Accepted || dialog.selectedFiles().isEmpty())
+        return QString();
+
+    return dialog.selectedFiles().first();
+}
+
+} // namespace NqqFileDialog

--- a/src/ui/nqqrun.cpp
+++ b/src/ui/nqqrun.cpp
@@ -1,10 +1,10 @@
 #include "include/nqqrun.h"
 
 #include "include/iconprovider.h"
+#include "include/nqqfiledialog.h"
 
 #include <QApplication>
 #include <QEasingCurve>
-#include <QFileDialog>
 #include <QGraphicsOpacityEffect>
 #include <QHeaderView>
 #include <QInputDialog>
@@ -233,7 +233,7 @@ bool RunDelegate::editorEvent(
             y = r.top();
             if (clickX > x && clickX < x + 16) {
                 if (clickY > y && clickY < y + 16) {
-                    QString f = QFileDialog::getOpenFileName(qobject_cast<QWidget*>(parent()), tr("Open File"));
+                    QString f = NqqFileDialog::getOpenFileName(qobject_cast<QWidget*>(parent()), tr("Open File"));
                     QString oldData = model->data(index, Qt::EditRole).toString();
                     oldData.prepend(f);
                     model->setData(index, oldData, Qt::EditRole);


### PR DESCRIPTION
Fixes #1187.

## Problem

Hidden files and folders never show up in the Open / Open Folder / Save as
dialogs, and there is no way to reveal them from within Notepadqq.

## Root cause

Two independent causes, which is why the obvious one-line fix does not work.

**1. The dialogs are unreachable.** Every call site used the `QFileDialog`
static helpers (`getOpenFileUrls`, `getExistingDirectory`, `getSaveFileName`,
`getOpenFileName`). Those build and run the dialog internally, so there is no
object on which to call `setFilter(QDir::Hidden)` — and `QFileDialog::Options`
has no flag for hidden entries.

**2. Native dialogs cannot be told either.** Qt does not forward the filter to
platform pickers. Checking the symbols the GTK theme plugin actually imports:

    $ nm -D --undefined-only .../platformthemes/libqgtk3.so | grep file_chooser
    gtk_file_chooser_add_filter
    gtk_file_chooser_set_action
    gtk_file_chooser_set_select_multiple
    ...
    # gtk_file_chooser_set_show_hidden is absent, though libgtk-3 exports it

So on GNOME the dialog decides on its own, from the global
`org.gtk.Settings.FileChooser show-hidden` key, and `Ctrl+H` is the only way in.
Honouring a per-application setting is only possible with the dialog Qt builds
itself.

**3. `Open Folder` had its own bug.** After the dialog returned, the directory
was enumerated with `QDir::Files` and every entry starting with a dot was
dropped explicitly. The check was redundant — without `QDir::Hidden`,
`entryList` already excludes them — and it guaranteed hidden files could never
be opened. `FileSearcher` already passes `QDir::Hidden`, so the codebase was
inconsistent with itself.

## Changes

- New `NqqFileDialog` helper (`src/ui/nqqfiledialog.{h,cpp}`) that builds the
  dialog explicitly and applies both settings in one place. It mirrors the Qt
  static helpers' signatures, including how a `dir` argument pointing at a file
  preselects that file.
- New `General/ShowHiddenFiles` setting. When enabled it adds `QDir::Hidden`
  **and** forces `DontUseNativeDialog`, because a native dialog would silently
  ignore the filter.
- All 8 call sites migrated. This removes the `UseNativeFilePicker` ternary that
  was duplicated 5 times, and incidentally fixes 3 dialogs that ignored that
  setting entirely (extension install, extension runtime browse, Run "Open
  File").
- `Open Folder` and folder drag & drop now follow the same setting instead of
  filtering dot files out unconditionally.
- Both settings exposed in **Preferences → General**. `UseNativeFilePicker` had
  no UI before and required hand-editing the ini file.

## Behaviour change worth reviewing

`ShowHiddenFiles` defaults to **true**, which means a fresh profile gets Qt's
file dialog instead of the desktop's native one. That is the unavoidable
consequence of cause #2 above: there is no way to have both hidden files and a
native picker. Users who prefer their desktop's dialog can uncheck the option
and keep `Ctrl+H`.

Happy to default it to `false` instead if you would rather not change the
out-of-the-box look — the fix and the UI stand either way.

## Testing

`ctest --preset dev` — 100% passed. Four new cases in `tst_notepadqqtest.cpp`:

- `hiddenFilesSettingDrivesDialogFilter` — `QDir::Hidden` set only when asked
- `showingHiddenFilesGivesUpTheNativeDialog` — the native dialog is dropped
- `entryFiltersRevealDotFiles` — directory enumeration honours the setting
- `forcedQtDialogActuallyListsHiddenEntries` — asserts on the
  `QFileSystemModel` behind the dialog, not just on its options, since
  `QFileDialog::setFilter()` only reaches the model once the widgets exist

Manually verified on Ubuntu 26.04 / GNOME / Wayland with Qt 6.10.2, with the
GTK platform theme both active and bypassed.

## Not included

Translation sources are untouched. The four new UI strings fall back to
English until a translator picks them up, which is how this repository has
always handled l10n — through per-language PRs rather than a maintainer-run
refresh.

For the record, `lupdate` currently reports 82 new source texts across the
codebase, only 4 of them from this change: the .ts files are already well
behind master. Refreshing all 14 languages here would add roughly 18k lines
of diff to a 367-line fix and bury it. Happy to send that as a separate
`l10n:` commit if you'd prefer it done now.